### PR TITLE
Reduce the number of seeded coaching sessions

### DIFF
--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -196,7 +196,7 @@ pub async fn seed_database(db: &DatabaseConnection) {
     .await
     .unwrap();
 
-    // In refactor_coaching, Jim is coaching Caleb.
+    // In Refactor Coaching organization, Jim is coaching Caleb.
     let jim_caleb_coaching_relationship = coaching_relationships::ActiveModel {
         coach_id: Set(jim_hodapp.id.clone().unwrap()),
         coachee_id: Set(caleb_bourg.id.clone().unwrap()),
@@ -237,7 +237,7 @@ pub async fn seed_database(db: &DatabaseConnection) {
     .await
     .unwrap();
 
-    // caleb is Coach
+    // Caleb is coach
     coaching_sessions::ActiveModel {
         coaching_relationship_id: Set(caleb_jim_coaching_relationship.id.clone().unwrap()),
         date: Set(now.naive_local()),
@@ -313,18 +313,6 @@ pub async fn seed_database(db: &DatabaseConnection) {
 
     coaching_sessions::ActiveModel {
         coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
-        date: Set(now.naive_local().checked_add_days(Days::new(28)).unwrap()),
-        collab_document_name: Set(None),
-        created_at: Set(now.into()),
-        updated_at: Set(now.into()),
-        ..Default::default()
-    }
-    .save(db)
-    .await
-    .unwrap();
-
-    coaching_sessions::ActiveModel {
-        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
         date: Set(now.naive_local().checked_sub_days(Days::new(7)).unwrap()),
         collab_document_name: Set(None),
         created_at: Set(now.into()),
@@ -338,30 +326,6 @@ pub async fn seed_database(db: &DatabaseConnection) {
     coaching_sessions::ActiveModel {
         coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
         date: Set(now.naive_local().checked_sub_days(Days::new(14)).unwrap()),
-        collab_document_name: Set(None),
-        created_at: Set(now.into()),
-        updated_at: Set(now.into()),
-        ..Default::default()
-    }
-    .save(db)
-    .await
-    .unwrap();
-
-    coaching_sessions::ActiveModel {
-        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
-        date: Set(now.naive_local().checked_sub_days(Days::new(21)).unwrap()),
-        collab_document_name: Set(None),
-        created_at: Set(now.into()),
-        updated_at: Set(now.into()),
-        ..Default::default()
-    }
-    .save(db)
-    .await
-    .unwrap();
-
-    coaching_sessions::ActiveModel {
-        coaching_relationship_id: Set(jim_caleb_coaching_relationship.id.clone().unwrap()),
-        date: Set(now.naive_local().checked_sub_days(Days::new(28)).unwrap()),
         collab_document_name: Set(None),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),

--- a/migration/src/refactor_platform_rs.sql
+++ b/migration/src/refactor_platform_rs.sql
@@ -1,6 +1,6 @@
--- SQL dump generated using DBML (dbml.dbdiagram.io)
+-- SQL dump generated using DBML (dbml-lang.org)
 -- Database: PostgreSQL
--- Generated at: 2025-02-11T12:14:51.996Z
+-- Generated at: 2025-02-26T21:52:09.494Z
 
 
 CREATE TYPE "refactor_platform"."status" AS ENUM (


### PR DESCRIPTION
## Description
This PR reduces the number of seeded coaching sessions for a development DB environment.


#### GitHub Issue: N/A

### Changes
* Reduce the number of seeded coaching sessions to 6

### Testing Strategy
1. Rebuild your local DB using the rebuild_db.sh script
2. Re-seed the DB
3. Notice there are only 6 that show up now when logged in as Jim


### Concerns
None
