### PR TITLE
Make sure that creating a new Organization accepts the "slug"  field

### DIFF
--- a/entity/src/organizations.rs
+++ b/entity/src/organizations.rs
@@ -15,7 +15,7 @@ pub struct Model {
     #[sea_orm(unique)]
     pub name: String,
     pub logo: Option<String>,
-    #[serde(skip_deserializing)]
+    #[sea_orm(unique)]
     pub slug: String,
     #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -19,8 +19,9 @@ pub async fn create(db: &DatabaseConnection, organization_model: Model) -> Resul
     let now = Utc::now();
 
     let organization_active_model: ActiveModel = ActiveModel {
-        logo: Set(organization_model.logo),
         name: Set(organization_model.name),
+        logo: Set(organization_model.logo),
+        slug: Set(organization_model.slug),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()
@@ -34,9 +35,9 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 
     let active_model: ActiveModel = ActiveModel {
         id: Unchanged(organization.id),
-        logo: Set(model.logo),
         name: Set(model.name),
-        slug: Unchanged(organization.slug),
+        logo: Set(model.logo),
+        slug: Set(organization.slug),
         updated_at: Unchanged(organization.updated_at),
         created_at: Unchanged(organization.created_at),
     };


### PR DESCRIPTION
## Description
This PR ensures that when creating a new Organization instance, it accepts the `slug` field and this value is unique across all Organizations.


#### GitHub Issue: None

### Changes
* Accept the `slug` field as non-optional
* Ensure `slug`'s value is unique across all Organizations

### Testing Strategy
1. Create a new organization with RAPIdoc


### Concerns
None
