### PR TITLE
88 feature add member management page create

### DIFF
--- a/domain/src/user.rs
+++ b/domain/src/user.rs
@@ -1,12 +1,16 @@
-use crate::{error::Error, users, Id};
-use entity_api::{mutate, query, query::IntoQueryFilterMap};
-use sea_orm::DatabaseConnection;
-use sea_orm::IntoActiveModel;
-
+use crate::{
+    error::Error,
+    error::{DomainErrorKind, EntityErrorKind, InternalErrorKind},
+    users, Id,
+};
+use chrono::Utc;
 pub use entity_api::user::{
     create, create_by_organization, find_by_email, find_by_id, find_by_organization, AuthSession,
     Backend, Credentials,
 };
+use entity_api::{mutate, query, query::IntoQueryFilterMap};
+use sea_orm::IntoActiveModel;
+use sea_orm::{DatabaseConnection, TransactionTrait};
 
 pub async fn find_by(
     db: &DatabaseConnection,
@@ -31,4 +35,45 @@ pub async fn update(
         params.into_update_map(),
     )
     .await?)
+}
+
+// This function is intended to be a temporary solution until we finalize our user experience strategy for assigning a new user
+// to a coach or designating them as a coach. In the future, the API will require the frontend to make separate requests:
+// one request to create a new user within the scope of an organization, and a subsequent request to assign that user to a
+// coaching relationship. This separation is necessary because a user can be created and then assigned to a coaching relationship at
+// a later time. Currently, we are combining these two operations to leverage the backend database transaction, which helps
+// prevent inconsistencies or errors that might arise from network issues or other problems, ensuring a consistent state
+// between new users and their coaching relationships.
+pub async fn create_user_and_coaching_relationship(
+    db: &DatabaseConnection,
+    organization_id: Id,
+    coach_id: Id,
+    user_model: users::Model,
+) -> Result<users::Model, Error> {
+    // This is not probably the type of error we'll ultimately be exposing. Again just temporary (hopfully)
+    let txn = db.begin().await.map_err(|e| Error {
+        source: Some(Box::new(e)),
+        error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(EntityErrorKind::Other)),
+    })?;
+
+    // Create the user within the organization
+    let new_user = create_by_organization(&txn, organization_id, user_model).await?;
+    // Create the coaching relationship using the new user's ID as the coachee_id
+    let new_coaching_relationship_model = entity_api::coaching_relationships::Model {
+        coachee_id: new_user.id,
+        coach_id,
+        organization_id,
+        // These will be overridden
+        id: Default::default(),
+        slug: "".to_string(),
+        created_at: Utc::now().into(),
+        updated_at: Utc::now().into(),
+    };
+    entity_api::coaching_relationship::create(&txn, new_coaching_relationship_model).await?;
+    // This is not probably the type of error we'll ultimately be exposing. Again just temporary (hopfully
+    txn.commit().await.map_err(|e| Error {
+        source: Some(Box::new(e)),
+        error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(EntityErrorKind::Other)),
+    })?;
+    Ok(new_user)
 }

--- a/domain/src/user.rs
+++ b/domain/src/user.rs
@@ -4,7 +4,8 @@ use sea_orm::DatabaseConnection;
 use sea_orm::IntoActiveModel;
 
 pub use entity_api::user::{
-    create, find_by_email, find_by_id, find_by_organization, AuthSession, Backend, Credentials,
+    create, create_by_organization, find_by_email, find_by_id, find_by_organization, AuthSession,
+    Backend, Credentials,
 };
 
 pub async fn find_by(

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -15,7 +15,7 @@ use serde::ser::{Serialize, SerializeStruct, Serializer};
 use slugify::slugify;
 
 pub async fn create(
-    db: &DatabaseConnection,
+    db: &impl ConnectionTrait,
     coaching_relationship_model: Model,
 ) -> Result<Model, Error> {
     debug!(
@@ -37,7 +37,6 @@ pub async fn create(
         updated_at: Set(now.into()),
         ..Default::default()
     };
-
     Ok(coaching_relationship_active_model.insert(db).await?)
 }
 

--- a/entity_api/src/user.rs
+++ b/entity_api/src/user.rs
@@ -7,12 +7,14 @@ use entity::users::{ActiveModel, Column, Entity, Model};
 use entity::{organizations, organizations_users, Id};
 use log::*;
 use password_auth::{generate_hash, verify_password};
-use sea_orm::{entity::prelude::*, DatabaseConnection, JoinType, QuerySelect, Set};
+use sea_orm::{
+    entity::prelude::*, DatabaseConnection, JoinType, QuerySelect, Set, TransactionTrait,
+};
 use serde::Deserialize;
 use std::sync::Arc;
 use utoipa::{IntoParams, ToSchema};
 
-pub async fn create(db: &DatabaseConnection, user_model: Model) -> Result<Model, Error> {
+pub async fn create(db: &impl ConnectionTrait, user_model: Model) -> Result<Model, Error> {
     debug!(
         "New User Relationship Model to be inserted: {:?}",
         user_model
@@ -34,6 +36,31 @@ pub async fn create(db: &DatabaseConnection, user_model: Model) -> Result<Model,
     };
 
     Ok(user_active_model.insert(db).await?)
+}
+
+pub async fn create_by_organization(
+    db: &DatabaseConnection,
+    organization_id: Id,
+    user_model: Model,
+) -> Result<Model, Error> {
+    // start database transaction
+    let txn = db.begin().await?;
+
+    let user = create(&txn, user_model).await?;
+    let now = Utc::now();
+    let organization_user = organizations_users::ActiveModel {
+        organization_id: Set(organization_id),
+        user_id: Set(user.id),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    };
+
+    organization_user.insert(&txn).await?;
+
+    txn.commit().await?;
+    // end database transaction
+    Ok(user)
 }
 
 pub async fn find_by_email(db: &DatabaseConnection, email: &str) -> Result<Option<Model>, Error> {
@@ -209,6 +236,77 @@ mod test {
                 [organization_id.into()]
             )]
         );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_by_organization_returns_a_new_user_model() -> Result<(), Error> {
+        let now = chrono::Utc::now();
+        let user_id = Id::new_v4();
+        let organization_id = Id::new_v4();
+
+        let user_model = entity::users::Model {
+            id: user_id,
+            email: "test@test.com".to_owned(),
+            first_name: "Test".to_owned(),
+            last_name: "User".to_owned(),
+            display_name: None,
+            password: "password123".to_owned(),
+            github_username: None,
+            github_profile_url: None,
+            created_at: now.into(),
+            updated_at: now.into(),
+        };
+
+        let organization_user_model = entity::organizations_users::Model {
+            id: Id::new_v4(),
+            organization_id,
+            user_id,
+            created_at: now.into(),
+            updated_at: now.into(),
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([[user_model.clone()]])
+            .append_query_results([[organization_user_model.clone()]])
+            .into_connection();
+
+        let user = create_by_organization(&db, organization_id, user_model.clone()).await?;
+
+        assert_eq!(user.id, user_model.id);
+        assert_eq!(user.email, user_model.email);
+        assert_eq!(user.first_name, user_model.first_name);
+        assert_eq!(user.last_name, user_model.last_name);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_by_organization_returns_error_on_duplicate_email() -> Result<(), Error> {
+        let now = chrono::Utc::now();
+        let user_id = Id::new_v4();
+        let organization_id = Id::new_v4();
+
+        let user_model = entity::users::Model {
+            id: user_id,
+            email: "test@test.com".to_owned(),
+            first_name: "Test".to_owned(),
+            last_name: "User".to_owned(),
+            display_name: None,
+            password: "password123".to_owned(),
+            github_username: None,
+            github_profile_url: None,
+            created_at: now.into(),
+            updated_at: now.into(),
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_errors([sea_orm::DbErr::Custom("Duplicate email".to_string())])
+            .into_connection();
+
+        let result = create_by_organization(&db, organization_id, user_model).await;
+        assert!(result.is_err());
 
         Ok(())
     }

--- a/web/src/controller/organization/user_controller.rs
+++ b/web/src/controller/organization/user_controller.rs
@@ -8,7 +8,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use domain::{user as UserApi, Id};
+use domain::{user as UserApi, users, Id};
 use service::config::ApiVersion;
 
 use log::*;
@@ -22,7 +22,7 @@ use log::*;
         ("organization_id" = Id, Path, description = "The ID of the organization to retrieve users for")
     ),
     responses(
-        (status = 200, description = "Successfully retrieved all Users", body = [users::Model]),
+        (status = 200, description = "Successfully retrieved all Users", body = [domain::users::Model]),
         (status = 401, description = "Unauthorized"),
         (status = 405, description = "Method not allowed")
     ),
@@ -43,4 +43,36 @@ pub async fn index(
     debug!("Found Users {:?}", &users);
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), users)))
+}
+
+/// CREATE a User for an organization
+/// This function creates a new user associated with the specified organization.
+#[utoipa::path(
+    post,
+    path = "/organizations/{organization_id}/users",
+    params(
+        ApiVersion,
+        ("organization_id" = Id, Path, description = "The ID of the organization"),
+    ),
+    request_body = domain::users::Model,
+    responses(
+        (status = 201, description = "User created successfully", body = domain::users::Model),
+        (status = 401, description = "Unauthorized"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub(crate) async fn create(
+    State(app_state): State<AppState>,
+    AuthenticatedUser(_authenticated_user): AuthenticatedUser,
+    Path(organization_id): Path<Id>,
+    Json(user_model): Json<users::Model>,
+) -> Result<impl IntoResponse, Error> {
+    let user =
+        UserApi::create_by_organization(app_state.db_conn_ref(), organization_id, user_model)
+            .await?;
+
+    Ok(Json(ApiResponse::new(StatusCode::CREATED.into(), user)))
 }

--- a/web/src/controller/user_controller.rs
+++ b/web/src/controller/user_controller.rs
@@ -4,41 +4,8 @@ use crate::extractors::{
 use crate::{controller::ApiResponse, params::user::*};
 use crate::{AppState, Error};
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
-use domain::{user as UserApi, users};
+use domain::user as UserApi;
 use service::config::ApiVersion;
-
-use log::*;
-
-/// CREATE a new User
-#[utoipa::path(
-    post,
-    path = "/users",
-    params(
-        ApiVersion,
-    ),
-    request_body = domain::users::Model,
-    responses(
-        (status = 200, description = "Successfully created a new User", body = [domain::users::Model]),
-        (status = 401, description = "Unauthorized"),
-        (status = 405, description = "Method not allowed")
-    ),
-    security(
-        ("cookie_auth" = [])
-    )
-    )]
-pub async fn create(
-    CompareApiVersion(_v): CompareApiVersion,
-    State(app_state): State<AppState>,
-    Json(user_model): Json<users::Model>,
-) -> Result<impl IntoResponse, Error> {
-    debug!("CREATE new User from: {:?}", user_model);
-
-    let user: users::Model = UserApi::create(app_state.db_conn_ref(), user_model).await?;
-
-    debug!("Newly created Users {:?}", &user);
-
-    Ok(Json(ApiResponse::new(StatusCode::CREATED.into(), user)))
-}
 
 /// UPDATE a User
 /// NOTE: that this is for updating the current user and as such uses the user

--- a/web/src/protect/organizations/users.rs
+++ b/web/src/protect/organizations/users.rs
@@ -47,6 +47,9 @@ pub(crate) async fn create(
     .await
 
     // TODO: Check that the authenticated user is a coach
+    // It's not immediately clear whether or not this endpoint will be only for coaches in the future until we work out some of the specifics
+    //around the user creation workflow. Ex create user -> assign user to coaching relationship later.
+    // Leaving this out at the moment. It may be that we decide on separate endpoints for different "flavors" of user creation.
 }
 
 async fn check_user_in_organization(

--- a/web/src/protect/organizations/users.rs
+++ b/web/src/protect/organizations/users.rs
@@ -5,8 +5,9 @@ use axum::{
     middleware::Next,
     response::IntoResponse,
 };
-use domain::{user, Id};
-use log::error;
+use domain::{user as UserApi, users, Id};
+
+use log::*;
 
 /// Checks that the authenticated user is associated with the organization specified by `organization_id`
 /// Intended to be given to axum::middleware::from_fn_with_state in the router
@@ -17,7 +18,45 @@ pub(crate) async fn index(
     request: Request,
     next: Next,
 ) -> impl IntoResponse {
-    match user::find_by_organization(app_state.db_conn_ref(), organization_id).await {
+    check_user_in_organization(
+        &app_state,
+        authenticated_user,
+        organization_id,
+        request,
+        next,
+    )
+    .await;
+}
+
+/// Checks that the authenticated user is associated with the organization specified by `organization_id`
+/// Intended to be given to axum::middleware::from_fn_with_state in the router
+pub(crate) async fn create(
+    State(app_state): State<AppState>,
+    AuthenticatedUser(authenticated_user): AuthenticatedUser,
+    Path(organization_id): Path<Id>,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    check_user_in_organization(
+        &app_state,
+        authenticated_user,
+        organization_id,
+        request,
+        next,
+    )
+    .await;
+
+    // TODO: Check that the authenticated user is a coach
+}
+
+async fn check_user_in_organization(
+    app_state: &AppState,
+    authenticated_user: users::Model,
+    organization_id: Id,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    match UserApi::find_by_organization(app_state.db_conn_ref(), organization_id).await {
         Ok(users) => {
             if users.iter().any(|user| user.id == authenticated_user.id) {
                 next.run(request).await
@@ -27,7 +66,6 @@ pub(crate) async fn index(
         }
         Err(_) => {
             error!("Organization not found with ID {:?}", organization_id);
-
             (StatusCode::NOT_FOUND, "NOT FOUND").into_response()
         }
     }

--- a/web/src/protect/organizations/users.rs
+++ b/web/src/protect/organizations/users.rs
@@ -25,7 +25,7 @@ pub(crate) async fn index(
         request,
         next,
     )
-    .await;
+    .await
 }
 
 /// Checks that the authenticated user is associated with the organization specified by `organization_id`
@@ -44,7 +44,7 @@ pub(crate) async fn create(
         request,
         next,
     )
-    .await;
+    .await
 
     // TODO: Check that the authenticated user is a coach
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -57,12 +57,12 @@ use self::organization::coaching_relationship_controller;
             organization::coaching_relationship_controller::index,
             organization::coaching_relationship_controller::read,
             organization::user_controller::index,
+            organization::user_controller::create,
             overarching_goal_controller::create,
             overarching_goal_controller::update,
             overarching_goal_controller::index,
             overarching_goal_controller::read,
             overarching_goal_controller::update_status,
-            user_controller::create,
             user_controller::update,
             user_session_controller::login,
             user_session_controller::logout,
@@ -255,6 +255,18 @@ fn organization_user_routes(app_state: AppState) -> Router {
                     protect::organizations::users::index,
                 )),
         )
+        .merge(
+            // POST /organizations/:organization_id/users
+            Router::new()
+                .route(
+                    "/organizations/:organization_id/users",
+                    post(organization::user_controller::create),
+                )
+                .route_layer(from_fn_with_state(
+                    app_state.clone(),
+                    protect::organizations::users::create,
+                )),
+        )
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)
 }
@@ -312,7 +324,6 @@ pub fn overarching_goal_routes(app_state: AppState) -> Router {
 
 pub fn user_routes(app_state: AppState) -> Router {
     Router::new()
-        .route("/users", post(user_controller::create))
         .route("/users", put(user_controller::update))
         .route_layer(login_required!(Backend, login_url = "/login"))
         .with_state(app_state)


### PR DESCRIPTION
## Description

This PR allows for Coaches to create new Coachees through the API.

The order of operations are as follows:
- A new user is created
- The new user is associated with the current organization
- A new coaching relationship is created where the new user is the coachee and the current authenticated user is the coach


#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

### Changes
* Adds `POST /organizations/{organization_id}/users` endpoint


### Testing Strategy
Tested locally against https://github.com/refactor-group/refactor-platform-fe/pull/92

