### PR TITLE
Slugify organization names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -900,6 +900,7 @@ dependencies = [
  "serde",
  "serde_json",
  "service",
+ "slugify",
  "sqlx",
  "sqlx-sqlite",
  "tokio",
@@ -2910,6 +2911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "slugify"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6b8cf203d2088b831d7558f8e5151bfa420c57a34240b28cee29d0ae5f2ac8b"
+dependencies = [
+ "unidecode",
+]
+
+[[package]]
 name = "smallvec"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,6 +3737,12 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unidecode"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "402bb19d8e03f1d1a7450e2bd613980869438e0666331be3e073089124aa1adc"
 
 [[package]]
 name = "untrusted"

--- a/entity/src/coaching_relationships.rs
+++ b/entity/src/coaching_relationships.rs
@@ -20,6 +20,12 @@ pub struct Model {
     pub coach_id: Id,
     pub coachee_id: Id,
     #[serde(skip_deserializing)]
+    // TODO we need to make sure this is unique in the scope of an organization_id.
+    // I did some research and there are two ways to do this:
+    // 1. Create a unique constraint at the database level.
+    // 2. Add application logic (probably in entity_api) to make the check.
+    // We'll need to add a migration for that eventually.
+    #[sea_orm(unique)]
     pub slug: String,
     #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema

--- a/entity/src/organizations.rs
+++ b/entity/src/organizations.rs
@@ -16,6 +16,7 @@ pub struct Model {
     pub name: String,
     pub logo: Option<String>,
     #[serde(skip_deserializing)]
+    #[sea_orm(unique)]
     pub slug: String,
     #[serde(skip_deserializing)]
     #[schema(value_type = String, format = DateTime)] // Applies to OpenAPI schema

--- a/entity/src/users.rs
+++ b/entity/src/users.rs
@@ -16,8 +16,8 @@ pub struct Model {
     pub id: Id,
     #[sea_orm(unique)]
     pub email: String,
-    pub first_name: Option<String>,
-    pub last_name: Option<String>,
+    pub first_name: String,
+    pub last_name: String,
     pub display_name: Option<String>,
     #[serde(skip_serializing)]
     pub password: String,

--- a/entity_api/Cargo.toml
+++ b/entity_api/Cargo.toml
@@ -14,6 +14,7 @@ log = "0.4.22"
 axum-login = "0.16.0"
 async-trait = "0.1.83"
 password-auth = "1.0.0"
+slugify = "0.1.0"
 sqlx = { version = "0.8.2", features = ["time", "runtime-tokio"] }
 sqlx-sqlite = { version = "0.8.2" }
 utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -1,4 +1,5 @@
 use super::error::{EntityApiErrorKind, Error};
+use crate::user;
 use chrono::Utc;
 use entity::{
     coachees, coaches,
@@ -10,7 +11,7 @@ use sea_orm::{
     QuerySelect, QueryTrait, Set,
 };
 use serde::ser::{Serialize, SerializeStruct, Serializer};
-
+use slugify::slugify;
 use log::*;
 
 pub async fn create(
@@ -23,11 +24,15 @@ pub async fn create(
     );
 
     let now = Utc::now();
+    let coach = user::find_by_id(db, coaching_relationship_model.coach_id).await?;
+    let coachee = user::find_by_id(db, coaching_relationship_model.coachee_id).await?;
+    let slug = slugify!(format!("{} {}", coach.first_name, coachee.first_name).as_str());
 
     let coaching_relationship_active_model: ActiveModel = ActiveModel {
         organization_id: Set(coaching_relationship_model.organization_id),
         coach_id: Set(coaching_relationship_model.coach_id),
         coachee_id: Set(coaching_relationship_model.coachee_id),
+        slug: Set(slug),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -6,13 +6,13 @@ use entity::{
     coaching_relationships::{self, ActiveModel, Entity, Model},
     Id,
 };
+use log::*;
 use sea_orm::{
     entity::prelude::*, sea_query::Alias, Condition, DatabaseConnection, FromQueryResult, JoinType,
     QuerySelect, QueryTrait, Set,
 };
 use serde::ser::{Serialize, SerializeStruct, Serializer};
 use slugify::slugify;
-use log::*;
 
 pub async fn create(
     db: &DatabaseConnection,

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -31,8 +31,8 @@ pub async fn seed_database(db: &DatabaseConnection) {
 
     let _admin_user: users::ActiveModel = users::ActiveModel {
         email: Set("admin@refactorcoach.com".to_owned()),
-        first_name: Set(Some("Admin".to_owned())),
-        last_name: Set(Some("User".to_owned())),
+        first_name: Set("Admin".to_owned()),
+        last_name: Set("User".to_owned()),
         display_name: Set(Some("Admin User".to_owned())),
         password: Set(generate_hash("dLxNxnjn&b!2sqkwFbb4s8jX")),
         github_username: Set(None),
@@ -47,8 +47,8 @@ pub async fn seed_database(db: &DatabaseConnection) {
 
     let jim_hodapp: users::ActiveModel = users::ActiveModel {
         email: Set("james.hodapp@gmail.com".to_owned()),
-        first_name: Set(Some("Jim".to_owned())),
-        last_name: Set(Some("Hodapp".to_owned())),
+        first_name: Set("Jim".to_owned()),
+        last_name: Set("Hodapp".to_owned()),
         display_name: Set(Some("Jim H".to_owned())),
         password: Set(generate_hash("password")),
         github_username: Set(Some("jhodapp".to_owned())),
@@ -63,8 +63,8 @@ pub async fn seed_database(db: &DatabaseConnection) {
 
     let caleb_bourg: users::ActiveModel = users::ActiveModel {
         email: Set("calebbourg2@gmail.com".to_owned()),
-        first_name: Set(Some("Caleb".to_owned())),
-        last_name: Set(Some("Bourg".to_owned())),
+        first_name: Set("Caleb".to_owned()),
+        last_name: Set("Bourg".to_owned()),
         display_name: Set(Some("cbourg2".to_owned())),
         password: Set(generate_hash("password")),
         github_username: Set(Some("calebbourg".to_owned())),
@@ -79,8 +79,8 @@ pub async fn seed_database(db: &DatabaseConnection) {
 
     let other_user: users::ActiveModel = users::ActiveModel {
         email: Set("other_user@gmail.com".to_owned()),
-        first_name: Set(Some("Other".to_owned())),
-        last_name: Set(Some("User".to_owned())),
+        first_name: Set("Other".to_owned()),
+        last_name: Set("User".to_owned()),
         display_name: Set(Some("Other U.".to_owned())),
         password: Set(generate_hash("password")),
         github_username: Set(None),

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -6,6 +6,7 @@ use sea_orm::{
     entity::prelude::*, sea_query, ActiveValue::Set, ActiveValue::Unchanged, DatabaseConnection,
     JoinType, QuerySelect, TryIntoModel,
 };
+use slugify::slugify;
 use std::collections::HashMap;
 
 use log::*;
@@ -17,10 +18,12 @@ pub async fn create(db: &DatabaseConnection, organization_model: Model) -> Resul
     );
 
     let now = Utc::now();
+    let name = organization_model.name;
 
     let organization_active_model: ActiveModel = ActiveModel {
         logo: Set(organization_model.logo),
-        name: Set(organization_model.name),
+        name: Set(name.clone()),
+        slug: Set(slugify!(name.as_str())),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -453,8 +453,8 @@ mod organization_endpoints_tests {
             Ok(users::Model {
                 id: Id::new_v4(),
                 email: "test@domain.com".to_string(),
-                first_name: Some("test".to_string()),
-                last_name: Some("login".to_string()),
+                first_name: "test".to_string(),
+                last_name: "login".to_string(),
                 display_name: Some("test login".to_string()),
                 password: generate_hash("password2").to_owned(),
                 github_username: None,


### PR DESCRIPTION
## Description

This PR generates `slug` values on the BE for Coaching Relationships and Organizations.

I also required users to have a `first_name` and `last_name`. This simplified the `slug` generation for Coaching Relationships and, I think, makes sense as a requirement. 

### Changes
* Adds `slug` creation for Coaching Relationships and Organizations
* Make `first_name` and `last_name` required for `users`
