### PR TITLE
88 feature add member management page delete

### DIFF
--- a/domain/src/user.rs
+++ b/domain/src/user.rs
@@ -8,7 +8,9 @@ pub use entity_api::user::{
     create, create_by_organization, find_by_email, find_by_id, find_by_organization, AuthSession,
     Backend, Credentials,
 };
-use entity_api::{coaching_relationship, mutate, organizations_user, query, query::IntoQueryFilterMap, user};
+use entity_api::{
+    coaching_relationship, mutate, organizations_user, query, query::IntoQueryFilterMap, user,
+};
 use sea_orm::IntoActiveModel;
 use sea_orm::{DatabaseConnection, TransactionTrait};
 
@@ -87,7 +89,7 @@ pub async fn delete(db: &DatabaseConnection, user_id: Id) -> Result<(), Error> {
     coaching_relationship::delete_by_user_id(&txn, user_id).await?;
     organizations_user::delete_by_user_id(&txn, user_id).await?;
     user::delete(&txn, user_id).await?;
-    
+
     txn.commit().await.map_err(|e| Error {
         source: Some(Box::new(e)),
         error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(EntityErrorKind::Other)),

--- a/domain/src/user.rs
+++ b/domain/src/user.rs
@@ -8,7 +8,7 @@ pub use entity_api::user::{
     create, create_by_organization, find_by_email, find_by_id, find_by_organization, AuthSession,
     Backend, Credentials,
 };
-use entity_api::{mutate, query, query::IntoQueryFilterMap};
+use entity_api::{coaching_relationship, mutate, organizations_user, query, query::IntoQueryFilterMap, user};
 use sea_orm::IntoActiveModel;
 use sea_orm::{DatabaseConnection, TransactionTrait};
 
@@ -76,4 +76,22 @@ pub async fn create_user_and_coaching_relationship(
         error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(EntityErrorKind::Other)),
     })?;
     Ok(new_user)
+}
+
+pub async fn delete(db: &DatabaseConnection, user_id: Id) -> Result<(), Error> {
+    let txn = db.begin().await.map_err(|e| Error {
+        source: Some(Box::new(e)),
+        error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(EntityErrorKind::Other)),
+    })?;
+
+    coaching_relationship::delete_by_user_id(&txn, user_id).await?;
+    organizations_user::delete_by_user_id(&txn, user_id).await?;
+    user::delete(&txn, user_id).await?;
+    
+    txn.commit().await.map_err(|e| Error {
+        source: Some(Box::new(e)),
+        error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(EntityErrorKind::Other)),
+    })?;
+
+    Ok(())
 }

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -15,6 +15,7 @@ pub mod error;
 pub mod mutate;
 pub mod note;
 pub mod organization;
+pub mod organizations_user;
 pub mod overarching_goal;
 pub mod query;
 pub mod user;

--- a/entity_api/src/organizations_user.rs
+++ b/entity_api/src/organizations_user.rs
@@ -1,0 +1,42 @@
+use super::error::Error;
+use entity::organizations_users::{Column, Entity};
+use entity::Id;
+use sea_orm::{ColumnTrait, Condition, ConnectionTrait, EntityTrait, QueryFilter};
+
+pub async fn delete_by_user_id(db: &impl ConnectionTrait, user_id: Id) -> Result<(), Error> {
+    Entity::delete_many()
+        .filter(Condition::all().add(Column::UserId.eq(user_id)))
+        .exec(db)
+        .await?;
+    Ok(())
+}
+
+#[cfg(test)]
+// We need to gate seaORM's mock feature behind conditional compilation because
+// the feature removes the Clone trait implementation from seaORM's DatabaseConnection.
+// see https://github.com/SeaQL/sea-orm/issues/830
+#[cfg(feature = "mock")]
+mod test {
+    use super::*;
+    use entity::Id;
+    use sea_orm::{DatabaseBackend, MockDatabase, Transaction};
+
+    #[tokio::test]
+    async fn test_delete_by_user_id() -> Result<(), Error> {
+        let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+
+        let user_id = Id::new_v4();
+        let _ = delete_by_user_id(&db, user_id).await;
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"DELETE FROM "refactor_platform"."organizations_users" WHERE "organizations_users"."user_id" = $1"#,
+                [user_id.into()]
+            )]
+        );
+
+        Ok(())
+    }
+}

--- a/web/src/controller/mod.rs
+++ b/web/src/controller/mod.rs
@@ -1,5 +1,4 @@
 use serde::Serialize;
-
 pub(crate) mod action_controller;
 pub(crate) mod agreement_controller;
 pub(crate) mod coaching_session_controller;
@@ -13,13 +12,54 @@ pub(crate) mod user_session_controller;
 
 #[derive(Debug, Serialize)]
 struct ApiResponse<T: Serialize> {
-    // Eventually we can add meta, errors, etc.
     status_code: u16,
-    data: T,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    data: Option<T>,
 }
 
 impl<T: Serialize> ApiResponse<T> {
     pub fn new(status_code: u16, data: T) -> Self {
-        Self { status_code, data }
+        Self {
+            status_code,
+            data: Some(data),
+        }
+    }
+
+    pub fn no_content(status_code: u16) -> ApiResponse<()> {
+        ApiResponse {
+            status_code,
+            data: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::StatusCode;
+    use serde_json::json;
+
+    #[tokio::test]
+    async fn test_serialize_api_response_with_some() {
+        let response = ApiResponse {
+            status_code: StatusCode::OK.into(),
+            data: Some(23),
+        };
+        let serialized = serde_json::to_string(&response).unwrap();
+
+        // Serializing and then deserializing because the string output from serde_json::to_string is
+        // non-deterministic as far as the order of the JSON keys. This ensures the test won't be flaky
+        let deserialized_value: serde_json::Value = serde_json::from_str(&serialized).unwrap();
+        let deserialized_expected_value: serde_json::Value =
+            json!({"data": 23, "status_code": 200});
+        assert_eq!(deserialized_value, deserialized_expected_value);
+    }
+
+    #[tokio::test]
+    async fn test_serialize_api_response_with_none() {
+        let response = ApiResponse::<()>::no_content(StatusCode::NO_CONTENT.into());
+        // No need to deserialize here because there's only one key
+        let serialized = serde_json::to_string(&response).unwrap();
+        assert_eq!(serialized, json!({"status_code": 204}).to_string());
     }
 }

--- a/web/src/protect/organizations/users.rs
+++ b/web/src/protect/organizations/users.rs
@@ -52,6 +52,25 @@ pub(crate) async fn create(
     // Leaving this out at the moment. It may be that we decide on separate endpoints for different "flavors" of user creation.
 }
 
+/// Checks that the authenticated user is associated with the organization specified by `organization_id`
+/// Intended to be given to axum::middleware::from_fn_with_state in the router
+pub(crate) async fn delete(
+    State(app_state): State<AppState>,
+    AuthenticatedUser(authenticated_user): AuthenticatedUser,
+    Path((organization_id, _user_id)): Path<(Id, Id)>,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    check_user_in_organization(
+        &app_state,
+        authenticated_user,
+        organization_id,
+        request,
+        next,
+    )
+    .await
+}
+
 async fn check_user_in_organization(
     app_state: &AppState,
     authenticated_user: users::Model,

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -58,6 +58,7 @@ use self::organization::coaching_relationship_controller;
             organization::coaching_relationship_controller::read,
             organization::user_controller::index,
             organization::user_controller::create,
+            organization::user_controller::delete,
             overarching_goal_controller::create,
             overarching_goal_controller::update,
             overarching_goal_controller::index,
@@ -265,6 +266,18 @@ fn organization_user_routes(app_state: AppState) -> Router {
                 .route_layer(from_fn_with_state(
                     app_state.clone(),
                     protect::organizations::users::create,
+                )),
+        )
+        .merge(
+            // POST /organizations/:organization_id/users
+            Router::new()
+                .route(
+                    "/organizations/:organization_id/users/:user_id",
+                    delete(organization::user_controller::delete),
+                )
+                .route_layer(from_fn_with_state(
+                    app_state.clone(),
+                    protect::organizations::users::delete,
                 )),
         )
         .route_layer(login_required!(Backend, login_url = "/login"))


### PR DESCRIPTION
## Description
This PR adds an endpoint for deleting a user




### Changes
* Adds `DELETE /organizations/{organization_id}/users/{user_id}`


### Testing Strategy
Tested locally

