### PR TITLE
Update Coaching Sessions

### DIFF
--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -40,7 +40,7 @@ pub async fn create(
         "{}.{}.{}-v0",
         organization.slug,
         coaching_relationship.slug,
-        coaching_session_model.date.and_utc().timestamp()
+        Id::new_v4()
     );
     info!(
         "Attempting to create Tiptap document with name: {}",

--- a/entity/src/coaching_sessions.rs
+++ b/entity/src/coaching_sessions.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize, ToSchema)]
-#[schema(as = entity::coaching_sessions::Model)]
+#[schema(as = domain::coaching_sessions::Model)]
 #[sea_orm(schema_name = "refactor_platform", table_name = "coaching_sessions")]
 pub struct Model {
     #[serde(skip_deserializing)]

--- a/entity/src/users.rs
+++ b/entity/src/users.rs
@@ -8,7 +8,7 @@ use utoipa::ToSchema;
 
 // TODO: We should find a way to centralize the users/coaches/coachees types
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, ToSchema, Serialize, Deserialize)]
-#[schema(as = entity::users::Model)] // OpenAPI schema
+#[schema(as = domain::users::Model)] // OpenAPI schema
 #[sea_orm(schema_name = "refactor_platform", table_name = "users")]
 pub struct Model {
     #[serde(skip_deserializing)]

--- a/entity_api/src/mutate.rs
+++ b/entity_api/src/mutate.rs
@@ -4,7 +4,6 @@ use sea_orm::{
     IntoActiveModel, Value,
 };
 use std::collections::HashMap;
-
 /// Updates an existing record in the database using a map of column names to values.
 ///
 /// This function provides a flexible way to update only specific fields of an entity

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -57,9 +57,9 @@ pub async fn index(
     post,
     path = "/coaching_sessions",
     params(ApiVersion),
-    request_body = coaching_sessions::Model,
+    request_body = domain::coaching_sessions::Model,
     responses(
-        (status = 201, description = "Successfully Created a new Coaching Session", body = [coaching_sessions::Model]),
+        (status = 201, description = "Successfully Created a new Coaching Session", body = [domain::coaching_sessions::Model]),
         (status= 422, description = "Unprocessable Entity"),
         (status = 401, description = "Unauthorized"),
         (status = 405, description = "Method not allowed")

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -2,13 +2,13 @@ use crate::controller::ApiResponse;
 use crate::extractors::{
     authenticated_user::AuthenticatedUser, compare_api_version::CompareApiVersion,
 };
-use crate::params::coaching_session::IndexParams;
+use crate::params::coaching_session::{IndexParams, UpdateParams};
 use crate::{AppState, Error};
-use axum::extract::{Query, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use domain::{coaching_session as CoachingSessionApi, coaching_sessions::Model};
+use domain::{coaching_session as CoachingSessionApi, coaching_sessions::Model, Id};
 use service::config::ApiVersion;
 
 use log::*;
@@ -94,4 +94,32 @@ pub async fn create(
         StatusCode::CREATED.into(),
         coaching_session,
     )))
+}
+
+/// PUT update a Coaching Session
+#[utoipa::path(
+    put,
+    path = "/coaching_sessions/{id}",
+    params(
+        ApiVersion,
+        ("id" = Id, Path, description = "Coaching Session ID to Update")
+    ),
+    request_body = UpdateParams,
+    responses(
+        (status = 204, description = "Successfully updated a Coaching Session", body = ()),
+        (status = 401, description = "Unauthorized"),
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn update(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    State(app_state): State<AppState>,
+    Path(coaching_session_id): Path<Id>,
+    Json(params): Json<UpdateParams>,
+) -> Result<impl IntoResponse, Error> {
+    CoachingSessionApi::update(app_state.db_conn_ref(), coaching_session_id, params).await?;
+    Ok(Json(ApiResponse::new(StatusCode::NO_CONTENT.into(), ())))
 }

--- a/web/src/controller/user_controller.rs
+++ b/web/src/controller/user_controller.rs
@@ -16,9 +16,9 @@ use log::*;
     params(
         ApiVersion,
     ),
-    request_body = users::Model,
+    request_body = domain::users::Model,
     responses(
-        (status = 200, description = "Successfully created a new User", body = [users::Model]),
+        (status = 200, description = "Successfully created a new User", body = [domain::users::Model]),
         (status = 401, description = "Unauthorized"),
         (status = 405, description = "Method not allowed")
     ),
@@ -49,8 +49,7 @@ pub async fn create(
     put,
     path = "/users",
     params(
-        ApiVersion,
-        UpdateParams
+        ApiVersion
     ),
     request_body = UpdateParams,
     responses(

--- a/web/src/controller/user_controller.rs
+++ b/web/src/controller/user_controller.rs
@@ -50,9 +50,9 @@ pub async fn create(
     path = "/users",
     params(
         ApiVersion,
-        UpdateUserParams
+        UpdateParams
     ),
-    request_body = UpdateUserParams,
+    request_body = UpdateParams,
     responses(
         (status = 204, description = "Successfully updated a User", body = ()),
         (status = 401, description = "Unauthorized"),
@@ -65,7 +65,7 @@ pub async fn update(
     CompareApiVersion(_v): CompareApiVersion,
     AuthenticatedUser(user): AuthenticatedUser,
     State(app_state): State<AppState>,
-    Json(params): Json<UpdateUserParams>,
+    Json(params): Json<UpdateParams>,
 ) -> Result<impl IntoResponse, Error> {
     UserApi::update(app_state.db_conn_ref(), user.id, params).await?;
     Ok(Json(ApiResponse::new(StatusCode::NO_CONTENT.into(), ())))

--- a/web/src/params/coaching_session.rs
+++ b/web/src/params/coaching_session.rs
@@ -1,9 +1,9 @@
-use chrono::NaiveDate;
+use chrono::{NaiveDate, NaiveDateTime};
 use domain::Id;
-use domain::{IntoQueryFilterMap, QueryFilterMap};
+use domain::{IntoQueryFilterMap, IntoUpdateMap, QueryFilterMap, UpdateMap};
 use sea_orm::Value;
 use serde::Deserialize;
-use utoipa::IntoParams;
+use utoipa::{IntoParams, ToSchema};
 
 #[derive(Debug, Deserialize, IntoParams)]
 pub(crate) struct IndexParams {
@@ -28,5 +28,21 @@ impl IntoQueryFilterMap for IndexParams {
             Some(Value::ChronoDate(Some(Box::new(self.to_date)))),
         );
         query_filter_map
+    }
+}
+
+#[derive(Debug, Deserialize, IntoParams, ToSchema)]
+pub(crate) struct UpdateParams {
+    pub(crate) date: NaiveDateTime,
+}
+
+impl IntoUpdateMap for UpdateParams {
+    fn into_update_map(self) -> UpdateMap {
+        let mut update_map = UpdateMap::new();
+        update_map.insert(
+            "date".to_string(),
+            Some(Value::ChronoDateTime(Some(Box::new(self.date)))),
+        );
+        update_map
     }
 }

--- a/web/src/params/user.rs
+++ b/web/src/params/user.rs
@@ -5,7 +5,7 @@ use utoipa::{IntoParams, ToSchema};
 use domain::{IntoUpdateMap, UpdateMap};
 
 #[derive(Debug, Deserialize, IntoParams, ToSchema)]
-pub struct UpdateUserParams {
+pub struct UpdateParams {
     pub email: Option<String>,
     pub first_name: Option<String>,
     pub last_name: Option<String>,
@@ -13,7 +13,7 @@ pub struct UpdateUserParams {
     pub github_profile_url: Option<String>,
 }
 
-impl IntoUpdateMap for UpdateUserParams {
+impl IntoUpdateMap for UpdateParams {
     fn into_update_map(self) -> UpdateMap {
         let mut update_map = UpdateMap::new();
         if let Some(email) = self.email {

--- a/web/src/protect/coaching_sessions.rs
+++ b/web/src/protect/coaching_sessions.rs
@@ -45,9 +45,9 @@ pub(crate) async fn index(
 }
 
 /// Checks that coaching session record referenced by `coaching_session_id`
-/// * exists
-/// * that the authenticated user is associated with it.
-/// * that the authenticated user is the coach
+///     * exists
+///     * that the authenticated user is associated with it.
+///     * that the authenticated user is the coach
 ///  Intended to be given to axum::middleware::from_fn_with_state in the router
 pub(crate) async fn update(
     State(app_state): State<AppState>,

--- a/web/src/protect/coaching_sessions.rs
+++ b/web/src/protect/coaching_sessions.rs
@@ -1,14 +1,14 @@
 use crate::{extractors::authenticated_user::AuthenticatedUser, AppState};
 use axum::{
-    extract::{Query, Request, State},
+    extract::{Path, Query, Request, State},
     http::StatusCode,
     middleware::Next,
     response::IntoResponse,
 };
 use serde::Deserialize;
 
-use domain::{coaching_relationship, Id};
-
+use domain::{coaching_relationship, coaching_session, Id};
+use log::error;
 #[derive(Debug, Deserialize)]
 pub(crate) struct QueryParams {
     coaching_relationship_id: Id,
@@ -41,5 +41,46 @@ pub(crate) async fn index(
         }
         // coaching relationship with given ID not found
         Err(_) => (StatusCode::NOT_FOUND, "NOT FOUND").into_response(),
+    }
+}
+
+/// Checks that coaching session record referenced by `coaching_session_id`
+/// * exists
+/// * that the authenticated user is associated with it.
+/// * that the authenticated user is the coach
+///  Intended to be given to axum::middleware::from_fn_with_state in the router
+pub(crate) async fn update(
+    State(app_state): State<AppState>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Path(coaching_session_id): Path<Id>,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    let coaching_session =
+        match coaching_session::find_by_id(app_state.db_conn_ref(), coaching_session_id).await {
+            Ok(session) => session,
+            Err(e) => {
+                error!("Authorization error finding coaching session: {:?}", e);
+                return (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response();
+            }
+        };
+
+    let coaching_relationship = match coaching_relationship::find_by_id(
+        app_state.db_conn_ref(),
+        coaching_session.coaching_relationship_id,
+    )
+    .await
+    {
+        Ok(relationship) => relationship,
+        Err(e) => {
+            error!("Authorization error finding coaching relationship: {:?}", e);
+            return (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response();
+        }
+    };
+
+    if coaching_relationship.coach_id == user.id {
+        next.run(request).await
+    } else {
+        (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response()
     }
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -183,7 +183,7 @@ pub fn coaching_sessions_routes(app_state: AppState) -> Router {
                 )),
         )
         .merge(
-            // Get /coaching_sessions
+            // Put /coaching_sessions
             Router::new()
                 .route(
                     "/coaching_sessions/:id",

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -43,6 +43,7 @@ use self::organization::coaching_relationship_controller;
             agreement_controller::delete,
             coaching_session_controller::index,
             coaching_session_controller::create,
+            coaching_session_controller::update,
             note_controller::create,
             note_controller::update,
             note_controller::index,
@@ -77,8 +78,8 @@ use self::organization::coaching_relationship_controller;
                 domain::overarching_goals::Model,
                 domain::users::Model,
                 domain::user::Credentials,
-                params::user::UpdateUserParams,
-
+                params::user::UpdateParams,
+                params::coaching_session::UpdateParams,
             )
         ),
         modifiers(&SecurityAddon),
@@ -179,6 +180,18 @@ pub fn coaching_sessions_routes(app_state: AppState) -> Router {
                 .route_layer(from_fn_with_state(
                     app_state.clone(),
                     protect::coaching_sessions::index,
+                )),
+        )
+        .merge(
+            // Get /coaching_sessions
+            Router::new()
+                .route(
+                    "/coaching_sessions/:id",
+                    put(coaching_session_controller::update),
+                )
+                .route_layer(from_fn_with_state(
+                    app_state.clone(),
+                    protect::coaching_sessions::update,
                 )),
         )
         .route_layer(login_required!(Backend, login_url = "/login"))


### PR DESCRIPTION
## Description
This PR adds an endpoint for updating existing Coaching Sessions.


### Changes
* Use `UUID` to uniquely identify Tiptap documents (Because we are able to update the `date` field for Coaching Sessions)
* Adds the ability to update an existing Coaching Session
* Small fixes for Utoipa schemas

### Testing Strategy
Tested locally

