### PR TITLE
Add User Update Endpoint

### DIFF
--- a/domain/src/action.rs
+++ b/domain/src/action.rs
@@ -1,6 +1,6 @@
 use crate::actions::Model;
 use crate::error::Error;
-use entity_api::IntoQueryFilterMap;
+use entity_api::query::IntoQueryFilterMap;
 use entity_api::{actions, query};
 use sea_orm::DatabaseConnection;
 

--- a/domain/src/agreement.rs
+++ b/domain/src/agreement.rs
@@ -1,6 +1,6 @@
 use crate::agreements::Model;
 use crate::error::Error;
-use entity_api::IntoQueryFilterMap;
+use entity_api::query::IntoQueryFilterMap;
 use entity_api::{agreements, query};
 use sea_orm::DatabaseConnection;
 

--- a/domain/src/coaching_relationship.rs
+++ b/domain/src/coaching_relationship.rs
@@ -1,6 +1,6 @@
 use crate::coaching_relationships::Model;
 use crate::error::Error;
-use entity_api::IntoQueryFilterMap;
+use entity_api::query::IntoQueryFilterMap;
 use entity_api::{coaching_relationships, query};
 use sea_orm::DatabaseConnection;
 

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -4,7 +4,7 @@ use crate::gateway::tiptap::client as tiptap_client;
 use chrono::{DurationRound, TimeDelta};
 use entity_api::{
     coaching_relationship, coaching_session, coaching_sessions, organization, query,
-    IntoQueryFilterMap,
+    query::IntoQueryFilterMap,
 };
 use log::*;
 use sea_orm::DatabaseConnection;

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -9,8 +9,7 @@ pub use entity_api::{
     query::{IntoQueryFilterMap, QueryFilterMap},
 };
 
-// Re-exports from `entity`
-pub use entity_api::user::{AuthSession, Backend, Credentials};
+// Re-exports from `entity` crate
 pub use entity_api::{
     actions, agreements, coachees, coaches, coaching_relationships, coaching_sessions, jwts, notes,
     organizations, overarching_goals, users, Id,

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -4,7 +4,10 @@
 //! directly depend on the `entity_api` crate. By re-exporting these items, we provide a clear and
 //! consistent interface for working with query filters within the domain layer, while encapsulating
 //! the underlying implementation details remain in the `entity_api` crate.
-pub use entity_api::query::{IntoQueryFilterMap, QueryFilterMap};
+pub use entity_api::{
+    mutate::{IntoUpdateMap, UpdateMap},
+    query::{IntoQueryFilterMap, QueryFilterMap},
+};
 
 // Re-exports from `entity`
 pub use entity_api::user::{AuthSession, Backend, Credentials};

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -4,7 +4,7 @@
 //! directly depend on the `entity_api` crate. By re-exporting these items, we provide a clear and
 //! consistent interface for working with query filters within the domain layer, while encapsulating
 //! the underlying implementation details remain in the `entity_api` crate.
-pub use entity_api::{IntoQueryFilterMap, QueryFilterMap};
+pub use entity_api::query::{IntoQueryFilterMap, QueryFilterMap};
 
 // Re-exports from `entity`
 pub use entity_api::user::{AuthSession, Backend, Credentials};

--- a/domain/src/overarching_goal.rs
+++ b/domain/src/overarching_goal.rs
@@ -1,6 +1,6 @@
 use crate::error::Error;
 use crate::overarching_goals::Model;
-use entity_api::IntoQueryFilterMap;
+use entity_api::query::IntoQueryFilterMap;
 use entity_api::{overarching_goals, query};
 use sea_orm::DatabaseConnection;
 

--- a/domain/src/user.rs
+++ b/domain/src/user.rs
@@ -3,7 +3,7 @@ use entity_api::mutate;
 use sea_orm::DatabaseConnection;
 use sea_orm::IntoActiveModel;
 
-pub use entity_api::user::{create, find_by_email, find_by_id};
+pub use entity_api::user::{create, find_by_email, find_by_id, AuthSession, Backend, Credentials};
 
 pub async fn update(
     db: &DatabaseConnection,

--- a/domain/src/user.rs
+++ b/domain/src/user.rs
@@ -1,1 +1,21 @@
-pub use entity_api::user::{create, find_by_email};
+use crate::{error::Error, users, Id};
+use entity_api::mutate;
+use sea_orm::DatabaseConnection;
+use sea_orm::IntoActiveModel;
+
+pub use entity_api::user::{create, find_by_email, find_by_id};
+
+pub async fn update(
+    db: &DatabaseConnection,
+    user_id: Id,
+    params: impl mutate::IntoUpdateMap,
+) -> Result<users::Model, Error> {
+    let existing_user = find_by_id(db, user_id).await?;
+    let active_model = existing_user.into_active_model();
+    Ok(mutate::update::<users::ActiveModel, users::Column>(
+        db,
+        active_model,
+        params.into_update_map(),
+    )
+    .await?)
+}

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -1,7 +1,6 @@
 use chrono::{Days, Utc};
 use password_auth::generate_hash;
-use sea_orm::{ActiveModelTrait, DatabaseConnection, Set, Value};
-use std::collections::HashMap;
+use sea_orm::{ActiveModelTrait, DatabaseConnection, Set};
 
 pub use entity::{
     actions, agreements, coachees, coaches, coaching_relationships, coaching_sessions, jwts, notes,
@@ -13,6 +12,7 @@ pub mod agreement;
 pub mod coaching_relationship;
 pub mod coaching_session;
 pub mod error;
+pub mod mutate;
 pub mod note;
 pub mod organization;
 pub mod overarching_goal;
@@ -24,87 +24,6 @@ pub(crate) fn uuid_parse_str(uuid_str: &str) -> Result<Id, error::Error> {
         source: None,
         error_kind: error::EntityApiErrorKind::InvalidQueryTerm,
     })
-}
-
-/// `QueryFilterMap` is a data structure that serves as a bridge for translating filter parameters
-/// between different layers of the application. It is essentially a wrapper around a `HashMap`
-/// where the keys are filter parameter names (as `String`) and the values are optional `Value` types
-/// from `sea_orm`.
-///
-/// This structure is particularly useful in scenarios where you need to pass filter parameters
-/// from a web request down to the database query layer in a type-safe and organized manner.
-///
-/// # Example
-///
-/// ```
-/// use sea_orm::Value;
-/// use entity_api::QueryFilterMap;
-///
-/// let mut query_filter_map = QueryFilterMap::new();
-/// query_filter_map.insert("coaching_session_id".to_string(), Some(Value::String(Some(Box::new("a_coaching_session_id".to_string())))));
-/// let filter_value = query_filter_map.get("coaching_session_id");
-/// ```
-pub struct QueryFilterMap {
-    map: HashMap<String, Option<Value>>,
-}
-
-impl QueryFilterMap {
-    pub fn new() -> Self {
-        Self {
-            map: HashMap::new(),
-        }
-    }
-
-    pub fn get(&self, key: &str) -> Option<Value> {
-        // HashMap.get returns an Option and so we need to "flatten" this to a single Option
-        self.map
-            .get(key)
-            .and_then(|inner_option| inner_option.clone())
-    }
-
-    pub fn insert(&mut self, key: String, value: Option<Value>) {
-        self.map.insert(key, value);
-    }
-}
-
-impl Default for QueryFilterMap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-/// `IntoQueryFilterMap` is a trait that provides a method for converting a struct into a `QueryFilterMap`.
-/// This is particularly useful for translating data between different layers of the application,
-/// such as from web request parameters to database query filters.
-///
-/// Implementing this trait for a struct allows you to define how the fields of the struct should be
-/// mapped to the keys and values of the `QueryFilterMap`. This ensures that the data is passed
-/// in a type-safe and organized manner.
-///
-/// # Example
-///
-/// ```
-/// use entity_api::QueryFilterMap;
-/// use entity_api::IntoQueryFilterMap;
-///
-/// #[derive(Debug)]
-/// struct MyParams {
-///     coaching_session_id: String,
-/// }
-///
-/// impl IntoQueryFilterMap for MyParams {
-///     fn into_query_filter_map(self) -> QueryFilterMap {
-///         let mut query_filter_map = QueryFilterMap::new();
-///         query_filter_map.insert(
-///             "coaching_session_id".to_string(),
-///             Some(sea_orm::Value::String(Some(Box::new(self.coaching_session_id)))),
-///         );
-///         query_filter_map
-///     }
-/// }
-/// ```
-pub trait IntoQueryFilterMap {
-    fn into_query_filter_map(self) -> QueryFilterMap;
 }
 
 pub async fn seed_database(db: &DatabaseConnection) {

--- a/entity_api/src/mutate.rs
+++ b/entity_api/src/mutate.rs
@@ -1,0 +1,86 @@
+use crate::error::Error;
+use sea_orm::{
+    ActiveModelBehavior, ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait,
+    IntoActiveModel, Value,
+};
+use std::collections::HashMap;
+
+/// Updates an existing record in the database using a map of column names to values.
+///
+/// This function provides a flexible way to update only specific fields of an entity
+/// without having to provide all fields. It takes an active model and an update map,
+/// and only modifies the fields specified in the map.
+///
+/// # Type Parameters
+///
+/// * `A` - The ActiveModel type that implements ActiveModelTrait and ActiveModelBehavior
+/// * `C` - The Column type that implements ColumnTrait
+///
+/// # Arguments
+///
+/// * `db` - A reference to the database connection
+/// * `active_model` - The active model to update
+/// * `update_map` - A map of column names to their new values
+///
+/// # Returns
+///
+/// Returns a Result containing either the updated Model or an Error
+pub async fn update<A, C>(
+    db: &DatabaseConnection,
+    mut active_model: A,
+    update_map: UpdateMap,
+) -> Result<<A::Entity as EntityTrait>::Model, Error>
+where
+    A: ActiveModelTrait + ActiveModelBehavior + Send,
+    C: ColumnTrait,
+    A::Entity: EntityTrait<Column = C>,
+    <A::Entity as EntityTrait>::Model: IntoActiveModel<A>,
+{
+    for column in C::iter() {
+        if let Some(value) = update_map.get(&column.to_string()) {
+            active_model.set(column, value.clone());
+        }
+    }
+    Ok(active_model.update(db).await?)
+}
+
+/// A map structure that holds column names and their corresponding values for updates.
+///
+/// This structure provides a flexible way to specify which fields should be updated
+/// and their new values. It's designed to work with SeaORM's Value type and supports
+/// optional values to handle nullable fields.
+#[derive(Default)]
+pub struct UpdateMap {
+    map: HashMap<String, Option<Value>>,
+}
+
+impl UpdateMap {
+    /// Creates a new empty UpdateMap.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Retrieves a value from the map by its key.
+    ///
+    /// Returns an Option containing a reference to the Value if it exists,
+    /// or None if the key is not found or the value is None.
+    pub fn get(&self, key: &str) -> Option<&Value> {
+        self.map.get(key).and_then(|opt| opt.as_ref())
+    }
+
+    /// Inserts a key-value pair into the map.
+    ///
+    /// If the key already exists, the value will be overwritten.
+    pub fn insert(&mut self, key: String, value: Option<Value>) {
+        self.map.insert(key, value);
+    }
+}
+
+/// A trait that allows types to be converted into an UpdateMap.
+///
+/// This trait provides a way to convert various types into an UpdateMap,
+/// making it easier to create update maps from different data structures.
+pub trait IntoUpdateMap {
+    /// Converts the implementing type into an UpdateMap.
+    fn into_update_map(self) -> UpdateMap;
+}

--- a/entity_api/src/query.rs
+++ b/entity_api/src/query.rs
@@ -1,6 +1,88 @@
-use crate::{error::Error, QueryFilterMap};
+use crate::error::Error;
 use sea_orm::strum::IntoEnumIterator;
-use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter};
+use sea_orm::{ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Value};
+use std::collections::HashMap;
+
+/// `QueryFilterMap` is a data structure that serves as a bridge for translating filter parameters
+/// between different layers of the application. It is essentially a wrapper around a `HashMap`
+/// where the keys are filter parameter names (as `String`) and the values are optional `Value` types
+/// from `sea_orm`.
+///
+/// This structure is particularly useful in scenarios where you need to pass filter parameters
+/// from a web request down to the database query layer in a type-safe and organized manner.
+///
+/// # Example
+///
+/// ```
+/// use sea_orm::Value;
+/// use entity_api::query::QueryFilterMap;
+///
+/// let mut query_filter_map = QueryFilterMap::new();
+/// query_filter_map.insert("coaching_session_id".to_string(), Some(Value::String(Some(Box::new("a_coaching_session_id".to_string())))));
+/// let filter_value = query_filter_map.get("coaching_session_id");
+/// ```
+pub struct QueryFilterMap {
+    map: HashMap<String, Option<Value>>,
+}
+
+impl QueryFilterMap {
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+        }
+    }
+
+    pub fn get(&self, key: &str) -> Option<Value> {
+        // HashMap.get returns an Option and so we need to "flatten" this to a single Option
+        self.map
+            .get(key)
+            .and_then(|inner_option| inner_option.clone())
+    }
+
+    pub fn insert(&mut self, key: String, value: Option<Value>) {
+        self.map.insert(key, value);
+    }
+}
+
+impl Default for QueryFilterMap {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// `IntoQueryFilterMap` is a trait that provides a method for converting a struct into a `QueryFilterMap`.
+/// This is particularly useful for translating data between different layers of the application,
+/// such as from web request parameters to database query filters.
+///
+/// Implementing this trait for a struct allows you to define how the fields of the struct should be
+/// mapped to the keys and values of the `QueryFilterMap`. This ensures that the data is passed
+/// in a type-safe and organized manner.
+///
+/// # Example
+///
+/// ```
+/// use entity_api::query::QueryFilterMap;
+/// use entity_api::query::IntoQueryFilterMap;
+///
+/// #[derive(Debug)]
+/// struct MyParams {
+///     coaching_session_id: String,
+/// }
+///
+/// impl IntoQueryFilterMap for MyParams {
+///     fn into_query_filter_map(self) -> QueryFilterMap {
+///         let mut query_filter_map = QueryFilterMap::new();
+///         query_filter_map.insert(
+///             "coaching_session_id".to_string(),
+///             Some(sea_orm::Value::String(Some(Box::new(self.coaching_session_id)))),
+///         );
+///         query_filter_map
+///     }
+/// }
+/// ```
+pub trait IntoQueryFilterMap {
+    fn into_query_filter_map(self) -> QueryFilterMap;
+}
 
 /// Find all records of an entity by the given query filter map.
 pub async fn find_by<E, C>(

--- a/entity_api/src/user.rs
+++ b/entity_api/src/user.rs
@@ -69,7 +69,7 @@ pub struct Backend {
 }
 
 #[derive(Debug, Clone, ToSchema, IntoParams, Deserialize)]
-#[schema(as = entity_api::user::Credentials)] // OpenAPI schema
+#[schema(as = domain::user::Credentials)] // OpenAPI schema
 pub struct Credentials {
     pub email: String,
     pub password: String,

--- a/web/src/controller/user_session_controller.rs
+++ b/web/src/controller/user_session_controller.rs
@@ -1,6 +1,6 @@
 use crate::controller::ApiResponse;
 use axum::{http::StatusCode, response::IntoResponse, Form, Json};
-use domain::{AuthSession, Credentials};
+use domain::user::{AuthSession, Credentials};
 use log::*;
 use serde::Deserialize;
 use serde_json::json;
@@ -37,7 +37,7 @@ pub async fn protected(auth_session: AuthSession) -> impl IntoResponse {
 #[utoipa::path(
     post,
     path = "/login",
-    request_body(content = Credentials, content_type = "application/x-www-form-urlencoded"),
+    request_body(content = domain::user::Credentials, content_type = "application/x-www-form-urlencoded"),
     responses(
         (status = 200, description = "Logs in and returns session authentication cookie"),
         (status = 401, description = "Unauthorized"),
@@ -94,7 +94,7 @@ security(
     ("cookie_auth" = [])
 )
 )]
-pub async fn logout(mut auth_session: domain::AuthSession) -> impl IntoResponse {
+pub async fn logout(mut auth_session: AuthSession) -> impl IntoResponse {
     debug!("UserSessionController::logout()");
     match auth_session.logout().await {
         Ok(_) => StatusCode::OK.into_response(),

--- a/web/src/extractors/authenticated_user.rs
+++ b/web/src/extractors/authenticated_user.rs
@@ -19,7 +19,7 @@ where
     // This extractor wraps the AuthSession extractor from axum_login. It extracts the user from the AuthSession and returns an AuthenticatedUser.
     // If the user is authenticated. If the user is not authenticated, it returns an Unauthorized error.
     async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
-        let session: domain::AuthSession = AuthSession::from_request_parts(parts, state)
+        let session: domain::user::AuthSession = AuthSession::from_request_parts(parts, state)
             .await
             .map_err(|(status, msg)| (status, msg.to_string()))?;
         match session.user {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -6,7 +6,7 @@ use axum_login::{
     tower_sessions::{Expiry, SessionManagerLayer},
     AuthManagerLayerBuilder,
 };
-use domain::Backend;
+use domain::user::Backend;
 use tower_sessions::session_store::ExpiredDeletion;
 use tower_sessions_sqlx_store::PostgresStore;
 

--- a/web/src/params/mod.rs
+++ b/web/src/params/mod.rs
@@ -16,3 +16,4 @@ pub(crate) mod agreement;
 pub(crate) mod coaching_session;
 pub(crate) mod jwt;
 pub(crate) mod overarching_goal;
+pub(crate) mod user;

--- a/web/src/params/user.rs
+++ b/web/src/params/user.rs
@@ -1,0 +1,51 @@
+use sea_orm::Value;
+use serde::Deserialize;
+use utoipa::{IntoParams, ToSchema};
+
+use domain::{IntoUpdateMap, UpdateMap};
+
+#[derive(Debug, Deserialize, IntoParams, ToSchema)]
+pub struct UpdateUserParams {
+    pub email: Option<String>,
+    pub first_name: Option<String>,
+    pub last_name: Option<String>,
+    pub display_name: Option<String>,
+    pub github_profile_url: Option<String>,
+}
+
+impl IntoUpdateMap for UpdateUserParams {
+    fn into_update_map(self) -> UpdateMap {
+        let mut update_map = UpdateMap::new();
+        if let Some(email) = self.email {
+            update_map.insert(
+                "email".to_string(),
+                Some(Value::String(Some(Box::new(email)))),
+            );
+        }
+        if let Some(first_name) = self.first_name {
+            update_map.insert(
+                "first_name".to_string(),
+                Some(Value::String(Some(Box::new(first_name)))),
+            );
+        }
+        if let Some(last_name) = self.last_name {
+            update_map.insert(
+                "last_name".to_string(),
+                Some(Value::String(Some(Box::new(last_name)))),
+            );
+        }
+        if let Some(display_name) = self.display_name {
+            update_map.insert(
+                "display_name".to_string(),
+                Some(Value::String(Some(Box::new(display_name)))),
+            );
+        }
+        if let Some(github_profile_url) = self.github_profile_url {
+            update_map.insert(
+                "github_profile_url".to_string(),
+                Some(Value::String(Some(Box::new(github_profile_url)))),
+            );
+        }
+        update_map
+    }
+}

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -1,4 +1,4 @@
-use crate::{protect, AppState};
+use crate::{params, protect, AppState};
 use axum::{
     middleware::from_fn_with_state,
     routing::{delete, get, post, put},
@@ -61,6 +61,7 @@ use self::organization::coaching_relationship_controller;
             overarching_goal_controller::read,
             overarching_goal_controller::update_status,
             user_controller::create,
+            user_controller::update,
             user_session_controller::login,
             user_session_controller::logout,
             jwt_controller::generate_collab_token,
@@ -76,6 +77,8 @@ use self::organization::coaching_relationship_controller;
                 domain::overarching_goals::Model,
                 domain::users::Model,
                 domain::Credentials,
+                params::user::UpdateUserParams,
+
             )
         ),
         modifiers(&SecurityAddon),
@@ -278,6 +281,7 @@ pub fn overarching_goal_routes(app_state: AppState) -> Router {
 pub fn user_routes(app_state: AppState) -> Router {
     Router::new()
         .route("/users", post(user_controller::create))
+        .route("/users", put(user_controller::update))
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -5,7 +5,7 @@ use axum::{
     Router,
 };
 use axum_login::login_required;
-use domain::Backend;
+use domain::user::Backend;
 use tower_http::services::ServeDir;
 
 use crate::controller::{
@@ -76,7 +76,7 @@ use self::organization::coaching_relationship_controller;
                 domain::organizations::Model,
                 domain::overarching_goals::Model,
                 domain::users::Model,
-                domain::Credentials,
+                domain::user::Credentials,
                 params::user::UpdateUserParams,
 
             )


### PR DESCRIPTION
## Description

This PR introduces a pattern for providing partial updates to database tables via our API.
By _partial_ updates I mean that we are able to modify a subset of columns for any given table without having to provide values for the the other columns. The pattern is somewhat based on the pattern for filtering queries as introduced in #102 

**Note:** This new endpoint assumes that the user being updated will always be the current user (as noted inline in comments). At some point we will likely want a user to be able to make updates to another user. We can decide how the code diverges at that point when we know more about how we want that to work.

### Changes
* Adds generic `update` function
* Updates user updating to use new function
* Adds `PUT /users` update endpoint
* Fixes a small issue with the Rapidoc for login

### Testing Strategy

#### I was able to test partially updating a user in Rapidoc
![Screenshot 2025-03-04 at 1 18 55 PM](https://github.com/user-attachments/assets/94806e22-91bc-4f08-af3a-162b327ae1f2)

### Coming Up
- Adding New Users
- Updating Coaching Sessions
- Stricter validations