### PR TITLE
Create tip tap documents

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -355,9 +355,9 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tokio",
- "tower 0.5.1",
+ "tower",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -378,7 +378,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -566,9 +566,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
@@ -833,6 +833,7 @@ version = "1.0.0-beta1"
 dependencies = [
  "entity",
  "entity_api",
+ "reqwest",
  "sea-orm",
 ]
 
@@ -1329,9 +1330,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.1.0"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1343,6 +1344,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -1382,9 +1384,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.3"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1395,7 +1397,6 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "tokio",
- "tower 0.4.13",
  "tower-service",
  "tracing",
 ]
@@ -1927,26 +1928,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
-name = "pin-project"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda4ed1c6c173e3fc7a83629421152e01d7b1f9b7f65fb301e490e8cfc656422"
-dependencies = [
- "pin-project-internal",
-]
-
-[[package]]
-name = "pin-project-internal"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.79",
-]
-
-[[package]]
 name = "pin-project-lite"
 version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,9 +2216,9 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.12.8"
+version = "0.12.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f713147fbe92361e52392c73b8c9e48c04c6625bce969ef54dc901e58e042a7b"
+checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
 dependencies = [
  "base64",
  "bytes",
@@ -2266,10 +2247,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.1",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2731,7 +2713,7 @@ dependencies = [
  "sqlx",
  "sqlx-sqlite",
  "tokio",
- "tower 0.5.1",
+ "tower",
  "utoipa",
 ]
 
@@ -3161,12 +3143,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
@@ -3395,30 +3371,14 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.4.13"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
-dependencies = [
- "futures-core",
- "futures-util",
- "pin-project",
- "pin-project-lite",
- "tokio",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "tower"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2873938d487c3cfb9aed7546dc9f2711d867c9f90c46b889989a2cb84eba6b4f"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 0.1.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -3837,7 +3797,7 @@ dependencies = [
  "sqlx-sqlite",
  "time",
  "tokio",
- "tower 0.5.1",
+ "tower",
  "tower-http",
  "tower-sessions",
  "tower-sessions-sqlx-store",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,7 +513,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f58b559fd6448c6e2fd0adb5720cd98a2506594cafa4737ff98c396f3e82f667"
 dependencies = [
  "borsh-derive",
- "cfg_aliases",
+ "cfg_aliases 0.1.1",
 ]
 
 [[package]]
@@ -590,6 +590,12 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -831,10 +837,13 @@ dependencies = [
 name = "domain"
 version = "1.0.0-beta1"
 dependencies = [
+ "chrono",
  "entity",
  "entity_api",
+ "log",
  "reqwest",
  "sea-orm",
+ "serde_json",
 ]
 
 [[package]]
@@ -1364,6 +1373,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2095,6 +2105,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7c5fdde3cdae7203427dc4f0a68fe0ed09833edc525a03456b153b79828684"
+dependencies = [
+ "bytes",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fadfaed2cd7f389d0161bb73eeb07b7b78f8691047a6f3e73caaeae55310a4a6"
+dependencies = [
+ "bytes",
+ "rand",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "slab",
+ "thiserror",
+ "tinyvec",
+ "tracing",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52cd4b1eff68bf27940dd39811292c49e007f4d0b4c357358dc9b0197be6b527"
+dependencies = [
+ "cfg_aliases 0.2.1",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2243,7 +2302,10 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2251,12 +2313,14 @@ dependencies = [
  "system-configuration",
  "tokio",
  "tokio-native-tls",
+ "tokio-rustls",
  "tower",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
+ "webpki-roots",
  "windows-registry",
 ]
 
@@ -2366,6 +2430,12 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
 
 [[package]]
 name = "rustix"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -844,6 +844,7 @@ dependencies = [
  "reqwest",
  "sea-orm",
  "serde_json",
+ "service",
 ]
 
 [[package]]

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 entity = { path = "../entity" }
 entity_api = { path = "../entity_api" }
+reqwest = { version = "0.12.12", features = ["json"] }
 
 [dependencies.sea-orm]
 version = "1.1.0"                                                       # sea-orm version

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 chrono = { version = "0.4.38", features = ["serde"] }
 entity = { path = "../entity" }
 entity_api = { path = "../entity_api" }
+service = { path = "../service" }
 log = "0.4.22"
 reqwest = { version = "0.12.12", features = ["json", "rustls-tls"] }
 serde_json = "1.0.128"

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -4,9 +4,12 @@ version = "1.0.0-beta1"
 edition = "2021"
 
 [dependencies]
+chrono = { version = "0.4.38", features = ["serde"] }
 entity = { path = "../entity" }
 entity_api = { path = "../entity_api" }
-reqwest = { version = "0.12.12", features = ["json"] }
+log = "0.4.22"
+reqwest = { version = "0.12.12", features = ["json", "rustls-tls"] }
+serde_json = "1.0.128"
 
 [dependencies.sea-orm]
 version = "1.1.0"                                                       # sea-orm version

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -1,28 +1,75 @@
+use super::error::Error;
 use entity::coaching_sessions::Model;
-use entity_api::{coaching_session, error::Error};
+use entity_api::{coaching_relationship, coaching_session, organization};
 use sea_orm::DatabaseConnection;
+use std::env;
 
 pub async fn create(
     db: &DatabaseConnection,
     coaching_session_model: Model,
 ) -> Result<Model, Error> {
-    coaching_session::create(db, coaching_session_model).await
+    let coaching_relationship =
+        coaching_relationship::find_by_id(db, coaching_session_model.coaching_relationship_id)
+            .await?
+            .ok_or_else(|| Error::new(None).entity())?;
+
+    let organization = organization::find_by_id(db, coaching_relationship.organization_id)
+        .await?
+        .ok_or_else(|| Error::new(None).entity())?;
+
+    let document_name = format!(
+        "{}.{}.{}",
+        organization.slug, coaching_relationship.slug, coaching_session_model.date
+    );
+    let tip_tap_url =
+        env::var("TIP_TAP_URL").map_err(|err| Error::new(Some(Box::new(err))).other())?;
+
+    let full_url = format!("{}//api/documents/{}", tip_tap_url, document_name);
+
+    let client = tip_tap_client().await?;
+
+    let res = client.post(full_url).send().await?;
+
+    if res.status().is_success() || res.status().as_u16() == 409 {
+        Ok(coaching_session::create(db, coaching_session_model).await?)
+    } else {
+        Err(Error::new(None).network())
+    }
 }
 
 pub async fn find_by_id(db: &DatabaseConnection, id: entity::Id) -> Result<Option<Model>, Error> {
-    coaching_session::find_by_id(db, id).await
+    Ok(coaching_session::find_by_id(db, id).await?)
 }
 
 pub async fn find_by_id_with_coaching_relationship(
     db: &DatabaseConnection,
     id: entity::Id,
 ) -> Result<(Model, entity::coaching_relationships::Model), Error> {
-    coaching_session::find_by_id_with_coaching_relationship(db, id).await
+    Ok(coaching_session::find_by_id_with_coaching_relationship(db, id).await?)
 }
 
 pub async fn find_by(
     db: &DatabaseConnection,
     params: std::collections::HashMap<String, String>,
 ) -> Result<Vec<Model>, Error> {
-    coaching_session::find_by(db, params).await
+    Ok(coaching_session::find_by(db, params).await?)
+}
+
+async fn tip_tap_client() -> Result<reqwest::Client, Error> {
+    let headers = build_auth_headers().await?;
+
+    Ok(reqwest::Client::builder()
+        .default_headers(headers)
+        .build()?)
+}
+
+async fn build_auth_headers() -> Result<reqwest::header::HeaderMap, Error> {
+    let auth_key =
+        env::var("TIP_TAP_AUTH_KEY").map_err(|err| Error::new(Some(Box::new(err))).other())?;
+    let mut headers = reqwest::header::HeaderMap::new();
+    let mut auth_value = reqwest::header::HeaderValue::from_str(&auth_key)
+        .map_err(|err| Error::new(Some(Box::new(err))).other())?;
+    auth_value.set_sensitive(true);
+    headers.insert(reqwest::header::AUTHORIZATION, auth_value);
+    Ok(headers)
 }

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -16,7 +16,7 @@ pub async fn create(
             .await?;
     let organization = organization::find_by_id(db, coaching_relationship.organization_id).await?;
     let document_name = format!(
-        "{}.{}.{}",
+        "{}.{}.{}-v0",
         organization.slug,
         coaching_relationship.slug,
         coaching_session_model.date.and_utc().timestamp()

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -1,4 +1,4 @@
-use super::error::Error;
+use super::error::{DomainErrorKind, Error, ExternalErrorKind, InternalErrorKind};
 use entity::coaching_sessions::Model;
 use entity_api::{coaching_relationship, coaching_session, organization};
 use sea_orm::DatabaseConnection;
@@ -10,19 +10,17 @@ pub async fn create(
 ) -> Result<Model, Error> {
     let coaching_relationship =
         coaching_relationship::find_by_id(db, coaching_session_model.coaching_relationship_id)
-            .await?
-            .ok_or_else(|| Error::new(None).entity())?;
-
-    let organization = organization::find_by_id(db, coaching_relationship.organization_id)
-        .await?
-        .ok_or_else(|| Error::new(None).entity())?;
+            .await?;
+    let organization = organization::find_by_id(db, coaching_relationship.organization_id).await?;
 
     let document_name = format!(
         "{}.{}.{}",
         organization.slug, coaching_relationship.slug, coaching_session_model.date
     );
-    let tip_tap_url =
-        env::var("TIP_TAP_URL").map_err(|err| Error::new(Some(Box::new(err))).other())?;
+    let tip_tap_url = env::var("TIP_TAP_URL").map_err(|err| Error {
+        source: Some(Box::new(err)),
+        error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+    })?;
 
     let full_url = format!("{}//api/documents/{}", tip_tap_url, document_name);
 
@@ -31,9 +29,13 @@ pub async fn create(
     let res = client.post(full_url).send().await?;
 
     if res.status().is_success() || res.status().as_u16() == 409 {
+        // TODO: Save document_name to record
         Ok(coaching_session::create(db, coaching_session_model).await?)
     } else {
-        Err(Error::new(None).network())
+        Err(Error {
+            source: None,
+            error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
+        })
     }
 }
 
@@ -64,11 +66,16 @@ async fn tip_tap_client() -> Result<reqwest::Client, Error> {
 }
 
 async fn build_auth_headers() -> Result<reqwest::header::HeaderMap, Error> {
-    let auth_key =
-        env::var("TIP_TAP_AUTH_KEY").map_err(|err| Error::new(Some(Box::new(err))).other())?;
+    let auth_key = env::var("TIP_TAP_AUTH_KEY").map_err(|err| Error {
+        source: Some(Box::new(err)),
+        error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+    })?;
     let mut headers = reqwest::header::HeaderMap::new();
-    let mut auth_value = reqwest::header::HeaderValue::from_str(&auth_key)
-        .map_err(|err| Error::new(Some(Box::new(err))).other())?;
+    let mut auth_value =
+        reqwest::header::HeaderValue::from_str(&auth_key).map_err(|err| Error {
+            source: Some(Box::new(err)),
+            error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+        })?;
     auth_value.set_sensitive(true);
     headers.insert(reqwest::header::AUTHORIZATION, auth_value);
     Ok(headers)

--- a/domain/src/error.rs
+++ b/domain/src/error.rs
@@ -1,23 +1,40 @@
+//! Error types for the `domain` layer.
 use entity_api::error::{EntityApiErrorKind, Error as EntityApiError};
 use std::error::Error as StdError;
 use std::fmt;
 
+/// Top-level domain error type.
+/// Errors in the Domain layer are modeled as a tree structure
+/// with `domain::error::Error` as the root type holding a tree of `error_kind`
+/// enums that represent the kinds of errors that can occur in the domain layer or
+/// in lower layers. The `source` field is used to hold the original error that caused
+/// the domain error. The intent is to translate errors between layers while maintaining
+/// layer boundaries. Ex. `domain` is dependent on `entity_api`, and `web` is dependent on `domain`.
+/// but `web` should not be dependent, directly, on `entity_api`. Each layer is free to define its own
+/// error kinds to whatever richeness needed at that layer. Ultimately the various `error_kind`s are used
+/// by `web` to return appropriate HTTP status codes and messages to the client.
 #[derive(Debug)]
 pub struct Error {
     pub source: Option<Box<dyn StdError + Send + Sync>>,
     pub error_kind: DomainErrorKind,
 }
+
+/// Enum representing the major categories of errors that can occur in the `domain` layer.
 #[derive(Debug, PartialEq)]
 pub enum DomainErrorKind {
     Internal(InternalErrorKind),
     External(ExternalErrorKind),
 }
+/// Enum representing the various kinds of internal errors that can occur in the `domain` layer.
 #[derive(Debug, PartialEq)]
 pub enum InternalErrorKind {
     Entity(EntityErrorKind),
     Other,
 }
 
+/// Enum representing the various kinds of entity errors that can bubble up from the "Entity" layer (`entity_api` and `entity`).
+/// These errors are translated from the `entity_api` layer to the `domain` layer and reduced to a subset of error kinds
+/// that are relevant to the `domain` layer.
 #[derive(Debug, PartialEq)]
 pub enum EntityErrorKind {
     NotFound,
@@ -25,6 +42,7 @@ pub enum EntityErrorKind {
     Other,
 }
 
+/// Enum representing the various kinds of external errors that can occur in the `domain`` layer.
 #[derive(Debug, PartialEq)]
 pub enum ExternalErrorKind {
     Network,
@@ -45,6 +63,7 @@ impl StdError for Error {
     }
 }
 
+// This is where we translate errors from the `entity_api`` layer to the `domain`` layer.
 impl From<EntityApiError> for Error {
     fn from(err: EntityApiError) -> Self {
         let entity_error_kind = match err.error_kind {
@@ -62,11 +81,14 @@ impl From<EntityApiError> for Error {
 
 impl From<reqwest::Error> for Error {
     fn from(err: reqwest::Error) -> Self {
+        // Errors that result from issues building the reqwest::Client instance. This
+        // type of error will occur prior to any network calls being made.
         if err.is_builder() {
             Error {
                 source: Some(Box::new(err)),
                 error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
             }
+        // Errors that result from issues with the network call itself.
         } else {
             Error {
                 source: Some(Box::new(err)),

--- a/domain/src/error.rs
+++ b/domain/src/error.rs
@@ -1,0 +1,77 @@
+use entity_api::error::{EntityApiErrorKind, Error as EntityApiError};
+use std::error::Error as StdError;
+use std::fmt;
+
+#[derive(Debug)]
+pub struct Error {
+    pub source: Option<Box<dyn StdError + Send + Sync>>,
+    pub error_kind: DomainErrorKind,
+}
+#[derive(Debug, PartialEq)]
+pub enum DomainErrorKind {
+    Internal(InternalErrorKind),
+    External(ExternalErrorKind),
+}
+#[derive(Debug, PartialEq)]
+pub enum InternalErrorKind {
+    Entity(EntityErrorKind),
+    Other,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum EntityErrorKind {
+    NotFound,
+    Invalid,
+    Other,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ExternalErrorKind {
+    Network,
+    Other,
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Domain Error: {:?}", self)
+    }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source
+            .as_ref()
+            .map(|e| e.as_ref() as &(dyn StdError + 'static))
+    }
+}
+
+impl From<EntityApiError> for Error {
+    fn from(err: EntityApiError) -> Self {
+        let entity_error_kind = match err.error_kind {
+            EntityApiErrorKind::RecordNotFound => EntityErrorKind::NotFound,
+            EntityApiErrorKind::InvalidQueryTerm => EntityErrorKind::Invalid,
+            _ => EntityErrorKind::Other,
+        };
+
+        Error {
+            source: Some(Box::new(err)),
+            error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(entity_error_kind)),
+        }
+    }
+}
+
+impl From<reqwest::Error> for Error {
+    fn from(err: reqwest::Error) -> Self {
+        if err.is_builder() {
+            Error {
+                source: Some(Box::new(err)),
+                error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+            }
+        } else {
+            Error {
+                source: Some(Box::new(err)),
+                error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
+            }
+        }
+    }
+}

--- a/domain/src/gateway/mod.rs
+++ b/domain/src/gateway/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod tiptap;

--- a/domain/src/gateway/tiptap.rs
+++ b/domain/src/gateway/tiptap.rs
@@ -1,0 +1,35 @@
+use crate::error::{DomainErrorKind, Error, InternalErrorKind};
+use log::*;
+use service::config::Config;
+
+/// HTTP client for making requests to Tiptap. This client is configured with the necessary
+/// authentication headers to make authenticated requests to Tiptap.
+pub(crate) async fn client(config: &Config) -> Result<reqwest::Client, Error> {
+    let headers = build_auth_headers(config).await?;
+
+    Ok(reqwest::Client::builder()
+        .use_rustls_tls()
+        .default_headers(headers)
+        .build()?)
+}
+
+async fn build_auth_headers(config: &Config) -> Result<reqwest::header::HeaderMap, Error> {
+    let auth_key = config.tip_tap_auth_key().ok_or_else(|| {
+        warn!("Failed to get auth key from config");
+        Error {
+            source: None,
+            error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+        }
+    })?;
+    let mut headers = reqwest::header::HeaderMap::new();
+    let mut auth_value = reqwest::header::HeaderValue::from_str(&auth_key).map_err(|err| {
+        warn!("Failed to create auth header value: {:?}", err);
+        Error {
+            source: Some(Box::new(err)),
+            error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+        }
+    })?;
+    auth_value.set_sensitive(true);
+    headers.insert(reqwest::header::AUTHORIZATION, auth_value);
+    Ok(headers)
+}

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod coaching_session;
+pub mod error;

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -1,2 +1,4 @@
 pub mod coaching_session;
 pub mod error;
+
+pub(crate) mod gateway;

--- a/entity_api/src/action.rs
+++ b/entity_api/src/action.rs
@@ -60,7 +60,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             error!("Action with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -96,7 +96,7 @@ pub async fn update_status(
             error!("Action with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -114,7 +114,7 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> 
             Ok(())
         }
         None => Err(Error {
-            inner: None,
+            source: None,
             error_kind: EntityApiErrorKind::RecordNotFound,
         }),
     }
@@ -131,14 +131,14 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
             error!("Action with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
         Err(err) => {
             error!("Action with id {} not found and returned error {}", id, err);
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -160,7 +160,7 @@ pub async fn find_by(
             }
             _ => {
                 return Err(Error {
-                    inner: None,
+                    source: None,
                     error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }

--- a/entity_api/src/action.rs
+++ b/entity_api/src/action.rs
@@ -1,4 +1,4 @@
-use super::error::{EntityApiErrorCode, Error};
+use super::error::{EntityApiErrorKind, Error};
 use crate::uuid_parse_str;
 use entity::actions::{self, ActiveModel, Entity, Model};
 use entity::{status::Status, Id};
@@ -61,7 +61,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -97,7 +97,7 @@ pub async fn update_status(
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -115,7 +115,7 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> 
         }
         None => Err(Error {
             inner: None,
-            error_code: EntityApiErrorCode::RecordNotFound,
+            error_kind: EntityApiErrorKind::RecordNotFound,
         }),
     }
 }
@@ -132,14 +132,14 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
         Err(err) => {
             error!("Action with id {} not found and returned error {}", id, err);
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -161,7 +161,7 @@ pub async fn find_by(
             _ => {
                 return Err(Error {
                     inner: None,
-                    error_code: EntityApiErrorCode::InvalidQueryTerm,
+                    error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }
         }

--- a/entity_api/src/agreement.rs
+++ b/entity_api/src/agreement.rs
@@ -54,7 +54,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             debug!("Agreement with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -75,7 +75,7 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> 
             Ok(())
         }
         None => Err(Error {
-            inner: None,
+            source: None,
             error_kind: EntityApiErrorKind::RecordNotFound,
         }),
     }
@@ -92,7 +92,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
             error!("Agreement with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -100,7 +100,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
             error!("Error finding Agreement with id {}: {:?}", id, err);
 
             Err(Error {
-                inner: Some(err),
+                source: Some(err),
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -122,7 +122,7 @@ pub async fn find_by(
             }
             _ => {
                 return Err(Error {
-                    inner: None,
+                    source: None,
                     error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }

--- a/entity_api/src/agreement.rs
+++ b/entity_api/src/agreement.rs
@@ -1,4 +1,4 @@
-use super::error::{EntityApiErrorCode, Error};
+use super::error::{EntityApiErrorKind, Error};
 use crate::uuid_parse_str;
 use entity::agreements::{self, ActiveModel, Entity, Model};
 use entity::Id;
@@ -55,7 +55,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -76,7 +76,7 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> 
         }
         None => Err(Error {
             inner: None,
-            error_code: EntityApiErrorCode::RecordNotFound,
+            error_kind: EntityApiErrorKind::RecordNotFound,
         }),
     }
 }
@@ -93,7 +93,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
         Err(err) => {
@@ -101,7 +101,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
 
             Err(Error {
                 inner: Some(err),
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -123,7 +123,7 @@ pub async fn find_by(
             _ => {
                 return Err(Error {
                     inner: None,
-                    error_code: EntityApiErrorCode::InvalidQueryTerm,
+                    error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }
         }

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -1,4 +1,4 @@
-use super::error::{EntityApiErrorCode, Error};
+use super::error::{EntityApiErrorKind, Error};
 use crate::uuid_parse_str;
 use chrono::Utc;
 use entity::{
@@ -154,7 +154,7 @@ pub async fn find_by(
             _ => {
                 return Err(Error {
                     inner: None,
-                    error_code: EntityApiErrorCode::InvalidQueryTerm,
+                    error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }
         }

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -37,8 +37,11 @@ pub async fn create(
     Ok(coaching_relationship_active_model.insert(db).await?)
 }
 
-pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>, Error> {
-    Ok(Entity::find_by_id(id).one(db).await?)
+pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Model, Error> {
+    Entity::find_by_id(id).one(db).await?.ok_or_else(|| Error {
+        source: None,
+        error_kind: EntityApiErrorKind::RecordNotFound,
+    })
 }
 
 pub async fn find_by_user(db: &DatabaseConnection, user_id: Id) -> Result<Vec<Model>, Error> {

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -153,7 +153,7 @@ pub async fn find_by(
             }
             _ => {
                 return Err(Error {
-                    inner: None,
+                    source: None,
                     error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -1,4 +1,4 @@
-use super::error::{EntityApiErrorCode, Error};
+use super::error::{EntityApiErrorKind, Error};
 use crate::{naive_date_parse_str, uuid_parse_str};
 use entity::{
     coaching_relationships,
@@ -54,7 +54,7 @@ pub async fn find_by_id_with_coaching_relationship(
     }
     Err(Error {
         inner: None,
-        error_code: EntityApiErrorCode::RecordNotFound,
+        error_kind: EntityApiErrorKind::RecordNotFound,
     })
 }
 
@@ -83,7 +83,7 @@ pub async fn find_by(
             _ => {
                 return Err(Error {
                     inner: None,
-                    error_code: EntityApiErrorCode::InvalidQueryTerm,
+                    error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }
         }

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -53,7 +53,7 @@ pub async fn find_by_id_with_coaching_relationship(
         }
     }
     Err(Error {
-        inner: None,
+        source: None,
         error_kind: EntityApiErrorKind::RecordNotFound,
     })
 }
@@ -82,7 +82,7 @@ pub async fn find_by(
             }
             _ => {
                 return Err(Error {
-                    inner: None,
+                    source: None,
                     error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -1,3 +1,4 @@
+//! Error types for entity API
 use std::error::Error as StdError;
 use std::fmt;
 

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -14,11 +14,11 @@ pub struct Error {
     // Underlying error emitted from seaORM internals
     pub inner: Option<DbErr>,
     // Enum representing which category of error
-    pub error_code: EntityApiErrorCode,
+    pub error_kind: EntityApiErrorKind,
 }
 
 #[derive(Debug, Serialize)]
-pub enum EntityApiErrorCode {
+pub enum EntityApiErrorKind {
     // Invalid search term
     InvalidQueryTerm,
     // Record not found
@@ -44,27 +44,27 @@ impl From<DbErr> for Error {
         match err {
             DbErr::RecordNotFound(_) => Error {
                 inner: Some(err),
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             },
             DbErr::RecordNotUpdated => Error {
                 inner: Some(err),
-                error_code: EntityApiErrorCode::RecordNotUpdated,
+                error_kind: EntityApiErrorKind::RecordNotUpdated,
             },
             DbErr::ConnectionAcquire(_) => Error {
                 inner: Some(err),
-                error_code: EntityApiErrorCode::SystemError,
+                error_kind: EntityApiErrorKind::SystemError,
             },
             DbErr::Conn(_) => Error {
                 inner: Some(err),
-                error_code: EntityApiErrorCode::SystemError,
+                error_kind: EntityApiErrorKind::SystemError,
             },
             DbErr::Exec(_) => Error {
                 inner: Some(err),
-                error_code: EntityApiErrorCode::SystemError,
+                error_kind: EntityApiErrorKind::SystemError,
             },
             _ => Error {
                 inner: Some(err),
-                error_code: EntityApiErrorCode::SystemError,
+                error_kind: EntityApiErrorKind::SystemError,
             },
         }
     }

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -9,15 +9,15 @@ use sea_orm::error::DbErr;
 /// The intent is to categorize errors into two major types:
 ///  * Errors related to data. Ex DbError::RecordNotFound
 ///  * Errors related to interactions with the database itself. Ex DbError::Conn
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub struct Error {
     // Underlying error emitted from seaORM internals
-    pub inner: Option<DbErr>,
+    pub source: Option<DbErr>,
     // Enum representing which category of error
     pub error_kind: EntityApiErrorKind,
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, PartialEq, Serialize)]
 pub enum EntityApiErrorKind {
     // Invalid search term
     InvalidQueryTerm,
@@ -43,27 +43,27 @@ impl From<DbErr> for Error {
     fn from(err: DbErr) -> Self {
         match err {
             DbErr::RecordNotFound(_) => Error {
-                inner: Some(err),
+                source: Some(err),
                 error_kind: EntityApiErrorKind::RecordNotFound,
             },
             DbErr::RecordNotUpdated => Error {
-                inner: Some(err),
+                source: Some(err),
                 error_kind: EntityApiErrorKind::RecordNotUpdated,
             },
             DbErr::ConnectionAcquire(_) => Error {
-                inner: Some(err),
+                source: Some(err),
                 error_kind: EntityApiErrorKind::SystemError,
             },
             DbErr::Conn(_) => Error {
-                inner: Some(err),
+                source: Some(err),
                 error_kind: EntityApiErrorKind::SystemError,
             },
             DbErr::Exec(_) => Error {
-                inner: Some(err),
+                source: Some(err),
                 error_kind: EntityApiErrorKind::SystemError,
             },
             _ => Error {
-                inner: Some(err),
+                source: Some(err),
                 error_kind: EntityApiErrorKind::SystemError,
             },
         }

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -17,14 +17,14 @@ pub mod user;
 pub(crate) fn uuid_parse_str(uuid_str: &str) -> Result<Id, error::Error> {
     Id::parse_str(uuid_str).map_err(|_| error::Error {
         inner: None,
-        error_code: error::EntityApiErrorCode::InvalidQueryTerm,
+        error_kind: error::EntityApiErrorKind::InvalidQueryTerm,
     })
 }
 
 pub(crate) fn naive_date_parse_str(date_str: &str) -> Result<chrono::NaiveDate, error::Error> {
     chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|_| error::Error {
         inner: None,
-        error_code: error::EntityApiErrorCode::InvalidQueryTerm,
+        error_kind: error::EntityApiErrorKind::InvalidQueryTerm,
     })
 }
 

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -16,14 +16,14 @@ pub mod user;
 
 pub(crate) fn uuid_parse_str(uuid_str: &str) -> Result<Id, error::Error> {
     Id::parse_str(uuid_str).map_err(|_| error::Error {
-        inner: None,
+        source: None,
         error_kind: error::EntityApiErrorKind::InvalidQueryTerm,
     })
 }
 
 pub(crate) fn naive_date_parse_str(date_str: &str) -> Result<chrono::NaiveDate, error::Error> {
     chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|_| error::Error {
-        inner: None,
+        source: None,
         error_kind: error::EntityApiErrorKind::InvalidQueryTerm,
     })
 }

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -1,4 +1,4 @@
-use super::error::{EntityApiErrorCode, Error};
+use super::error::{EntityApiErrorKind, Error};
 use crate::uuid_parse_str;
 use entity::notes::{self, ActiveModel, Entity, Model};
 use entity::Id;
@@ -55,7 +55,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -73,14 +73,14 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
         Err(err) => {
             error!("Note with id {} not found and returned error {}", id, err);
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -102,7 +102,7 @@ pub async fn find_by(
             _ => {
                 return Err(Error {
                     inner: None,
-                    error_code: EntityApiErrorCode::InvalidQueryTerm,
+                    error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }
         }

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -54,7 +54,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             error!("Note with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -72,14 +72,14 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
             error!("Note with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
         Err(err) => {
             error!("Note with id {} not found and returned error {}", id, err);
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -101,7 +101,7 @@ pub async fn find_by(
             }
             _ => {
                 return Err(Error {
-                    inner: None,
+                    source: None,
                     error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -50,7 +50,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             Ok(active_model.update(db).await?.try_into_model()?)
         }
         None => Err(Error {
-            inner: None,
+            source: None,
             error_kind: EntityApiErrorKind::RecordNotFound,
         }),
     }
@@ -70,7 +70,7 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> 
             Ok(())
         }
         None => Err(Error {
-            inner: None,
+            source: None,
             error_kind: EntityApiErrorKind::RecordNotFound,
         }),
     }
@@ -101,7 +101,7 @@ pub async fn find_by(
             }
             _ => {
                 return Err(Error {
-                    inner: None,
+                    source: None,
                     error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }
@@ -179,7 +179,7 @@ mod tests {
             db.into_transaction_log(),
             [Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                r#"SELECT DISTINCT "organizations"."id", "organizations"."name", "organizations"."logo", "organizations"."slug", "organizations"."created_at", "organizations"."updated_at" FROM "refactor_platform"."organizations" INNER JOIN "refactor_platform"."coaching_relationships" ON "organizations"."id" = "coaching_relationships"."organization_id" WHERE "coaching_relationships"."coach_id" = $1 OR "coaching_relationships"."coachee_id" = $2"#,
+                r#"SELECT DISTINCT "organizations"."id", "organizations"."name", "organizations"."logo", "organizations"."slug", "organizations"."created_at", "organizations"."updated_at" FROM "refactor_platform"."organizations" source JOIN "refactor_platform"."coaching_relationships" ON "organizations"."id" = "coaching_relationships"."organization_id" WHERE "coaching_relationships"."coach_id" = $1 OR "coaching_relationships"."coachee_id" = $2"#,
                 [user_id.clone().into(), user_id.into()]
             )]
         );

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -152,7 +152,7 @@ mod tests {
             db.into_transaction_log(),
             [Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
-                r#"SELECT DISTINCT "organizations"."id", "organizations"."name", "organizations"."logo", "organizations"."slug", "organizations"."created_at", "organizations"."updated_at" FROM "refactor_platform"."organizations" source JOIN "refactor_platform"."coaching_relationships" ON "organizations"."id" = "coaching_relationships"."organization_id" WHERE "coaching_relationships"."coach_id" = $1 OR "coaching_relationships"."coachee_id" = $2"#,
+                r#"SELECT DISTINCT "organizations"."id", "organizations"."name", "organizations"."logo", "organizations"."slug", "organizations"."created_at", "organizations"."updated_at" FROM "refactor_platform"."organizations" INNER JOIN "refactor_platform"."coaching_relationships" ON "organizations"."id" = "coaching_relationships"."organization_id" WHERE "coaching_relationships"."coach_id" = $1 OR "coaching_relationships"."coachee_id" = $2"#,
                 [user_id.clone().into(), user_id.into()]
             )]
         );

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -1,4 +1,4 @@
-use super::error::{EntityApiErrorCode, Error};
+use super::error::{EntityApiErrorKind, Error};
 use crate::{organization::Entity, uuid_parse_str};
 use chrono::Utc;
 use entity::{coaching_relationships, organizations::*, prelude::Organizations, Id};
@@ -51,7 +51,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
         }
         None => Err(Error {
             inner: None,
-            error_code: EntityApiErrorCode::RecordNotFound,
+            error_kind: EntityApiErrorKind::RecordNotFound,
         }),
     }
 }
@@ -71,7 +71,7 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> 
         }
         None => Err(Error {
             inner: None,
-            error_code: EntityApiErrorCode::RecordNotFound,
+            error_kind: EntityApiErrorKind::RecordNotFound,
         }),
     }
 }
@@ -102,7 +102,7 @@ pub async fn find_by(
             _ => {
                 return Err(Error {
                     inner: None,
-                    error_code: EntityApiErrorCode::InvalidQueryTerm,
+                    error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }
         }

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -30,61 +30,34 @@ pub async fn create(db: &DatabaseConnection, organization_model: Model) -> Resul
 }
 
 pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Model, Error> {
-    let result = find_by_id(db, id).await?;
+    let organization = find_by_id(db, id).await?;
 
-    match result {
-        Some(organization) => {
-            debug!(
-                "Existing Organization model to be Updated: {:?}",
-                organization
-            );
-
-            let active_model: ActiveModel = ActiveModel {
-                id: Unchanged(organization.id),
-                logo: Set(model.logo),
-                name: Set(model.name),
-                slug: Unchanged(organization.slug),
-                updated_at: Unchanged(organization.updated_at),
-                created_at: Unchanged(organization.created_at),
-            };
-            Ok(active_model.update(db).await?.try_into_model()?)
-        }
-        None => Err(Error {
-            source: None,
-            error_kind: EntityApiErrorKind::RecordNotFound,
-        }),
-    }
+    let active_model: ActiveModel = ActiveModel {
+        id: Unchanged(organization.id),
+        logo: Set(model.logo),
+        name: Set(model.name),
+        slug: Unchanged(organization.slug),
+        updated_at: Unchanged(organization.updated_at),
+        created_at: Unchanged(organization.created_at),
+    };
+    Ok(active_model.update(db).await?.try_into_model()?)
 }
 
 pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> {
-    let result = find_by_id(db, id).await?;
-
-    match result {
-        Some(organization_model) => {
-            debug!(
-                "Existing Organization model to be deleted: {:?}",
-                organization_model
-            );
-
-            organization_model.delete(db).await?;
-            Ok(())
-        }
-        None => Err(Error {
-            source: None,
-            error_kind: EntityApiErrorKind::RecordNotFound,
-        }),
-    }
+    let organization_model = find_by_id(db, id).await?;
+    organization_model.delete(db).await?;
+    Ok(())
 }
 
 pub async fn find_all(db: &DatabaseConnection) -> Result<Vec<Model>, Error> {
     Ok(Entity::find().all(db).await?)
 }
 
-pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>, Error> {
-    let organization = Entity::find_by_id(id).one(db).await?;
-    debug!("Organization found: {:?}", organization);
-
-    Ok(organization)
+pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Model, Error> {
+    Entity::find_by_id(id).one(db).await?.ok_or_else(|| Error {
+        source: None,
+        error_kind: EntityApiErrorKind::RecordNotFound,
+    })
 }
 
 pub async fn find_by(

--- a/entity_api/src/overarching_goal.rs
+++ b/entity_api/src/overarching_goal.rs
@@ -1,4 +1,4 @@
-use super::error::{EntityApiErrorCode, Error};
+use super::error::{EntityApiErrorKind, Error};
 use crate::uuid_parse_str;
 use entity::overarching_goals::{self, ActiveModel, Entity, Model};
 use entity::{status::Status, Id};
@@ -83,7 +83,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -123,7 +123,7 @@ pub async fn update_status(
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -141,7 +141,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
 
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
         Err(err) => {
@@ -151,7 +151,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
             );
             Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordNotFound,
+                error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
     }
@@ -174,7 +174,7 @@ pub async fn find_by(
             _ => {
                 return Err(Error {
                     inner: None,
-                    error_code: EntityApiErrorCode::InvalidQueryTerm,
+                    error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }
         }

--- a/entity_api/src/overarching_goal.rs
+++ b/entity_api/src/overarching_goal.rs
@@ -82,7 +82,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             error!("Overarching Goal with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -122,7 +122,7 @@ pub async fn update_status(
             error!("Overarching Goal with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -140,7 +140,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
             error!("Overarching Goal with id {} not found", id);
 
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -150,7 +150,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
                 id, err
             );
             Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,
             })
         }
@@ -173,7 +173,7 @@ pub async fn find_by(
             }
             _ => {
                 return Err(Error {
-                    inner: None,
+                    source: None,
                     error_kind: EntityApiErrorKind::InvalidQueryTerm,
                 });
             }

--- a/entity_api/src/user.rs
+++ b/entity_api/src/user.rs
@@ -51,7 +51,7 @@ async fn authenticate_user(creds: Credentials, user: Model) -> Result<Option<Mod
     match verify_password(creds.password, &user.password) {
         Ok(_) => Ok(Some(user)),
         Err(_) => Err(Error {
-            inner: None,
+            source: None,
             error_kind: EntityApiErrorKind::RecordUnauthenticated,
         }),
     }
@@ -74,7 +74,7 @@ impl Backend {
     pub fn new(db: &Arc<DatabaseConnection>) -> Self {
         info!("** Backend::new()");
         Self {
-            // Arc is cloned, but the inner DatabaseConnection refers to the same instance
+            // Arc is cloned, but the source DatabaseConnection refers to the same instance
             // as the one passed in to new() (see the Arc documentation for more info)
             db: Arc::clone(db),
         }
@@ -96,7 +96,7 @@ impl AuthnBackend for Backend {
         match find_by_email(&self.db, &creds.email).await? {
             Some(user) => authenticate_user(creds, user).await,
             None => Err(Error {
-                inner: None,
+                source: None,
                 error_kind: EntityApiErrorKind::RecordUnauthenticated,
             }),
         }

--- a/entity_api/src/user.rs
+++ b/entity_api/src/user.rs
@@ -1,4 +1,4 @@
-use super::error::{EntityApiErrorCode, Error};
+use super::error::{EntityApiErrorKind, Error};
 use async_trait::async_trait;
 use axum_login::{AuthnBackend, UserId};
 use chrono::Utc;
@@ -52,7 +52,7 @@ async fn authenticate_user(creds: Credentials, user: Model) -> Result<Option<Mod
         Ok(_) => Ok(Some(user)),
         Err(_) => Err(Error {
             inner: None,
-            error_code: EntityApiErrorCode::RecordUnauthenticated,
+            error_kind: EntityApiErrorKind::RecordUnauthenticated,
         }),
     }
 }
@@ -97,7 +97,7 @@ impl AuthnBackend for Backend {
             Some(user) => authenticate_user(creds, user).await,
             None => Err(Error {
                 inner: None,
-                error_code: EntityApiErrorCode::RecordUnauthenticated,
+                error_kind: EntityApiErrorKind::RecordUnauthenticated,
             }),
         }
     }

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -58,6 +58,7 @@ pub struct Config {
     #[arg(short, long, env)]
     tip_tap_url: Option<String>,
 
+    /// The authorization key to use when calling the TipTap Cloud API.
     #[arg(short, long, env)]
     tip_tap_auth_key: Option<String>,
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -54,6 +54,12 @@ pub struct Config {
     )]
     database_uri: Option<String>,
 
+    #[arg(short, long, env)]
+    tip_tap_url: Option<String>,
+
+    #[arg(short, long, env)]
+    tip_tap_auth_key: Option<String>,
+
     /// The host interface to listen for incoming connections
     #[arg(short, long, env, default_value = "127.0.0.1")]
     pub interface: Option<String>,
@@ -103,6 +109,14 @@ impl Config {
         self.database_uri
             .as_ref()
             .expect("No Database URI Provided")
+    }
+
+    pub fn tip_tap_url(&self) -> Option<String> {
+        self.tip_tap_url.clone()
+    }
+
+    pub fn tip_tap_auth_key(&self) -> Option<String> {
+        self.tip_tap_auth_key.clone()
     }
 }
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -54,6 +54,7 @@ pub struct Config {
     )]
     database_uri: Option<String>,
 
+    /// The URL for the TipTap Cloud API provider
     #[arg(short, long, env)]
     tip_tap_url: Option<String>,
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -55,11 +55,11 @@ pub struct Config {
     database_uri: Option<String>,
 
     /// The URL for the TipTap Cloud API provider
-    #[arg(short, long, env)]
+    #[arg(long, env)]
     tip_tap_url: Option<String>,
 
     /// The authorization key to use when calling the TipTap Cloud API.
-    #[arg(short, long, env)]
+    #[arg(long, env)]
     tip_tap_auth_key: Option<String>,
 
     /// The host interface to listen for incoming connections

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -44,4 +44,4 @@ mock = ["sea-orm/mock"]
 anyhow = "1.0.89"
 chrono = { version = "0.4.38", features = ["serde"] }
 password-auth = "1.0.0"
-reqwest = { version = "0.12.8", features = ["json", "cookies"] }
+reqwest = { version = "0.12.12", features = ["json", "cookies"] }

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -82,8 +82,12 @@ pub async fn create(
         coaching_sessions_model
     );
 
-    let coaching_session =
-        CoachingSessionApi::create(app_state.db_conn_ref(), coaching_sessions_model).await?;
+    let coaching_session = CoachingSessionApi::create(
+        app_state.db_conn_ref(),
+        &app_state.config,
+        coaching_sessions_model,
+    )
+    .await?;
 
     debug!("New Coaching Session: {:?}", coaching_session);
 

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -77,8 +77,7 @@ pub async fn read(
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET Organization by id: {}", id);
 
-    let organization: Option<organizations::Model> =
-        OrganizationApi::find_by_id(app_state.db_conn_ref(), id).await?;
+    let organization = OrganizationApi::find_by_id(app_state.db_conn_ref(), id).await?;
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), organization)))
 }

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -3,7 +3,7 @@ use std::error::Error as StdError;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 
-use entity_api::error::EntityApiErrorCode;
+use entity_api::error::EntityApiErrorKind;
 use entity_api::error::Error as EntityApiError;
 
 extern crate log;
@@ -25,8 +25,8 @@ impl std::fmt::Display for Error {
 // List of possible StatusCode variants https://docs.rs/http/latest/http/status/struct.StatusCode.html#associatedconstant.UNPROCESSABLE_ENTITY
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        match self.0.error_code {
-            EntityApiErrorCode::InvalidQueryTerm => {
+        match self.0.error_kind {
+            EntityApiErrorKind::InvalidQueryTerm => {
                 error!(
                     "Error: {:#?}, mapping to UNPROCESSABLE_ENTITY (reason: {})",
                     self,
@@ -38,7 +38,7 @@ impl IntoResponse for Error {
 
                 (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
             }
-            EntityApiErrorCode::SystemError => {
+            EntityApiErrorKind::SystemError => {
                 error!(
                     "Error: {:#?}, mapping to INTERNAL_SERVER_ERROR (reason: {})",
                     self,
@@ -50,12 +50,12 @@ impl IntoResponse for Error {
 
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
-            EntityApiErrorCode::RecordNotFound => {
+            EntityApiErrorKind::RecordNotFound => {
                 error!("Error: {:#?}, mapping to NO_CONTENT", self);
 
                 (StatusCode::NOT_FOUND, "NOT FOUND").into_response()
             }
-            EntityApiErrorCode::RecordNotUpdated => {
+            EntityApiErrorKind::RecordNotUpdated => {
                 error!(
                     "Error: {:#?}, mapping to UNPROCESSABLE_ENTITY (reason: {})",
                     self,
@@ -67,7 +67,7 @@ impl IntoResponse for Error {
 
                 (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
             }
-            EntityApiErrorCode::RecordUnauthenticated => {
+            EntityApiErrorKind::RecordUnauthenticated => {
                 error!("Error: {:#?}, mapping to UNAUTHORIZED", self);
 
                 (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response()

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -8,7 +8,6 @@ use domain::error::{
 };
 
 extern crate log;
-use log::*;
 
 pub type Result<T> = core::result::Result<T, Error>;
 

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -1,3 +1,6 @@
+//! Error handling for the web layer.
+//! Errors from lower layers are translated through `domain` to `web`
+//! so that `web` can return appropriate HTTP status codes and messages to the client.
 use std::error::Error as StdError;
 
 use axum::http::StatusCode;
@@ -7,7 +10,7 @@ use domain::error::{
     DomainErrorKind, EntityErrorKind, Error as DomainError, ExternalErrorKind, InternalErrorKind,
 };
 
-extern crate log;
+use log::*;
 
 pub type Result<T> = core::result::Result<T, Error>;
 
@@ -29,24 +32,30 @@ impl IntoResponse for Error {
             DomainErrorKind::Internal(internal_error_kind) => match internal_error_kind {
                 InternalErrorKind::Entity(entity_error_kind) => match entity_error_kind {
                     EntityErrorKind::NotFound => {
+                        warn!("EntityErrorKind::NotFound: Responding with 404 Not Found");
                         (StatusCode::NOT_FOUND, "NOT FOUND").into_response()
                     }
                     EntityErrorKind::Invalid => {
+                        warn!("EntityErrorKind::Invalid: Responding with 422 Unprocessable Entity");
                         (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
                     }
                     EntityErrorKind::Other => {
+                        warn!("EntityErrorKind::Other: Responding with 500 Internal Server Error");
                         (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
                     }
                 },
                 InternalErrorKind::Other => {
+                    warn!("InternalErrorKind::Other: Responding with 500 Internal Server Error");
                     (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
                 }
             },
             DomainErrorKind::External(external_error_kind) => match external_error_kind {
                 ExternalErrorKind::Network => {
+                    warn!("ExternalErrorKind::Network: Responding with 502 Bad Gateway");
                     (StatusCode::BAD_GATEWAY, "BAD GATEWAY").into_response()
                 }
                 ExternalErrorKind::Other => {
+                    warn!("ExternalErrorKind::Other: Responding with 500 Internal Server Error");
                     (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
                 }
             },

--- a/web/src/protect/coaching_sessions.rs
+++ b/web/src/protect/coaching_sessions.rs
@@ -27,10 +27,9 @@ pub(crate) async fn index(
 ) -> impl IntoResponse {
     let coaching_relationship =
         coaching_relationship::find_by_id(app_state.db_conn_ref(), params.coaching_relationship_id)
-            .await
-            .unwrap_or_default();
+            .await;
     match coaching_relationship {
-        Some(coaching_relationship) => {
+        Ok(coaching_relationship) => {
             if coaching_relationship.coach_id == user.id
                 || coaching_relationship.coachee_id == user.id
             {
@@ -42,6 +41,6 @@ pub(crate) async fn index(
             }
         }
         // coaching relationship with given ID not found
-        None => (StatusCode::NOT_FOUND, "NOT FOUND").into_response(),
+        Err(_) => (StatusCode::NOT_FOUND, "NOT FOUND").into_response(),
     }
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -532,7 +532,7 @@ mod organization_endpoints_tests {
 
         // Note: for entity_api::organization::find_all() to be able to return
         // the correct query_results for the assert_eq!() below, they must all
-        // be grouped together in the same inner vector.
+        // be grouped together in the same source vector.
         let organizations = [vec![organization1, organization2, organization3]];
 
         let db = Arc::new(


### PR DESCRIPTION
## Description
This PR adds the creation of Tiptap documents when a new `coaching_sessions` record is created.

It also refactors and modifies a few other patterns in the application.

**Note:** This one is somewhat beefy. It may be helpful to review commit by commit.

#### GitHub Issue: Part of epic issue #96 

### Changes
* Refactors how errors are handled, categorized, and passed upward through the application layers.
* Adds network calls to Tiptap to create new documents when a coaching session is created
* Adds/updates documentation and logging

### Testing Strategy
I tested this using Utoipa
TIP_TAP_URL=https://{your tiptap app ID}.collab.tiptap.cloud TIP_TAP_AUTH_KEY={your tiptap API key} cargo run
1. Start the server adding new environment variables
2. dispatch a `POST /coaching_sessions` request from Utoipa with a body similar to:
```json
{
  "coaching_relationship_id": "d0ae575a-ca20-4cfe-ab79-5092f0cdc0aa",
   # pay special attention to the datetime format
  "date": "2024-12-19T10:23:45",
  "timezone": "string"
}
```

### Concerns
#### Name Changes
- I made a few name changes. The biggest one being changing the convention of "error types" to "error kinds". I did this because I found myself becoming somewhat confused reasoning about an error's "type" as a business logic concept vs an error's Type as a Rust type system concept. I decided "kind" based on some other projects I have seen and because I feel it establishes a clear distinction.
#### What's Next
- Clarify and improve datetime formats and requirements
- Validating that two coaching sessions cannot have the same date and time for a given user (wouldn't make sense to double up)
- Potentially save document names as part of the coaching_sessions record
- write unit tests 