### PR TITLE
Add /jwt/generate_collab_token endpoint and JWT generation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -288,7 +288,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -305,7 +305,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -395,7 +395,7 @@ dependencies = [
  "form_urlencoded",
  "serde",
  "subtle",
- "thiserror",
+ "thiserror 1.0.56",
  "tower-cookies",
  "tower-layer",
  "tower-service",
@@ -526,7 +526,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
  "syn_derive",
 ]
 
@@ -643,7 +643,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -786,7 +786,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -797,7 +797,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -840,9 +840,11 @@ dependencies = [
  "chrono",
  "entity",
  "entity_api",
+ "jsonwebtoken",
  "log",
  "reqwest",
  "sea-orm",
+ "serde",
  "serde_json",
  "service",
 ]
@@ -1108,7 +1110,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1480,7 +1482,7 @@ checksum = "0122b7114117e64a63ac49f752a5ca4624d534c7b1c7de796ac196381cd2d947"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1511,6 +1513,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a1d36f1235bc969acba30b7f5990b864423a6068a10f7c90ae8f0112e3a59d1"
 dependencies = [
  "wasm-bindgen",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
 ]
 
 [[package]]
@@ -1804,7 +1821,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1856,7 +1873,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -1922,6 +1939,16 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "pem"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
+dependencies = [
+ "base64",
+ "serde",
+]
 
 [[package]]
 name = "pem-rfc7468"
@@ -2049,9 +2076,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.87"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3e4daa0dcf6feba26f985457cdf104d4b4256fc5a09547140f3631bb076b19a"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -2064,7 +2091,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
  "version_check",
  "yansi",
 ]
@@ -2118,7 +2145,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 1.0.56",
  "tokio",
  "tracing",
 ]
@@ -2135,7 +2162,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "slab",
- "thiserror",
+ "thiserror 1.0.56",
  "tinyvec",
  "tracing",
 ]
@@ -2151,7 +2178,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2528,7 +2555,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2552,7 +2579,7 @@ dependencies = [
  "serde_json",
  "sqlx",
  "strum",
- "thiserror",
+ "thiserror 1.0.56",
  "time",
  "tracing",
  "url",
@@ -2586,7 +2613,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sea-bae",
- "syn 2.0.79",
+ "syn 2.0.98",
  "unicode-ident",
 ]
 
@@ -2650,8 +2677,8 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
- "thiserror",
+ "syn 2.0.98",
+ "thiserror 1.0.56",
 ]
 
 [[package]]
@@ -2674,7 +2701,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2732,7 +2759,7 @@ checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -2849,6 +2876,18 @@ name = "simdutf8"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f27f6278552951f1f2b8cf9da965d10969b2efdea95a6ec47987ab46edfe263a"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "297f631f50729c8c99b84667867963997ec0b50f32b2a7dbcab828ef0541e8bb"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.11",
+ "time",
+]
 
 [[package]]
 name = "simplelog"
@@ -2977,7 +3016,7 @@ dependencies = [
  "sha2",
  "smallvec",
  "sqlformat",
- "thiserror",
+ "thiserror 1.0.56",
  "time",
  "tokio",
  "tokio-stream",
@@ -2997,7 +3036,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3020,7 +3059,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.79",
+ "syn 2.0.98",
  "tempfile",
  "tokio",
  "url",
@@ -3066,7 +3105,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.56",
  "time",
  "tracing",
  "uuid",
@@ -3110,7 +3149,7 @@ dependencies = [
  "smallvec",
  "sqlx-core",
  "stringprep",
- "thiserror",
+ "thiserror 1.0.56",
  "time",
  "tracing",
  "uuid",
@@ -3191,9 +3230,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3209,7 +3248,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3276,7 +3315,16 @@ version = "1.0.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.56",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -3287,7 +3335,18 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3374,7 +3433,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3543,7 +3602,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.56",
  "time",
  "tokio",
  "tracing",
@@ -3570,7 +3629,7 @@ dependencies = [
  "async-trait",
  "rmp-serde",
  "sqlx",
- "thiserror",
+ "thiserror 1.0.56",
  "time",
  "tower-sessions-core",
 ]
@@ -3595,7 +3654,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]
@@ -3721,7 +3780,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "regex",
- "syn 2.0.79",
+ "syn 2.0.98",
  "uuid",
 ]
 
@@ -3801,7 +3860,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -3835,7 +3894,7 @@ checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4160,7 +4219,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.79",
+ "syn 2.0.98",
 ]
 
 [[package]]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
       BACKEND_LOG_FILTER_LEVEL: ${BACKEND_LOG_FILTER_LEVEL}
       TIPTAP_URL: ${TIPTAP_URL}
       TIPTAP_AUTH_KEY: ${TIPTAP_AUTH_KEY}
-      TIPTAP_SIGNING_KEY: ${TIPTAP_SIGNING_KEY}
+      TIPTAP_JWT_SIGNING_KEY: ${TIPTAP_JWT_SIGNING_KEY}
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"  # Map host port to container's service port
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,6 +38,9 @@ services:
       BACKEND_INTERFACE: ${BACKEND_INTERFACE}  # Set service interface from environment variable
       BACKEND_ALLOWED_ORIGINS: ${BACKEND_ALLOWED_ORIGINS}
       BACKEND_LOG_FILTER_LEVEL: ${BACKEND_LOG_FILTER_LEVEL}
+      TIPTAP_URL: ${TIPTAP_URL}
+      TIPTAP_AUTH_KEY: ${TIPTAP_AUTH_KEY}
+      TIPTAP_SIGNING_KEY: ${TIPTAP_SIGNING_KEY}
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"  # Map host port to container's service port
     depends_on:

--- a/docs/runbooks/Container-README.md
+++ b/docs/runbooks/Container-README.md
@@ -61,7 +61,7 @@ PLATFORM=linux/arm64
 
 TIPTAP_URL=https://{Tiptap API Key}.collab.tiptap.cloud/
 TIPTAP_AUTH_KEY=tiptap-auth-key
-TIPTAP_SIGNING_KEY=tiptap-signing-key
+TIPTAP_JWT_SIGNING_KEY=tiptap-jwt-signing-key
 ```
 
 #### **For Remote PostgreSQL**
@@ -105,7 +105,7 @@ USER_GID=1000  # Group ID for the appuser
 
 TIPTAP_URL=https://{Tiptap API Key}.collab.tiptap.cloud/
 TIPTAP_AUTH_KEY=tiptap-auth-key
-TIPTAP_SIGNING_KEY=tiptap-signing-key
+TIPTAP_JWT_SIGNING_KEY=tiptap-jwt-signing-key
 ```
 
 ### 3. **Review `docker-compose.yaml`**
@@ -154,7 +154,7 @@ services:
       BACKEND_LOG_FILTER_LEVEL: ${BACKEND_LOG_FILTER_LEVEL}
       TIPTAP_URL: ${TIPTAP_URL}
       TIPTAP_AUTH_KEY: ${TIPTAP_AUTH_KEY}
-      TIPTAP_SIGNING_KEY: ${TIPTAP_SIGNING_KEY}
+      TIPTAP_JWT_SIGNING_KEY: ${TIPTAP_JWT_SIGNING_KEY}
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"
     depends_on:

--- a/docs/runbooks/Container-README.md
+++ b/docs/runbooks/Container-README.md
@@ -58,6 +58,10 @@ USER_UID=1000
 USER_GID=1000
 CONTAINER_NAME=refactor-platform
 PLATFORM=linux/arm64
+
+TIPTAP_URL=https://{Tiptap API Key}.collab.tiptap.cloud/
+TIPTAP_AUTH_KEY=tiptap-auth-key
+TIPTAP_SIGNING_KEY=tiptap-signing-key
 ```
 
 #### **For Remote PostgreSQL**
@@ -98,6 +102,10 @@ CONTAINER_NAME="refactor-platform"
 USERNAME=appuser  # Username for the non-root user in the container
 USER_UID=1000  # User ID for the appuser
 USER_GID=1000  # Group ID for the appuser
+
+TIPTAP_URL=https://{Tiptap API Key}.collab.tiptap.cloud/
+TIPTAP_AUTH_KEY=tiptap-auth-key
+TIPTAP_SIGNING_KEY=tiptap-signing-key
 ```
 
 ### 3. **Review `docker-compose.yaml`**
@@ -144,6 +152,9 @@ services:
       BACKEND_INTERFACE: ${BACKEND_INTERFACE}
       BACKEND_ALLOWED_ORIGINS: ${BACKEND_ALLOWED_ORIGINS}
       BACKEND_LOG_FILTER_LEVEL: ${BACKEND_LOG_FILTER_LEVEL}
+      TIPTAP_URL: ${TIPTAP_URL}
+      TIPTAP_AUTH_KEY: ${TIPTAP_AUTH_KEY}
+      TIPTAP_SIGNING_KEY: ${TIPTAP_SIGNING_KEY}
     ports:
       - "${BACKEND_PORT}:${BACKEND_PORT}"
     depends_on:

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -12,8 +12,6 @@ service = { path = "../service" }
 log = "0.4.22"
 reqwest = { version = "0.12.12", features = ["json", "rustls-tls"] }
 serde_json = "1.0.128"
-# If you do not need pem decoding, you can disable the default feature `use_pem` that way:
-# jsonwebtoken = {version = "9", default-features = false }
 serde = {version = "1.0.210", features = ["derive"] }
 
 [dependencies.sea-orm]

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -7,10 +7,14 @@ edition = "2021"
 chrono = { version = "0.4.38", features = ["serde"] }
 entity = { path = "../entity" }
 entity_api = { path = "../entity_api" }
+jsonwebtoken = "9"
 service = { path = "../service" }
 log = "0.4.22"
 reqwest = { version = "0.12.12", features = ["json", "rustls-tls"] }
 serde_json = "1.0.128"
+# If you do not need pem decoding, you can disable the default feature `use_pem` that way:
+# jsonwebtoken = {version = "9", default-features = false }
+serde = {version = "1.0.210", features = ["derive"] }
 
 [dependencies.sea-orm]
 version = "1.1.0"                                                       # sea-orm version

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -1,5 +1,5 @@
 use crate::error::{DomainErrorKind, Error, ExternalErrorKind, InternalErrorKind};
-use crate::gateway::tiptap::client as tip_tap_client;
+use crate::gateway::tiptap::client as tiptap_client;
 use chrono::{DurationRound, TimeDelta};
 use entity::coaching_sessions::Model;
 use entity_api::{coaching_relationship, coaching_session, organization};
@@ -41,18 +41,15 @@ pub async fn create(
         document_name
     );
     coaching_session_model.collab_document_name = Some(document_name.clone());
-    let tip_tap_url = config.tip_tap_url().ok_or_else(|| {
+    let tiptap_url = config.tiptap_url().ok_or_else(|| {
         warn!("Failed to get Tiptap URL from config");
         Error {
             source: None,
             error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
         }
     })?;
-    let full_url = format!(
-        "{}/api/documents/{}?format=json",
-        tip_tap_url, document_name
-    );
-    let client = tip_tap_client(config).await?;
+    let full_url = format!("{}/api/documents/{}?format=json", tiptap_url, document_name);
+    let client = tiptap_client(config).await?;
 
     let request = client
         .post(full_url)
@@ -85,7 +82,7 @@ pub async fn create(
     }
 }
 
-pub async fn find_by_id(db: &DatabaseConnection, id: entity::Id) -> Result<Option<Model>, Error> {
+pub async fn find_by_id(db: &DatabaseConnection, id: entity::Id) -> Result<Model, Error> {
     Ok(coaching_session::find_by_id(db, id).await?)
 }
 

--- a/domain/src/error.rs
+++ b/domain/src/error.rs
@@ -97,3 +97,12 @@ impl From<reqwest::Error> for Error {
         }
     }
 }
+
+impl From<jsonwebtoken::errors::Error> for Error {
+    fn from(err: jsonwebtoken::errors::Error) -> Self {
+        Error {
+            source: Some(Box::new(err)),
+            error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+        }
+    }
+}

--- a/domain/src/gateway/tiptap.rs
+++ b/domain/src/gateway/tiptap.rs
@@ -14,7 +14,7 @@ pub(crate) async fn client(config: &Config) -> Result<reqwest::Client, Error> {
 }
 
 async fn build_auth_headers(config: &Config) -> Result<reqwest::header::HeaderMap, Error> {
-    let auth_key = config.tip_tap_auth_key().ok_or_else(|| {
+    let auth_key = config.tiptap_auth_key().ok_or_else(|| {
         warn!("Failed to get auth key from config");
         Error {
             source: None,

--- a/domain/src/jwt/claims.rs
+++ b/domain/src/jwt/claims.rs
@@ -1,5 +1,41 @@
+//! This module defines the claims used in JSON Web Tokens (JWTs) within the domain layer.
+//!
+//! It provides structures for various types of claims that can be included in JWTs, such as
+//! those used for Tiptap collaboration. Each claim type is represented by a struct that can
+//! be serialized and deserialized for use in JWTs.
+//!
+//! The module is designed to be extensible, allowing for the addition of new claim types
+//! as needed. The current implementation includes `TiptapCollabClaims`, which contains
+//! fields like expiration time, issuer, subject, and allowed document names.
+//!
+//! # Example
+//!
+//! ```rust
+//! use domain::jwt::claims::TiptapCollabClaims;
+//! use serde_json;
+//!
+//! let claims = TiptapCollabClaims {
+//!     exp: 1625247600,
+//!     iss: "issuer".to_string(),
+//!     sub: "subject".to_string(),
+//!     allowed_document_names: vec!["document1".to_string(), "document2".to_string()],
+//! };
+//!
+//! let serialized_claims = serde_json::to_string(&claims).unwrap();
+//! println!("Serialized claims: {}", serialized_claims);
+//!
+//! let deserialized_claims: TiptapCollabClaims = serde_json::from_str(&serialized_claims).unwrap();
+//! println!("Deserialized claims: {:?}", deserialized_claims);
+//! ```
+
 use serde::{Deserialize, Serialize};
 
+/// Represents the claims for a Tiptap collaboration token.
+///
+/// This struct is used to serialize and deserialize the claims for a Tiptap collaboration token.
+///
+/// The `TiptapCollabClaims` struct contains the following fields:
+///
 #[derive(Debug, Serialize, Deserialize)]
 pub(crate) struct TiptapCollabClaims {
     pub(crate) exp: usize,

--- a/domain/src/jwt/claims.rs
+++ b/domain/src/jwt/claims.rs
@@ -1,0 +1,11 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+pub(crate) struct TiptapCollabClaims {
+    pub(crate) exp: usize,
+    pub(crate) iss: String,
+    pub(crate) sub: String,
+    // Titap requires this claim to be JS style case.
+    #[serde(rename = "allowedDocumentNames")]
+    pub(crate) allowed_document_names: Vec<String>,
+}

--- a/domain/src/jwt/mod.rs
+++ b/domain/src/jwt/mod.rs
@@ -1,3 +1,28 @@
+//! This module provides functionality for handling JSON Web Tokens (JWTs) within the domain layer.
+//! It includes the definition of claims used in JWTs, as well as functions for generating and validating tokens.
+//!
+//! The primary use case for this module is to generate collaboration tokens for coaching sessions,
+//! which are used to authorize access to collaborative documents. The tokens include claims that specify
+//! the allowed document names and other relevant information.
+//!
+//! The module also re-exports the `Jwt` struct from the `entity` module for convenience.
+//!
+//! # Example
+//!
+//! ```rust
+//! use domain::jwt::generate_collab_token;
+//! use sea_orm::DatabaseConnection;
+//! use service::config::Config;
+//! use entity::Id;
+//!
+//! async fn example(db: &DatabaseConnection, config: &Config, coaching_session_id: Id) {
+//!     match generate_collab_token(db, config, coaching_session_id).await {
+//!         Ok(jwt) => println!("Generated JWT: {:?}", jwt),
+//!         Err(e) => eprintln!("Error generating JWT: {:?}", e),
+//!     }
+//! }
+//! ```
+
 use crate::coaching_session;
 use crate::error::{DomainErrorKind, Error, InternalErrorKind};
 use claims::TiptapCollabClaims;
@@ -11,6 +36,13 @@ use service::config::Config;
 pub use entity::jwt::Jwt;
 
 pub(crate) mod claims;
+
+/// Generates a collaboration token for a coaching session.
+///
+/// This function generates a JWT token that authorizes access to a specific collaborative document
+/// associated with a coaching session. The token includes claims that specify the allowed document
+/// names and other relevant information.
+///
 
 pub async fn generate_collab_token(
     db: &DatabaseConnection,
@@ -51,6 +83,7 @@ pub async fn generate_collab_token(
         allowed_document_names: vec![allowed_document_name_str],
     };
 
+    // Encode the claims into a JWT
     let token = encode(
         &Header::default(),
         &claims,

--- a/domain/src/jwt/mod.rs
+++ b/domain/src/jwt/mod.rs
@@ -1,0 +1,64 @@
+use crate::coaching_session;
+use crate::error::{DomainErrorKind, Error, InternalErrorKind};
+use claims::TiptapCollabClaims;
+use entity::Id;
+use jsonwebtoken::{encode, EncodingKey, Header};
+use log::*;
+use sea_orm::DatabaseConnection;
+use service::config::Config;
+
+// re-export the Jwt struct from the entity module
+pub use entity::jwt::Jwt;
+
+pub(crate) mod claims;
+
+pub async fn generate_collab_token(
+    db: &DatabaseConnection,
+    config: &Config,
+    coaching_session_id: Id,
+) -> Result<Jwt, Error> {
+    let coaching_session = coaching_session::find_by_id(db, coaching_session_id).await?;
+
+    let collab_document_name = coaching_session.collab_document_name.ok_or_else(|| {
+        warn!("Failed to get collab document name from coaching session");
+        Error {
+            source: None,
+            error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+        }
+    })?;
+
+    // Remove the timestamp and add wildcard
+    // a document name like "refactor-coaching.jim-caleb.1747304040-v0"
+    // becomes "refactor-coaching.jim-caleb/*""
+    let allowed_document_name_str = {
+        let parts: Vec<&str> = collab_document_name.rsplitn(2, '.').collect();
+        format!("{}/*", parts[1])
+    };
+    let tiptap_signing_key = config.tiptap_signing_key().ok_or_else(|| {
+        warn!("Failed to get tiptap signing key from config");
+        Error {
+            source: None,
+            // TODO make this InternalErrorKind::ConfigError
+            error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+        }
+    })?;
+
+    let claims = TiptapCollabClaims {
+        exp: 0,
+        // We'll need to add something here eventually. Potentially a company email address
+        iss: "".to_string(),
+        sub: collab_document_name.clone(),
+        allowed_document_names: vec![allowed_document_name_str],
+    };
+
+    let token = encode(
+        &Header::default(),
+        &claims,
+        &EncodingKey::from_secret(tiptap_signing_key.as_bytes()),
+    )?;
+
+    Ok(Jwt {
+        token,
+        sub: collab_document_name,
+    })
+}

--- a/domain/src/jwt/mod.rs
+++ b/domain/src/jwt/mod.rs
@@ -65,7 +65,7 @@ pub async fn generate_collab_token(
         let parts: Vec<&str> = collab_document_name.rsplitn(2, '.').collect();
         format!("{}/*", parts[1])
     };
-    let tiptap_signing_key = config.tiptap_signing_key().ok_or_else(|| {
+    let tiptap_jwt_signing_key = config.tiptap_jwt_signing_key().ok_or_else(|| {
         warn!("Failed to get tiptap signing key from config");
         Error {
             source: None,
@@ -86,7 +86,7 @@ pub async fn generate_collab_token(
     let token = encode(
         &Header::default(),
         &claims,
-        &EncodingKey::from_secret(tiptap_signing_key.as_bytes()),
+        &EncodingKey::from_secret(tiptap_jwt_signing_key.as_bytes()),
     )?;
 
     Ok(Jwt {

--- a/domain/src/jwt/mod.rs
+++ b/domain/src/jwt/mod.rs
@@ -43,7 +43,6 @@ pub(crate) mod claims;
 /// associated with a coaching session. The token includes claims that specify the allowed document
 /// names and other relevant information.
 ///
-
 pub async fn generate_collab_token(
     db: &DatabaseConnection,
     config: &Config,

--- a/domain/src/jwt/mod.rs
+++ b/domain/src/jwt/mod.rs
@@ -80,7 +80,7 @@ pub async fn generate_collab_token(
     let claims = TiptapCollabClaims {
         exp: 0,
         // We'll need to add something here eventually. Potentially a company email address
-        iss: "".to_string(),
+        iss: "https://refactorcoach.com".to_string(),
         sub: collab_document_name.clone(),
         allowed_document_names: vec![allowed_document_name_str],
     };

--- a/domain/src/jwt/mod.rs
+++ b/domain/src/jwt/mod.rs
@@ -51,7 +51,10 @@ pub async fn generate_collab_token(
     let coaching_session = coaching_session::find_by_id(db, coaching_session_id).await?;
 
     let collab_document_name = coaching_session.collab_document_name.ok_or_else(|| {
-        warn!("Failed to get collab document name from coaching session");
+        warn!(
+            "Failed to get collab document name from coaching session with ID: {}",
+            coaching_session_id
+        );
         Error {
             source: None,
             error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
@@ -66,7 +69,7 @@ pub async fn generate_collab_token(
         format!("{}/*", parts[1])
     };
     let tiptap_jwt_signing_key = config.tiptap_jwt_signing_key().ok_or_else(|| {
-        warn!("Failed to get tiptap signing key from config");
+        warn!("Failed to get a useable Tiptap JWT signing key from config");
         Error {
             source: None,
             // TODO make this InternalErrorKind::ConfigError

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod coaching_session;
 pub mod error;
+pub mod jwt;
 
 pub(crate) mod gateway;

--- a/entity/src/jwt.rs
+++ b/entity/src/jwt.rs
@@ -1,13 +1,16 @@
 use serde::Serialize;
+use utoipa::ToSchema;
 
 /// Represents a JSON Web Token (JWT).
+/// Note: This struct does not have a corresponding entity in the database.
 ///
 /// This struct contains two fields:
 ///
 /// - `token`: A string representing the JWT.
 /// - `sub`: A string representing the subject of the JWT for conveniently accessing
 /// the subject without having to decode the JWT.
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, ToSchema)]
+#[schema(as = entity::jwt::Jwt)] // OpenAPI schema
 pub struct Jwt {
     pub token: String,
     pub sub: String,

--- a/entity/src/jwt.rs
+++ b/entity/src/jwt.rs
@@ -1,5 +1,12 @@
 use serde::Serialize;
 
+/// Represents a JSON Web Token (JWT).
+///
+/// This struct contains two fields:
+///
+/// - `token`: A string representing the JWT.
+/// - `sub`: A string representing the subject of the JWT for conveniently accessing
+/// the subject without having to decode the JWT.
 #[derive(Serialize, Debug)]
 pub struct Jwt {
     pub token: String,

--- a/entity/src/jwt.rs
+++ b/entity/src/jwt.rs
@@ -8,9 +8,9 @@ use utoipa::ToSchema;
 ///
 /// - `token`: A string representing the JWT.
 /// - `sub`: A string representing the subject of the JWT for conveniently accessing
-/// the subject without having to decode the JWT.
+///    the subject without having to decode the JWT.
 #[derive(Serialize, Debug, ToSchema)]
-#[schema(as = entity::jwt::Jwt)] // OpenAPI schema
+#[schema(as = jwt::Jwt)] // OpenAPI schema
 pub struct Jwt {
     pub token: String,
     pub sub: String,

--- a/entity/src/jwt.rs
+++ b/entity/src/jwt.rs
@@ -1,0 +1,7 @@
+use serde::Serialize;
+
+#[derive(Serialize, Debug)]
+pub struct Jwt {
+    pub token: String,
+    pub sub: String,
+}

--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -8,6 +8,7 @@ pub mod coachees;
 pub mod coaches;
 pub mod coaching_relationships;
 pub mod coaching_sessions;
+pub mod jwt;
 pub mod notes;
 pub mod organizations;
 pub mod overarching_goals;

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -35,8 +35,11 @@ pub async fn create(
         .try_into_model()?)
 }
 
-pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>, Error> {
-    Ok(Entity::find_by_id(id).one(db).await?)
+pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Model, Error> {
+    Entity::find_by_id(id).one(db).await?.ok_or_else(|| Error {
+        source: None,
+        error_kind: EntityApiErrorKind::RecordNotFound,
+    })
 }
 
 pub async fn find_by_id_with_coaching_relationship(

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -64,7 +64,7 @@ pub struct Config {
 
     /// The signing key to use when calling the Tiptap Cloud API.
     #[arg(long, env)]
-    tiptap_signing_key: Option<String>,
+    tiptap_jwt_signing_key: Option<String>,
 
     /// The host interface to listen for incoming connections
     #[arg(short, long, env, default_value = "127.0.0.1")]
@@ -125,8 +125,8 @@ impl Config {
         self.tiptap_auth_key.clone()
     }
 
-    pub fn tiptap_signing_key(&self) -> Option<String> {
-        self.tiptap_signing_key.clone()
+    pub fn tiptap_jwt_signing_key(&self) -> Option<String> {
+        self.tiptap_jwt_signing_key.clone()
     }
 }
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -54,13 +54,17 @@ pub struct Config {
     )]
     database_uri: Option<String>,
 
-    /// The URL for the TipTap Cloud API provider
+    /// The URL for the Tiptap Cloud API provider
     #[arg(long, env)]
-    tip_tap_url: Option<String>,
+    tiptap_url: Option<String>,
 
-    /// The authorization key to use when calling the TipTap Cloud API.
+    /// The authorization key to use when calling the Tiptap Cloud API.
     #[arg(long, env)]
-    tip_tap_auth_key: Option<String>,
+    tiptap_auth_key: Option<String>,
+
+    /// The signing key to use when calling the Tiptap Cloud API.
+    #[arg(long, env)]
+    tiptap_signing_key: Option<String>,
 
     /// The host interface to listen for incoming connections
     #[arg(short, long, env, default_value = "127.0.0.1")]
@@ -113,12 +117,16 @@ impl Config {
             .expect("No Database URI Provided")
     }
 
-    pub fn tip_tap_url(&self) -> Option<String> {
-        self.tip_tap_url.clone()
+    pub fn tiptap_url(&self) -> Option<String> {
+        self.tiptap_url.clone()
     }
 
-    pub fn tip_tap_auth_key(&self) -> Option<String> {
-        self.tip_tap_auth_key.clone()
+    pub fn tiptap_auth_key(&self) -> Option<String> {
+        self.tiptap_auth_key.clone()
+    }
+
+    pub fn tiptap_signing_key(&self) -> Option<String> {
+        self.tiptap_signing_key.clone()
     }
 }
 

--- a/web/src/controller/jwt_controller.rs
+++ b/web/src/controller/jwt_controller.rs
@@ -2,21 +2,15 @@ use crate::controller::ApiResponse;
 use crate::extractors::{
     authenticated_user::AuthenticatedUser, compare_api_version::CompareApiVersion,
 };
+use crate::params::jwt::GenerateCollabTokenParams;
 use crate::{AppState, Error};
 use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
 use domain::jwt as JwtApi;
-use entity::Id;
 use log::*;
-use serde::Deserialize;
 use service::config::ApiVersion;
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct GenerateCollabTokenParams {
-    pub(crate) coaching_session_id: Id,
-}
 
 /// GET generate a collaboration token
 #[utoipa::path(

--- a/web/src/controller/jwt_controller.rs
+++ b/web/src/controller/jwt_controller.rs
@@ -1,0 +1,50 @@
+use crate::controller::ApiResponse;
+use crate::extractors::{
+    authenticated_user::AuthenticatedUser, compare_api_version::CompareApiVersion,
+};
+use crate::{AppState, Error};
+use axum::extract::{Query, State};
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::Json;
+use domain::jwt as JwtApi;
+use entity::Id;
+use log::*;
+use service::config::ApiVersion;
+
+/// GET generate a collaboration token
+#[utoipa::path(
+    get,
+    path = "/jwt/generate_collab_token",
+    params(
+        ApiVersion,
+        ("coaching_session_id" = Id, Query, description = "Coaching session id to generate token for")
+    ),
+    responses(
+        (status = 200, description = "Successfully generated a collaboration token", body = Jwt),  
+        (status = 500, description = "Internal Server Error")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn generate_collab_token(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    State(app_state): State<AppState>,
+    Query(coaching_session_id): Query<Id>,
+) -> Result<impl IntoResponse, Error> {
+    debug!(
+        "GET generate collaboration token for coaching session id: {}",
+        coaching_session_id
+    );
+
+    let jwt = JwtApi::generate_collab_token(
+        app_state.db_conn_ref(),
+        &app_state.config,
+        coaching_session_id,
+    )
+    .await?;
+
+    Ok(Json(ApiResponse::new(StatusCode::OK.into(), jwt)))
+}

--- a/web/src/controller/jwt_controller.rs
+++ b/web/src/controller/jwt_controller.rs
@@ -10,7 +10,13 @@ use axum::Json;
 use domain::jwt as JwtApi;
 use entity::Id;
 use log::*;
+use serde::Deserialize;
 use service::config::ApiVersion;
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct GenerateCollabTokenParams {
+    pub(crate) coaching_session_id: Id,
+}
 
 /// GET generate a collaboration token
 #[utoipa::path(
@@ -32,17 +38,17 @@ pub async fn generate_collab_token(
     CompareApiVersion(_v): CompareApiVersion,
     AuthenticatedUser(_user): AuthenticatedUser,
     State(app_state): State<AppState>,
-    Query(coaching_session_id): Query<Id>,
+    Query(params): Query<GenerateCollabTokenParams>,
 ) -> Result<impl IntoResponse, Error> {
     debug!(
         "GET generate collaboration token for coaching session id: {}",
-        coaching_session_id
+        params.coaching_session_id
     );
 
     let jwt = JwtApi::generate_collab_token(
         app_state.db_conn_ref(),
         &app_state.config,
-        coaching_session_id,
+        params.coaching_session_id,
     )
     .await?;
 

--- a/web/src/controller/mod.rs
+++ b/web/src/controller/mod.rs
@@ -3,6 +3,7 @@ use serde::Serialize;
 pub(crate) mod action_controller;
 pub(crate) mod agreement_controller;
 pub(crate) mod coaching_session_controller;
+pub(crate) mod jwt_controller;
 pub(crate) mod note_controller;
 pub(crate) mod organization;
 pub(crate) mod organization_controller;

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -22,6 +22,7 @@ use tower_http::cors::CorsLayer;
 mod controller;
 mod error;
 pub(crate) mod extractors;
+pub(crate) mod params;
 pub(crate) mod protect;
 mod router;
 

--- a/web/src/params/jwt.rs
+++ b/web/src/params/jwt.rs
@@ -1,12 +1,13 @@
 use entity::Id;
 use serde::Deserialize;
+use utoipa::IntoParams;
 
 /// Parameters required to generate a collaboration token
 ///
 /// # Fields
 ///
 /// * `coaching_session_id` - The ID of the coaching session for which the token is being generated
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, IntoParams)]
 pub(crate) struct GenerateCollabTokenParams {
     pub(crate) coaching_session_id: Id,
 }

--- a/web/src/params/jwt.rs
+++ b/web/src/params/jwt.rs
@@ -1,0 +1,12 @@
+use entity::Id;
+use serde::Deserialize;
+
+/// Parameters required to generate a collaboration token
+///
+/// # Fields
+///
+/// * `coaching_session_id` - The ID of the coaching session for which the token is being generated
+#[derive(Debug, Deserialize)]
+pub(crate) struct GenerateCollabTokenParams {
+    pub(crate) coaching_session_id: Id,
+}

--- a/web/src/params/mod.rs
+++ b/web/src/params/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod jwt;

--- a/web/src/params/mod.rs
+++ b/web/src/params/mod.rs
@@ -1,1 +1,14 @@
+//! This module holds typed parameters for various endpoint inputs.
+//!
+//! The purpose of this module is to define and manage the parameters that are used as inputs
+//! for different endpoints in the web application. By using typed parameters, we can ensure
+//! that the inputs are validated (by type) and correctly formatted before they are processed by the
+//! application logic.
+//!
+//! Each parameter type is represented by a struct or enum, which can be serialized and
+//! deserialized as needed. This approach helps to maintain a clear and consistent structure
+//! for endpoint inputs, making the codebase easier to understand and maintain.
+//
+//! ```
+
 pub(crate) mod jwt;

--- a/web/src/protect/jwt.rs
+++ b/web/src/protect/jwt.rs
@@ -1,0 +1,44 @@
+use crate::params::jwt::GenerateCollabTokenParams;
+use crate::{extractors::authenticated_user::AuthenticatedUser, AppState};
+use axum::{
+    extract::{Query, Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::IntoResponse,
+};
+use entity_api::coaching_session;
+use log::*;
+
+/// Checks that coaching relationship record associated with the coaching session
+/// referenced by `coaching_session_id exists and that the authenticated user is associated with it.
+///  Intended to be given to axum::middleware::from_fn_with_state in the router
+pub(crate) async fn generate_collab_token(
+    State(app_state): State<AppState>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Query(params): Query<GenerateCollabTokenParams>,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    match coaching_session::find_by_id_with_coaching_relationship(
+        app_state.db_conn_ref(),
+        params.coaching_session_id,
+    )
+    .await
+    {
+        Ok((_coaching_session, coaching_relationship)) => {
+            if coaching_relationship.coach_id == user.id
+                || coaching_relationship.coachee_id == user.id
+            {
+                next.run(request).await
+            } else {
+                // User does not have access to coaching relationship
+                (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response()
+            }
+        }
+        Err(e) => {
+            error!("Error authorizing collaboration token generation {:?}", e);
+
+            (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
+        }
+    }
+}

--- a/web/src/protect/jwt.rs
+++ b/web/src/protect/jwt.rs
@@ -1,3 +1,4 @@
+//! This module contains middleware functions for protecting routes that expose JWT operations.
 use crate::params::jwt::GenerateCollabTokenParams;
 use crate::{extractors::authenticated_user::AuthenticatedUser, AppState};
 use axum::{

--- a/web/src/protect/mod.rs
+++ b/web/src/protect/mod.rs
@@ -1,3 +1,13 @@
+//! This module provides protection mechanisms for various resources in the web application.
+//!
+//! It includes submodules for authorizing access to resources. Each submodule contains the necessary logic to protect
+//! the corresponding resources, ensuring that only authorized users can access or modify them.
+//!
+//! The protection mechanisms are designed to be flexible and extensible, allowing for the addition
+//! of new resources and protection strategies as needed. By organizing the protection logic into
+//! separate submodules, we can maintain a clear and modular structure, making the codebase easier
+//! to understand and maintain.
+
 pub(crate) mod actions;
 pub(crate) mod agreements;
 pub(crate) mod coaching_relationships;

--- a/web/src/protect/mod.rs
+++ b/web/src/protect/mod.rs
@@ -2,5 +2,6 @@ pub(crate) mod actions;
 pub(crate) mod agreements;
 pub(crate) mod coaching_relationships;
 pub(crate) mod coaching_sessions;
+pub(crate) mod jwt;
 pub(crate) mod notes;
 pub(crate) mod overarching_goals;

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -299,6 +299,10 @@ fn jwt_routes(app_state: AppState) -> Router {
             "/jwt/generate_collab_token",
             get(jwt_controller::generate_collab_token),
         )
+        .route_layer(from_fn_with_state(
+            app_state.clone(),
+            protect::jwt::generate_collab_token,
+        ))
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -9,9 +9,9 @@ use entity_api::user::Backend;
 use tower_http::services::ServeDir;
 
 use crate::controller::{
-    action_controller, agreement_controller, coaching_session_controller, note_controller,
-    organization, organization_controller, overarching_goal_controller, user_controller,
-    user_session_controller,
+    action_controller, agreement_controller, coaching_session_controller, jwt_controller,
+    note_controller, organization, organization_controller, overarching_goal_controller,
+    user_controller, user_session_controller,
 };
 
 use utoipa::{
@@ -63,6 +63,7 @@ use self::organization::coaching_relationship_controller;
             user_controller::create,
             user_session_controller::login,
             user_session_controller::logout,
+            jwt_controller::generate_collab_token,
         ),
         components(
             schemas(
@@ -114,6 +115,7 @@ pub fn define_routes(app_state: AppState) -> Router {
         .merge(user_session_routes())
         .merge(user_session_protected_routes())
         .merge(coaching_sessions_routes(app_state.clone()))
+        .merge(jwt_routes(app_state.clone()))
         // FIXME: protect the OpenAPI web UI
         .merge(RapiDoc::with_openapi("/api-docs/openapi2.json", ApiDoc::openapi()).path("/rapidoc"))
         .fallback_service(static_routes())
@@ -289,6 +291,16 @@ pub fn user_session_protected_routes() -> Router {
 
 pub fn user_session_routes() -> Router {
     Router::new().route("/login", post(user_session_controller::login))
+}
+
+fn jwt_routes(app_state: AppState) -> Router {
+    Router::new()
+        .route(
+            "/jwt/generate_collab_token",
+            get(jwt_controller::generate_collab_token),
+        )
+        .route_layer(login_required!(Backend, login_url = "/login"))
+        .with_state(app_state)
 }
 
 // This will serve static files that we can use as a "fallback" for when the server panics


### PR DESCRIPTION
## Description

This adds a new endpoint `GET /jwt/generate_collab_token` for generating a signed JWT for the FE to use to fetch documents from Tiptap.

**Note:** This is the first PR I've authored using Cursor. Much of the documentation was auto-generated by cursor so if there's anything weird there please feel encouraged to point that out.

### Changes
* Adds `GET /jwt/generate_collab_token`
* Adds Authorization for `GET /jwt/generate_collab_token`
* Adds a new `entity::Jwt` struct for structuring token data
* Adds `web::params` module for organizing typed parameters for endpoints

### Testing Strategy
* Be sure to set --tiptap-signing-key which is the App Secret from TipTap's cloud dashboard settings
* Tested using Rapidoc
* Use [jwt.io](http://jwt.io/) to check the claims inside the returned JWT

#### Successful Token Creation
<img width="241" alt="Screenshot 2025-02-15 at 3 56 03 PM" src="https://github.com/user-attachments/assets/c440fb5f-a10a-4e1e-a427-73a126e044e3" />

#### Correct Claims
<img width="575" alt="Screenshot 2025-02-15 at 3 55 54 PM" src="https://github.com/user-attachments/assets/d04e8244-2e46-48e2-9b9b-f39f539d1d92" />


