### PR TITLE
Add GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,0 +1,40 @@
+name: Bug Report
+description: File a bug report for refactor-platform-rs
+title: "[Bug]: "
+labels: ["bug", "triage"]
+
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Describe the issue here.
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: What is the version of refactor-platform-rs that you're seeing the problem on?
+      placeholder: ex. v0.3.0
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Any related code to produce this issue and relevant log output.
+      description: Please copy and paste any relevant code or logs to reproduce this issue. If you have your own public repository, you can link to that here. 
+      render: shell

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,0 +1,18 @@
+name: Feature request
+description: Suggest an feature / idea for this project
+title: "[Feature Request / Suggestion]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        We appreciate your feedback on how to improve this project. Please be sure to include as much details & any resources as possible!
+  - type: textarea
+    id: Suggestion
+    attributes:
+      label: Suggestion / Feature Request
+      description: Describe the feature(s) you would like to see added.
+      placeholder: Tell us your suggestion
+      value: "Your suggestion here"
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Description
+_describe the intent of your changes here_
+
+
+#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_
+
+### Changes
+* ...
+* ...
+* ...
+
+### Testing Strategy
+_describe how you or someone else can test and verify the changes_
+
+
+### Concerns
+_describe any concerns that might be worth mentioning or discussing_


### PR DESCRIPTION
Add GitHub templates for new PRs, requesting new features and filing new bugs.

Relates to #5 