### PR TITLE
Enable the use of .env for setting runtime variables and non-static setting of CORS allow_origins

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,6 +2712,7 @@ name = "service"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "dotenvy",
  "log",
  "sea-orm",
  "semver",

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ EXPOSE 4000
 
 # Default command starts an interactive bash shell
 # Set ENTRYPOINT to default to run the Rust binary with arguments
-ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/refactor_platform_rs -l $LOG_LEVEL_FILTER -i \"$BACKEND_INTERFACE\" -p \"$BACKEND_PORT\" -d \"$DATABASE_URL\" --allowed_origins=\"$ALLOWED_ORIGINS\""]
+ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/refactor_platform_rs -l \"$BACKEND_LOG_FILTER_LEVEL\" -i \"$BACKEND_INTERFACE\" -p \"$BACKEND_PORT\" -d \"$DATABASE_URL\" --allowed-origins=$BACKEND_ALLOWED_ORIGINS"]
 
 # Default CMD allows overriding with custom commands
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ EXPOSE 4000
 
 # Default command starts an interactive bash shell
 # Set ENTRYPOINT to default to run the Rust binary with arguments
-ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/refactor_platform_rs -l DEBUG -i \"$SERVICE_INTERFACE\" -p \"$SERVICE_PORT\" -d \"$DATABASE_URL\""]
+ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/refactor_platform_rs"]
 
 # Default CMD allows overriding with custom commands
 CMD ["bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,7 +67,7 @@ EXPOSE 4000
 
 # Default command starts an interactive bash shell
 # Set ENTRYPOINT to default to run the Rust binary with arguments
-ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/refactor_platform_rs"]
+ENTRYPOINT ["/bin/bash", "-c", "/usr/local/bin/refactor_platform_rs -l $LOG_LEVEL_FILTER -i \"$BACKEND_INTERFACE\" -p \"$BACKEND_PORT\" -d \"$DATABASE_URL\" --allowed_origins=\"$ALLOWED_ORIGINS\""]
 
 # Default CMD allows overriding with custom commands
 CMD ["bash"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,10 +34,10 @@ services:
       POSTGRES_HOST: postgres  # Set PostgreSQL host to "postgres" service
       POSTGRES_PORT: ${POSTGRES_PORT}  # Set PostgreSQL port from environment variable
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:${POSTGRES_PORT}/${POSTGRES_DB}  # Configure database URL
-      SERVICE_PORT: ${SERVICE_PORT}  # Set service port from environment variable
-      SERVICE_INTERFACE: ${SERVICE_INTERFACE}  # Set service interface from environment variable
+      PORT: ${BACKEND_PORT}  # Set service port from environment variable
+      INTERFACE: ${BACKEND_INTERFACE}  # Set service interface from environment variable
     ports:
-      - "${SERVICE_PORT}:${SERVICE_PORT}"  # Map host port to container's service port
+      - "${BACKEND_PORT}:${BACKEND_PORT}"  # Map host port to container's service port
     depends_on:
       - postgres  # Ensure postgres service starts before rust-app
     networks:
@@ -50,7 +50,7 @@ services:
       dockerfile: Dockerfile
       target: runner  # Use runner target
     ports:
-      - "${NEXTJS_FRONTEND_PORT}:${NEXTJS_FRONTEND_PORT}"  # Map host port to frontend container's service port
+      - "${FRONTEND_PORT}:${FRONTEND_PORT}"  # Map host port to frontend container's service port
     depends_on:
       - rust-app  # Ensure postgres service starts before rust-app
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -34,8 +34,10 @@ services:
       POSTGRES_HOST: postgres  # Set PostgreSQL host to "postgres" service
       POSTGRES_PORT: ${POSTGRES_PORT}  # Set PostgreSQL port from environment variable
       DATABASE_URL: postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:${POSTGRES_PORT}/${POSTGRES_DB}  # Configure database URL
-      PORT: ${BACKEND_PORT}  # Set service port from environment variable
-      INTERFACE: ${BACKEND_INTERFACE}  # Set service interface from environment variable
+      BACKEND_PORT: ${BACKEND_PORT}  # Set service port from environment variable
+      BACKEND_INTERFACE: ${BACKEND_INTERFACE}  # Set service interface from environment variable
+      BACKEND_ALLOWED_ORIGINS: ${BACKEND_ALLOWED_ORIGINS}
+      BACKEND_LOG_FILTER_LEVEL: ${BACKEND_LOG_FILTER_LEVEL}
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"  # Map host port to container's service port
     depends_on:

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -16,6 +16,7 @@ features = [
 
 [dependencies]
 clap = { version = "4.5.20", features = ["cargo", "derive", "env"] }
+dotenvy = "0.15"
 log = "0.4.22"
 simplelog = { version = "0.12.2", features = ["paris"] }
 serde = { version = "1.0.210", features = ["derive"] }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -25,6 +25,7 @@ pub(crate) mod extractors;
 mod router;
 
 pub async fn init_server(app_state: AppState) -> Result<()> {
+    info!("Connecting to DB with URI: {}", app_state.config.database_uri());
     // Session layer
     let session_store = PostgresStore::new(
         app_state
@@ -70,7 +71,7 @@ pub async fn init_server(app_state: AppState) -> Result<()> {
         .iter()
         .filter_map(|origin| origin.parse().ok())
         .collect::<Vec<HeaderValue>>();
-    debug!("allowed_origins: {:#?}", allowed_origins);
+    info!("allowed_origins: {:#?}", allowed_origins);
 
     let cors_layer = CorsLayer::new()
         .allow_methods([

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -25,7 +25,10 @@ pub(crate) mod extractors;
 mod router;
 
 pub async fn init_server(app_state: AppState) -> Result<()> {
-    info!("Connecting to DB with URI: {}", app_state.config.database_uri());
+    info!(
+        "Connecting to DB with URI: {}",
+        app_state.config.database_uri()
+    );
     // Session layer
     let session_store = PostgresStore::new(
         app_state
@@ -61,7 +64,6 @@ pub async fn init_server(app_state: AppState) -> Result<()> {
 
     let server_url = format!("{host}:{port}");
     let listen_addr = SocketAddr::from_str(&server_url).unwrap();
-
 
     let listener = TcpListener::bind(listen_addr).await.unwrap();
     // Convert the type of the allow_origins Vec into a HeaderValue that the CorsLayer accepts

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -57,11 +57,11 @@ pub async fn init_server(app_state: AppState) -> Result<()> {
     // These will probably come from app_state.config (command line)
     let host = app_state.config.interface.as_ref().unwrap();
     let port = app_state.config.port;
-    let server_url = format!("{host}:{port}");
+    info!("Server starting... listening for connections on http://{host}:{port}");
 
+    let server_url = format!("{host}:{port}");
     let listen_addr = SocketAddr::from_str(&server_url).unwrap();
 
-    info!("Server starting... listening for connections on http://{host}:{port}");
 
     let listener = TcpListener::bind(listen_addr).await.unwrap();
     // Convert the type of the allow_origins Vec into a HeaderValue that the CorsLayer accepts


### PR DESCRIPTION
## Description
This PR enables the use of .env for setting runtime variables alongside CLI params. Also accept a list of CORS allowed origin URLs instead of hardcoding them.

#### GitHub Issue: None

### Changes
* Enable the use of a .env file at runtime for setting all of the command line flags
* Allow the setting of a list of servers to allow for CORS Allow Origins purposes

### Testing Strategy
1. Test using the following .env file when running the backend as bare metal or when building the Docker containers

```sh
# PostgreSQL environment variables for local development
POSTGRES_USER=refactor  # Default PostgreSQL user for local development
POSTGRES_PASSWORD=password  # Default PostgreSQL password for local development
POSTGRES_DB=refactor  # Default PostgreSQL database for local development
POSTGRES_HOST=postgres  # The local Docker Compose PostgreSQL container hostname
POSTGRES_PORT=5432  # PostgreSQL default port for local development
POSTGRES_SCHEMA=refactor_platform  # PostgreSQL schema for the application
# Database connection URL for the Rust application
# Rust application environment variables
ALLOWED_ORIGINS="http://localhost:3000,http://localhost:3001,http://*.rove-barbel.ts.net:3000,https://jims-macbook-air.rove-barbel.ts.net,https://jims-macbook-air.rove-barbel.ts.net:3000,http://jims-macbook-air.rove-barbel.ts.net:3000,http://100.66.34.44:3000,http://192.168.1.65:3000,http://192.168.1.111:3000"
DATABASE_URI=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:${POSTGRES_PORT}/${POSTGRES_DB}
INTERFACE="0.0.0.0"
LOG_LEVEL_FILTER="DEBUG"
PORT=4000

NEXTJS_FRONTEND_PORT=3000

CONTAINER_NAME="refactor-platform"

# App user configuration
USERNAME=appuser  # Username for the non-root user in the container
USER_UID=1000  # User ID for the appuser
USER_GID=1000  # Group ID for the appuser
```

### Concerns
None
