### PR TITLE
Deserialize just the right fields when creating new entities

### DIFF
--- a/entity/src/actions.rs
+++ b/entity/src/actions.rs
@@ -20,8 +20,10 @@ pub struct Model {
     #[serde(skip_deserializing)]
     pub status_changed_at: DateTimeWithTimeZone,
     #[serde(skip_deserializing)]
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub created_at: DateTimeWithTimeZone,
     #[serde(skip_deserializing)]
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub updated_at: DateTimeWithTimeZone,
 }
 

--- a/entity/src/coachees.rs
+++ b/entity/src/coachees.rs
@@ -7,6 +7,7 @@ use utoipa::ToSchema;
 #[schema(as = entity::users::Model)] // OpenAPI schema
 #[sea_orm(schema_name = "refactor_platform", table_name = "users")]
 pub struct Model {
+    #[serde(skip_deserializing)]
     #[sea_orm(primary_key)]
     pub id: Id,
     #[sea_orm(unique)]
@@ -18,8 +19,10 @@ pub struct Model {
     pub password: String,
     pub github_username: Option<String>,
     pub github_profile_url: Option<String>,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub created_at: DateTimeWithTimeZone,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub updated_at: DateTimeWithTimeZone,
 }

--- a/entity/src/coaches.rs
+++ b/entity/src/coaches.rs
@@ -7,6 +7,7 @@ use utoipa::ToSchema;
 #[schema(as = entity::users::Model)] // OpenAPI schema
 #[sea_orm(schema_name = "refactor_platform", table_name = "users")]
 pub struct Model {
+    #[serde(skip_deserializing)]
     #[sea_orm(primary_key)]
     pub id: Id,
     #[sea_orm(unique)]
@@ -18,8 +19,10 @@ pub struct Model {
     pub password: String,
     pub github_username: Option<String>,
     pub github_profile_url: Option<String>,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub created_at: DateTimeWithTimeZone,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub updated_at: DateTimeWithTimeZone,
 }

--- a/entity/src/coaching_relationships.rs
+++ b/entity/src/coaching_relationships.rs
@@ -12,14 +12,17 @@ use utoipa::ToSchema;
     table_name = "coaching_relationships"
 )]
 pub struct Model {
+    #[serde(skip_deserializing)]
     #[sea_orm(primary_key)]
     pub id: Id,
     #[sea_orm(unique)]
     pub organization_id: Id,
     pub coach_id: Id,
     pub coachee_id: Id,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub created_at: DateTimeWithTimeZone,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub updated_at: DateTimeWithTimeZone,
 }

--- a/entity/src/coaching_sessions.rs
+++ b/entity/src/coaching_sessions.rs
@@ -9,12 +9,17 @@ use utoipa::ToSchema;
 #[schema(as = entity::coaching_sessions::Model)]
 #[sea_orm(schema_name = "refactor_platform", table_name = "coaching_sessions")]
 pub struct Model {
+    #[serde(skip_deserializing)]
     #[sea_orm(primary_key)]
     pub id: Id,
     pub coaching_relationship_id: Id,
     pub date: DateTime,
     pub timezone: String,
+    #[serde(skip_deserializing)]
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub created_at: DateTimeWithTimeZone,
+    #[serde(skip_deserializing)]
+    #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub updated_at: DateTimeWithTimeZone,
 }
 

--- a/entity/src/organizations.rs
+++ b/entity/src/organizations.rs
@@ -9,13 +9,16 @@ use utoipa::ToSchema;
 #[schema(as = entity::organizations::Model)] // OpenAPI schema
 #[sea_orm(schema_name = "refactor_platform", table_name = "organizations")]
 pub struct Model {
+    #[serde(skip_deserializing)]
     #[sea_orm(primary_key)]
     pub id: Id,
     #[sea_orm(unique)]
     pub name: String,
     pub logo: Option<String>,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub created_at: DateTimeWithTimeZone,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub updated_at: DateTimeWithTimeZone,
 }

--- a/entity/src/users.rs
+++ b/entity/src/users.rs
@@ -11,6 +11,7 @@ use utoipa::ToSchema;
 #[schema(as = entity::users::Model)] // OpenAPI schema
 #[sea_orm(schema_name = "refactor_platform", table_name = "users")]
 pub struct Model {
+    #[serde(skip_deserializing)]
     #[sea_orm(primary_key)]
     pub id: Id,
     #[sea_orm(unique)]
@@ -22,8 +23,10 @@ pub struct Model {
     pub password: String,
     pub github_username: Option<String>,
     pub github_profile_url: Option<String>,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub created_at: DateTimeWithTimeZone,
+    #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema
     pub updated_at: DateTimeWithTimeZone,
 }

--- a/entity/src/users.rs
+++ b/entity/src/users.rs
@@ -19,7 +19,7 @@ pub struct Model {
     pub first_name: Option<String>,
     pub last_name: Option<String>,
     pub display_name: Option<String>,
-    #[serde(skip)]
+    #[serde(skip_serializing)]
     pub password: String,
     pub github_username: Option<String>,
     pub github_profile_url: Option<String>,

--- a/web/src/controller/user_controller.rs
+++ b/web/src/controller/user_controller.rs
@@ -7,7 +7,7 @@ use service::config::ApiVersion;
 
 use log::*;
 
-/// CREATE a new User.
+/// CREATE a new User
 #[utoipa::path(
     post,
     path = "/users",
@@ -16,7 +16,7 @@ use log::*;
     ),
     request_body = entity::users::Model,
     responses(
-        (status = 200, description = "Successfully created a new Coaching Relationship", body = [entity::users::Model]),
+        (status = 200, description = "Successfully created a new User", body = [entity::users::Model]),
         (status = 401, description = "Unauthorized"),
         (status = 405, description = "Method not allowed")
     ),


### PR DESCRIPTION
## Description
This PR fixes each entity's SeaORM model such that we can call the create endpoints with just the right fields for creating a new instance of each one.


#### GitHub Issue: None

### Changes
* Ensure we deserialize just the right fields when creating new entities
* Make sure we can set a password when creating a new `User` but still not able to serialize it for returning an existing `User`'s hashed password
* Use `#[schema(value_type = String, format = DateTime)]` consistently on `DateTimeWithTimeStamp` entity fields

### Testing Strategy
1. From the RAPIdoc UI (http://localhost:4000/rapidoc)
2. Sign in with a test user
3. Try creating a new instance of each entity. Check over the entity's schema
4. Ensure that the schema only includes fields that you expect (i.e. they don't include things like `id` or `created_at`
5. Each entity should create successfully


### Concerns
None
