### PR TITLE
Add a new docker-compose service for our Next.js frontend application

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -42,6 +42,16 @@ services:
     networks:
       - backend_network  # Connect to backend_network
     command: ["sh", "-c", "sleep 5 && /usr/local/bin/refactor_platform_rs"]  # Wait for Postgres and run the app
+  
+  nextjs-app:
+    build:
+      context: https://github.com/refactor-group/refactor-platform-fe.git # change to fs directory to run locally
+      dockerfile: Dockerfile
+      target: runner  # Use runner target
+    ports:
+      - "${NEXTJS_FRONTEND_PORT}:${NEXTJS_FRONTEND_PORT}"  # Map host port to frontend container's service port
+    depends_on:
+      - rust-app  # Ensure postgres service starts before rust-app
 
 networks:
   backend_network:


### PR DESCRIPTION
## Description
This PR adds a new docker-compose service for building/running our Next.js frontend application as a container. docker-compose build && docker-compose up will now start a complete application in 3 different containers.


#### GitHub Issue: #61 

### Changes
* Add a new service to docker-compose.yaml that defines the Next.js frontend application
* Can build a frontend image
* Can start a frontend container
* All 3 services run as a complete platform system

### Testing Strategy
1. `docker-compose build`
2. `docker-compose up`
3. Visit http://localhost:3000/login and verify that the page loads
4. Try logging in and observe in the docker runtime log that the frontend tries to authenticate a non-existent user with the backend and fails

### Context
I used the follow .env file to build the complete containerized system:

```
# PostgreSQL environment variables for local development
POSTGRES_USER=refactor  # Default PostgreSQL user for local development
POSTGRES_PASSWORD=password  # Default PostgreSQL password for local development
POSTGRES_DB=refactor  # Default PostgreSQL database for local development
POSTGRES_HOST=postgres  # The local Docker Compose PostgreSQL container hostname
POSTGRES_PORT=5432  # PostgreSQL default port for local development
POSTGRES_SCHEMA=refactor_platform  # PostgreSQL schema for the application
# Database connection URL for the Rust application
DATABASE_URL=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
# Rust application environment variables
SERVICE_INTERFACE=0.0.0.0
SERVICE_PORT=4000
NEXTJS_FRONTEND_PORT=3000

# App user configuration
USERNAME=appuser  # Username for the non-root user in the container
USER_UID=1000  # User ID for the appuser
USER_GID=1000  # Group ID for the appuser
```

### Concerns
None
