### PR TITLE
Refactor parameter typing

### DIFF
--- a/domain/src/agreement.rs
+++ b/domain/src/agreement.rs
@@ -1,0 +1,14 @@
+use crate::error::Error;
+use entity::agreements::Model;
+pub use entity_api::agreement::{create, delete_by_id, find_by_id, update};
+use entity_api::{agreement, IntoQueryFilterMap};
+use sea_orm::DatabaseConnection;
+
+pub async fn find_by(
+    db: &DatabaseConnection,
+    params: impl IntoQueryFilterMap,
+) -> Result<Vec<Model>, Error> {
+    let agreements = agreement::find_by(db, params.into_query_filter_map()).await?;
+
+    Ok(agreements)
+}

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -1,3 +1,12 @@
+//! This module re-exports `IntoQueryFilterMap` and `QueryFilterMap` from the `entity_api` crate.
+//!
+//! The purpose of this re-export is to ensure that consumers of the `domain` crate do not need to
+//! directly depend on the `entity_api` crate. By re-exporting these items, we provide a clear and
+//! consistent interface for working with query filters within the domain layer, while encapsulating
+//! the underlying implementation details remain in the `entity_api` crate.
+pub use entity_api::{IntoQueryFilterMap, QueryFilterMap};
+
+pub mod agreement;
 pub mod coaching_session;
 pub mod error;
 pub mod jwt;

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -1,6 +1,7 @@
 use chrono::{Days, Utc};
 use password_auth::generate_hash;
-use sea_orm::{ActiveModelTrait, DatabaseConnection, Set};
+use sea_orm::{ActiveModelTrait, DatabaseConnection, Set, Value};
+use std::collections::HashMap;
 
 use entity::{coaching_relationships, coaching_sessions, organizations, users, Id};
 
@@ -26,6 +27,87 @@ pub(crate) fn naive_date_parse_str(date_str: &str) -> Result<chrono::NaiveDate, 
         source: None,
         error_kind: error::EntityApiErrorKind::InvalidQueryTerm,
     })
+}
+
+/// `QueryFilterMap` is a data structure that serves as a bridge for translating filter parameters
+/// between different layers of the application. It is essentially a wrapper around a `HashMap`
+/// where the keys are filter parameter names (as `String`) and the values are optional `Value` types
+/// from `sea_orm`.
+///
+/// This structure is particularly useful in scenarios where you need to pass filter parameters
+/// from a web request down to the database query layer in a type-safe and organized manner.
+///
+/// # Example
+///
+/// ```
+/// use sea_orm::Value;
+/// use entity_api::QueryFilterMap;
+///
+/// let mut query_filter_map = QueryFilterMap::new();
+/// query_filter_map.insert("coaching_session_id".to_string(), Some(Value::String(Some(Box::new("a_coaching_session_id".to_string())))));
+/// let filter_value = query_filter_map.get("coaching_session_id");
+/// ```
+pub struct QueryFilterMap {
+    map: HashMap<String, Option<Value>>,
+}
+
+impl QueryFilterMap {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<Value> {
+        // HashMap.get returns an Option and so we need to "flatten" this to a single Option
+        self.map
+            .get(key)
+            .and_then(|inner_option| inner_option.clone())
+    }
+
+    pub fn insert(&mut self, key: String, value: Option<Value>) {
+        self.map.insert(key, value);
+    }
+}
+
+impl Default for QueryFilterMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// `IntoQueryFilterMap` is a trait that provides a method for converting a struct into a `QueryFilterMap`.
+/// This is particularly useful for translating data between different layers of the application,
+/// such as from web request parameters to database query filters.
+///
+/// Implementing this trait for a struct allows you to define how the fields of the struct should be
+/// mapped to the keys and values of the `QueryFilterMap`. This ensures that the data is passed
+/// in a type-safe and organized manner.
+///
+/// # Example
+///
+/// ```
+/// use entity_api::QueryFilterMap;
+/// use entity_api::IntoQueryFilterMap;
+///
+/// #[derive(Debug)]
+/// struct MyParams {
+///     coaching_session_id: String,
+/// }
+///
+/// impl IntoQueryFilterMap for MyParams {
+///     fn into_query_filter_map(self) -> QueryFilterMap {
+///         let mut query_filter_map = QueryFilterMap::new();
+///         query_filter_map.insert(
+///             "coaching_session_id".to_string(),
+///             Some(sea_orm::Value::String(Some(Box::new(self.coaching_session_id)))),
+///         );
+///         query_filter_map
+///     }
+/// }
+/// ```
+pub trait IntoQueryFilterMap {
+    fn into_query_filter_map(self) -> QueryFilterMap;
 }
 
 pub async fn seed_database(db: &DatabaseConnection) {

--- a/web/src/controller/agreement_controller.rs
+++ b/web/src/controller/agreement_controller.rs
@@ -2,16 +2,16 @@ use crate::controller::ApiResponse;
 use crate::extractors::{
     authenticated_user::AuthenticatedUser, compare_api_version::CompareApiVersion,
 };
+use crate::params::agreement::IndexParams;
 use crate::{AppState, Error};
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
+use domain::agreement as AgreementApi;
 use entity::{agreements::Model, Id};
-use entity_api::agreement as AgreementApi;
 use serde_json::json;
 use service::config::ApiVersion;
-use std::collections::HashMap;
 
 use log::*;
 
@@ -122,7 +122,7 @@ pub async fn update(
     path = "/agreements",
     params(
         ApiVersion,
-        ("coaching_session_id" = Option<Id>, Query, description = "Filter by coaching_session_id")
+        ("coaching_session_id" = Id, Query, description = "Filter by coaching_session_id")
     ),
     responses(
         (status = 200, description = "Successfully retrieved all Agreements", body = [entity::agreements::Model]),
@@ -139,15 +139,11 @@ pub async fn index(
     // TODO: create a new Extractor to authorize the user to access
     // the data requested
     State(app_state): State<AppState>,
-    Query(params): Query<HashMap<String, String>>,
+    Query(params): Query<IndexParams>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET all Agreements");
-    debug!("Filter Params: {:?}", params);
-
+    info!("Params: {:?}", params);
     let agreements = AgreementApi::find_by(app_state.db_conn_ref(), params).await?;
-
-    debug!("Found Agreements: {:?}", agreements);
-
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), agreements)))
 }
 

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -15,7 +15,16 @@ use log::*;
 pub type Result<T> = core::result::Result<T, Error>;
 
 #[derive(Debug)]
-pub struct Error(DomainError);
+pub enum Error {
+    Domain(DomainError),
+    Web(WebErrorKind),
+}
+
+#[derive(Debug)]
+pub enum WebErrorKind {
+    Input,
+    Other,
+}
 
 impl StdError for Error {}
 
@@ -28,41 +37,100 @@ impl std::fmt::Display for Error {
 // List of possible StatusCode variants https://docs.rs/http/latest/http/status/struct.StatusCode.html#associatedconstant.UNPROCESSABLE_ENTITY
 impl IntoResponse for Error {
     fn into_response(self) -> Response {
-        match &self.0.error_kind {
-            DomainErrorKind::Internal(internal_error_kind) => match internal_error_kind {
-                InternalErrorKind::Entity(entity_error_kind) => match entity_error_kind {
-                    EntityErrorKind::NotFound => {
-                        warn!(
-                            "EntityErrorKind::NotFound: Responding with 404 Not Found. Error: {:?}",
-                            self
-                        );
-                        (StatusCode::NOT_FOUND, "NOT FOUND").into_response()
-                    }
-                    EntityErrorKind::Invalid => {
-                        warn!("EntityErrorKind::Invalid: Responding with 422 Unprocessable Entity. Error: {:?}", self);
-                        (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
-                    }
-                    EntityErrorKind::Other => {
-                        warn!("EntityErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}", self);
-                        (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
-                    }
-                },
-                InternalErrorKind::Other => {
-                    warn!("InternalErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}", self);
-                    (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
-                }
-            },
-            DomainErrorKind::External(external_error_kind) => {
-                match external_error_kind {
-                    ExternalErrorKind::Network => {
-                        warn!("ExternalErrorKind::Network: Responding with 502 Bad Gateway. Error: {:?}", self);
-                        (StatusCode::BAD_GATEWAY, "BAD GATEWAY").into_response()
-                    }
-                    ExternalErrorKind::Other => {
-                        warn!("ExternalErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}", self);
-                        (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
-                    }
-                }
+        match self {
+            Error::Domain(ref domain_error) => self.handle_domain_error(domain_error),
+            Error::Web(ref web_error_kind) => self.handle_web_error(web_error_kind),
+        }
+    }
+}
+
+impl Error {
+    fn handle_domain_error(&self, domain_error: &DomainError) -> Response {
+        match domain_error.error_kind {
+            DomainErrorKind::Internal(ref internal_error_kind) => {
+                self.handle_internal_error(internal_error_kind)
+            }
+            DomainErrorKind::External(ref external_error_kind) => {
+                self.handle_external_error(external_error_kind)
+            }
+        }
+    }
+
+    fn handle_internal_error(&self, internal_error_kind: &InternalErrorKind) -> Response {
+        match internal_error_kind {
+            InternalErrorKind::Entity(ref entity_error_kind) => {
+                self.handle_entity_error(entity_error_kind)
+            }
+            InternalErrorKind::Other => {
+                warn!(
+                    "InternalErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}",
+                    self
+                );
+                (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
+            }
+        }
+    }
+
+    fn handle_entity_error(&self, entity_error_kind: &EntityErrorKind) -> Response {
+        match entity_error_kind {
+            EntityErrorKind::NotFound => {
+                warn!(
+                    "EntityErrorKind::NotFound: Responding with 404 Not Found. Error: {:?}",
+                    self
+                );
+                (StatusCode::NOT_FOUND, "NOT FOUND").into_response()
+            }
+            EntityErrorKind::Invalid => {
+                warn!(
+                    "EntityErrorKind::Invalid: Responding with 422 Unprocessable Entity. Error: {:?}",
+                    self
+                );
+                (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
+            }
+            EntityErrorKind::Other => {
+                warn!(
+                    "EntityErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}",
+                    self
+                );
+                (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
+            }
+        }
+    }
+
+    fn handle_external_error(&self, external_error_kind: &ExternalErrorKind) -> Response {
+        match external_error_kind {
+            ExternalErrorKind::Network => {
+                warn!(
+                    "ExternalErrorKind::Network: Responding with 502 Bad Gateway. Error: {:?}",
+                    self
+                );
+                (StatusCode::BAD_GATEWAY, "BAD GATEWAY").into_response()
+            }
+            ExternalErrorKind::Other => {
+                warn!(
+                    "ExternalErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}",
+                    self
+                );
+                (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
+            }
+        }
+    }
+
+    fn handle_web_error(&self, web_error_kind: &WebErrorKind) -> Response {
+        match web_error_kind {
+            WebErrorKind::Input => {
+                warn!(
+                    "WebErrorKind::Input: Responding with 400 Bad Request. Error: {:?}",
+                    self
+                );
+                (StatusCode::BAD_REQUEST, "BAD REQUEST").into_response()
+            }
+            WebErrorKind::Other => {
+                warn!(
+                    "WebErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}",
+                    self
+                );
+                (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
         }
     }
@@ -73,6 +141,6 @@ where
     E: Into<DomainError>,
 {
     fn from(err: E) -> Self {
-        Self(err.into())
+        Error::Domain(err.into())
     }
 }

--- a/web/src/params/agreement.rs
+++ b/web/src/params/agreement.rs
@@ -1,0 +1,23 @@
+use entity::Id;
+use sea_orm::Value;
+use serde::Deserialize;
+use utoipa::IntoParams;
+
+use domain::{IntoQueryFilterMap, QueryFilterMap};
+
+#[derive(Debug, Deserialize, IntoParams)]
+pub(crate) struct IndexParams {
+    pub(crate) coaching_session_id: Id,
+}
+
+impl IntoQueryFilterMap for IndexParams {
+    fn into_query_filter_map(self) -> QueryFilterMap {
+        let mut query_filter_map = QueryFilterMap::new();
+        query_filter_map.insert(
+            "coaching_session_id".to_string(),
+            Some(Value::Uuid(Some(Box::new(self.coaching_session_id)))),
+        );
+
+        query_filter_map
+    }
+}

--- a/web/src/params/mod.rs
+++ b/web/src/params/mod.rs
@@ -11,4 +11,5 @@
 //
 //! ```
 
+pub(crate) mod agreement;
 pub(crate) mod jwt;

--- a/web/src/protect/agreements.rs
+++ b/web/src/protect/agreements.rs
@@ -1,3 +1,4 @@
+use crate::params::agreement::IndexParams;
 use crate::{extractors::authenticated_user::AuthenticatedUser, AppState};
 use axum::{
     extract::{Query, Request, State},
@@ -5,15 +6,8 @@ use axum::{
     middleware::Next,
     response::IntoResponse,
 };
-use entity::Id;
 use entity_api::coaching_session;
 use log::*;
-use serde::Deserialize;
-
-#[derive(Debug, Deserialize)]
-pub(crate) struct QueryParams {
-    coaching_session_id: Id,
-}
 
 /// Checks that coaching relationship record associated with the coaching session
 /// referenced by `coaching_session_id exists and that the authenticated user is associated with it.
@@ -21,7 +15,7 @@ pub(crate) struct QueryParams {
 pub(crate) async fn index(
     State(app_state): State<AppState>,
     AuthenticatedUser(user): AuthenticatedUser,
-    Query(params): Query<QueryParams>,
+    Query(params): Query<IndexParams>,
     request: Request,
     next: Next,
 ) -> impl IntoResponse {


### PR DESCRIPTION
## Description
This PR refactors how we type incoming parameters for certain types of requests.

It adds a `QueryFilterMap` for type safety around parameters used to filter database queries.
It adds a related `IntoQueryFilterMap` trait which provides the mechanism for translating types between application layers.

This way we can provide types for endpoint parameters in the `web` layer and then translate that data into types understood and used by `domain` and `entity_api` without these lower layers needing to depend on `web` (avoiding circular dependency)

This a step toward my current goal of removing `web` dependency on anything other than `domain`




### Changes
* Adds `QueryFilterMap`
* Adds `IntoQueryFilterMap`
* Updates `web::error::Error`

### Testing Strategy
I tested this via Rapidoc and against the FE


### Next
- Apply this pattern to other endpoints
- Re-Export any necessary `entity_api` or `entity` types through `domain`
- Remove `web` dependencies on `entity_api` and `entity`
- Add data validation mechanism to `domain`
- Allow for partial updates to data (for user, coaching session, etc. updates)