### PR TITLE
scope coaching_relationships query by user_id

### DIFF
--- a/web/src/controller/organization/coaching_relationship_controller.rs
+++ b/web/src/controller/organization/coaching_relationship_controller.rs
@@ -113,7 +113,7 @@ pub async fn read(
 )]
 pub async fn index(
     CompareApiVersion(_v): CompareApiVersion,
-    AuthenticatedUser(_user): AuthenticatedUser,
+    AuthenticatedUser(user): AuthenticatedUser,
     // TODO: create a new Extractor to authorize the user to access
     // the data requested
     State(app_state): State<AppState>,
@@ -123,6 +123,7 @@ pub async fn index(
     let coaching_relationships = CoachingRelationshipApi::find_by_organization_with_user_names(
         app_state.db_conn_ref(),
         organization_id,
+        user.id,
     )
     .await?;
 


### PR DESCRIPTION
## Description
Updates `coaching_relationships` index endpoint to scope query by the current user.


#### GitHub Issue: Fixes #92 

### Changes
* Update `coaching_relationships` endpoint
* Update `entity_api::`coaching_relationships::find_by_organization_with_user_names` to accept a `user_id`


### Testing Strategy
_describe how you or someone else can test and verify the changes_

