### PR TITLE
Delete coaching sessions

### DIFF
--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -1,18 +1,37 @@
 use crate::coaching_sessions::Model;
-use crate::error::{DomainErrorKind, Error, ExternalErrorKind, InternalErrorKind};
-use crate::gateway::tiptap::client as tiptap_client;
+use crate::error::{DomainErrorKind, Error, InternalErrorKind};
+use crate::gateway::tiptap::TiptapDocument;
 use crate::Id;
-use chrono::{DurationRound, TimeDelta};
+use chrono::{DurationRound, NaiveDateTime, TimeDelta};
 use entity_api::{
     coaching_relationship, coaching_session, coaching_sessions, mutate, organization, query,
     query::IntoQueryFilterMap,
 };
 use log::*;
 use sea_orm::{DatabaseConnection, IntoActiveModel};
-use serde_json::json;
 use service::config::Config;
 
 pub use entity_api::coaching_session::{find_by_id, find_by_id_with_coaching_relationship};
+
+#[derive(Debug, Clone)]
+struct SessionDate(NaiveDateTime);
+
+impl SessionDate {
+    fn new(date: NaiveDateTime) -> Result<Self, Error> {
+        let truncated = date.duration_trunc(TimeDelta::minutes(1)).map_err(|err| {
+            warn!("Failed to truncate date_time: {:?}", err);
+            Error {
+                source: Some(Box::new(err)),
+                error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+            }
+        })?;
+        Ok(Self(truncated))
+    }
+
+    fn into_inner(self) -> NaiveDateTime {
+        self.0
+    }
+}
 
 pub async fn create(
     db: &DatabaseConnection,
@@ -23,68 +42,20 @@ pub async fn create(
         coaching_relationship::find_by_id(db, coaching_session_model.coaching_relationship_id)
             .await?;
     let organization = organization::find_by_id(db, coaching_relationship.organization_id).await?;
-    // Remove seconds because all coaching_sessions will be scheduled by the minute
-    // TODO: we might consider codifying this in the type system at some point.
-    let date_time = coaching_session_model
-        .date
-        .duration_trunc(TimeDelta::minutes(1))
-        .map_err(|err| {
-            warn!("Failed to truncate date_time: {:?}", err);
-            Error {
-                source: Some(Box::new(err)),
-                error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
-            }
-        })?;
-    coaching_session_model.date = date_time;
-    let document_name = format!(
-        "{}.{}.{}-v0",
-        organization.slug,
-        coaching_relationship.slug,
-        Id::new_v4()
-    );
+
+    coaching_session_model.date = SessionDate::new(coaching_session_model.date)?.into_inner();
+
+    let document_name = generate_document_name(&organization.slug, &coaching_relationship.slug);
     info!(
         "Attempting to create Tiptap document with name: {}",
         document_name
     );
     coaching_session_model.collab_document_name = Some(document_name.clone());
-    let tiptap_url = config.tiptap_url().ok_or_else(|| {
-        warn!("Failed to get Tiptap URL from config");
-        Error {
-            source: None,
-            error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
-        }
-    })?;
-    let full_url = format!("{}/api/documents/{}?format=json", tiptap_url, document_name);
-    let client = tiptap_client(config).await?;
 
-    let request = client
-        .post(full_url)
-        .json(&json!({"type": "doc", "content": []}));
-    let response = match request.send().await {
-        Ok(response) => {
-            info!("Tiptap response: {:?}", response);
-            response
-        }
-        Err(e) => {
-            warn!("Failed to send request: {:?}", e);
-            return Err(e.into());
-        }
-    };
+    let tiptap = TiptapDocument::new(config).await?;
+    tiptap.create(&document_name).await?;
 
-    // Tiptap's API will return a 200 for successful creation of a new document
-    // and will return a 409 if the document already exists. We consider both "successful".
-    if response.status().is_success() || response.status().as_u16() == 409 {
-        Ok(coaching_session::create(db, coaching_session_model).await?)
-    } else {
-        warn!(
-            "Failed to create Tiptap document: {}",
-            response.text().await?
-        );
-        Err(Error {
-            source: None,
-            error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
-        })
-    }
+    Ok(coaching_session::create(db, coaching_session_model).await?)
 }
 
 pub async fn find_by(
@@ -127,41 +98,18 @@ pub async fn delete(db: &DatabaseConnection, config: &Config, id: Id) -> Result<
         }
     })?;
 
-    let tiptap_url = config.tiptap_url().ok_or_else(|| {
-        warn!("Failed to get Tiptap URL from config");
-        Error {
-            source: None,
-            error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
-        }
-    })?;
-    let full_url = format!("{}/api/documents/{}?format=json", tiptap_url, document_name);
-    let client = tiptap_client(config).await?;
+    let tiptap = TiptapDocument::new(config).await?;
+    tiptap.delete(&document_name).await?;
 
-    let request = client.delete(full_url);
-    let response = match request.send().await {
-        Ok(response) => {
-            info!("Tiptap response: {:?}", response);
-            response
-        }
-        Err(e) => {
-            warn!("Failed to send request: {:?}", e);
-            return Err(e.into());
-        }
-    };
+    coaching_session::delete(db, id).await?;
+    Ok(())
+}
 
-    // Tiptap's API will return a 204 for successful deletion of a document
-    // and will return a 404 if the document does not exist.
-    let status = response.status();
-    if status.is_success() {
-        Ok(coaching_session::delete(db, id).await?)
-    } else {
-        warn!(
-            "Failed to delete Tiptap document: {}, with status: {}",
-            document_name, status
-        );
-        Err(Error {
-            source: None,
-            error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
-        })
-    }
+fn generate_document_name(organization_slug: &str, relationship_slug: &str) -> String {
+    format!(
+        "{}.{}.{}-v0",
+        organization_slug,
+        relationship_slug,
+        Id::new_v4()
+    )
 }

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -12,7 +12,7 @@ use sea_orm::{DatabaseConnection, IntoActiveModel};
 use serde_json::json;
 use service::config::Config;
 
-pub use entity_api::coaching_session::{find_by_id, find_by_id_with_coaching_relationship};
+pub use entity_api::coaching_session::{delete, find_by_id, find_by_id_with_coaching_relationship};
 
 pub async fn create(
     db: &DatabaseConnection,

--- a/domain/src/gateway/tiptap.rs
+++ b/domain/src/gateway/tiptap.rs
@@ -1,5 +1,6 @@
-use crate::error::{DomainErrorKind, Error, InternalErrorKind};
+use crate::error::{DomainErrorKind, Error, ExternalErrorKind, InternalErrorKind};
 use log::*;
+use serde_json::json;
 use service::config::Config;
 
 /// HTTP client for making requests to Tiptap. This client is configured with the necessary
@@ -32,4 +33,82 @@ async fn build_auth_headers(config: &Config) -> Result<reqwest::header::HeaderMa
     auth_value.set_sensitive(true);
     headers.insert(reqwest::header::AUTHORIZATION, auth_value);
     Ok(headers)
+}
+
+pub struct TiptapDocument {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl TiptapDocument {
+    pub async fn new(config: &Config) -> Result<Self, Error> {
+        let client = client(config).await?;
+        let base_url = config.tiptap_url().ok_or_else(|| {
+            warn!("Failed to get Tiptap URL from config");
+            Error {
+                source: None,
+                error_kind: DomainErrorKind::Internal(InternalErrorKind::Other),
+            }
+        })?;
+        Ok(Self { client, base_url })
+    }
+
+    pub async fn create(&self, document_name: &str) -> Result<(), Error> {
+        let url = format!(
+            "{}/api/documents/{}?format=json",
+            self.base_url, document_name
+        );
+        let response = self
+            .client
+            .post(url)
+            .json(&json!({"type": "doc", "content": []}))
+            .send()
+            .await
+            .map_err(|e| {
+                warn!("Failed to send request: {:?}", e);
+                Error {
+                    source: Some(Box::new(e)),
+                    error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
+                }
+            })?;
+
+        if response.status().is_success() || response.status().as_u16() == 409 {
+            Ok(())
+        } else {
+            let error_text = response.text().await.unwrap_or_default();
+            warn!("Failed to create Tiptap document: {}", error_text);
+            Err(Error {
+                source: None,
+                error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
+            })
+        }
+    }
+
+    pub async fn delete(&self, document_name: &str) -> Result<(), Error> {
+        let url = format!(
+            "{}/api/documents/{}?format=json",
+            self.base_url, document_name
+        );
+        let response = self.client.delete(url).send().await.map_err(|e| {
+            warn!("Failed to send request: {:?}", e);
+            Error {
+                source: Some(Box::new(e)),
+                error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
+            }
+        })?;
+
+        let status = response.status();
+        if status.is_success() || status.as_u16() == 404 {
+            Ok(())
+        } else {
+            warn!(
+                "Failed to delete Tiptap document: {}, with status: {}",
+                document_name, status
+            );
+            Err(Error {
+                source: None,
+                error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
+            })
+        }
+    }
 }

--- a/domain/src/gateway/tiptap.rs
+++ b/domain/src/gateway/tiptap.rs
@@ -54,10 +54,7 @@ impl TiptapDocument {
     }
 
     pub async fn create(&self, document_name: &str) -> Result<(), Error> {
-        let url = format!(
-            "{}/api/documents/{}?format=json",
-            self.base_url, document_name
-        );
+        let url = self.format_url(document_name);
         let response = self
             .client
             .post(url)
@@ -85,10 +82,7 @@ impl TiptapDocument {
     }
 
     pub async fn delete(&self, document_name: &str) -> Result<(), Error> {
-        let url = format!(
-            "{}/api/documents/{}?format=json",
-            self.base_url, document_name
-        );
+        let url = self.format_url(document_name);
         let response = self.client.delete(url).send().await.map_err(|e| {
             warn!("Failed to send request: {:?}", e);
             Error {
@@ -110,5 +104,12 @@ impl TiptapDocument {
                 error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
             })
         }
+    }
+
+    fn format_url(&self, document_name: &str) -> String {
+        format!(
+            "{}/api/documents/{}?format=json",
+            self.base_url, document_name
+        )
     }
 }

--- a/entity/src/jwts.rs
+++ b/entity/src/jwts.rs
@@ -7,8 +7,7 @@ use utoipa::ToSchema;
 /// This struct contains two fields:
 ///
 /// - `token`: A string representing the JWT.
-/// - `sub`: A string representing the subject of the JWT for conveniently accessing
-///    the subject without having to decode the JWT.
+/// - `sub`: A string representing the subject of the JWT for conveniently accessing the subject without having to decode the JWT.
 #[derive(Serialize, Debug, ToSchema)]
 #[schema(as = jwt::Jwt)] // OpenAPI schema
 pub struct Jwt {

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -123,3 +123,28 @@ pub async fn update(
     CoachingSessionApi::update(app_state.db_conn_ref(), coaching_session_id, params).await?;
     Ok(Json(ApiResponse::new(StatusCode::NO_CONTENT.into(), ())))
 }
+
+/// DELETE a Coaching Session
+#[utoipa::path(
+    delete,
+    path = "/coaching_sessions/{id}",
+    params(ApiVersion, ("id" = Id, Path, description = "Coaching Session ID to Delete")),
+    responses(
+        (status = 204, description = "Successfully deleted a Coaching Session", body = ()),
+        (status = 401, description = "Unauthorized"),
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+
+pub async fn delete(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    State(app_state): State<AppState>,
+    Path(coaching_session_id): Path<Id>,
+) -> Result<impl IntoResponse, Error> {
+    CoachingSessionApi::delete(app_state.db_conn_ref(), coaching_session_id).await?;
+
+    Ok(Json(ApiResponse::new(StatusCode::NO_CONTENT.into(), ())))
+}

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -137,14 +137,18 @@ pub async fn update(
         ("cookie_auth" = [])
     )
 )]
-
 pub async fn delete(
     CompareApiVersion(_v): CompareApiVersion,
     AuthenticatedUser(_user): AuthenticatedUser,
     State(app_state): State<AppState>,
     Path(coaching_session_id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    CoachingSessionApi::delete(app_state.db_conn_ref(), coaching_session_id).await?;
+    CoachingSessionApi::delete(
+        app_state.db_conn_ref(),
+        &app_state.config,
+        coaching_session_id,
+    )
+    .await?;
 
     Ok(Json(ApiResponse::new(StatusCode::NO_CONTENT.into(), ())))
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -44,6 +44,7 @@ use self::organization::coaching_relationship_controller;
             coaching_session_controller::index,
             coaching_session_controller::create,
             coaching_session_controller::update,
+            coaching_session_controller::delete,
             note_controller::create,
             note_controller::update,
             note_controller::index,
@@ -195,6 +196,18 @@ pub fn coaching_sessions_routes(app_state: AppState) -> Router {
                 .route_layer(from_fn_with_state(
                     app_state.clone(),
                     protect::coaching_sessions::update,
+                )),
+        )
+        .merge(
+            // DELETE /coaching_sessions
+            Router::new()
+                .route(
+                    "/coaching_sessions/:id",
+                    delete(coaching_session_controller::delete),
+                )
+                .route_layer(from_fn_with_state(
+                    app_state.clone(),
+                    protect::coaching_sessions::delete,
                 )),
         )
         .route_layer(login_required!(Backend, login_url = "/login"))


### PR DESCRIPTION
## Description

Adds endpoint for deleting existing coaching sessions.

The following applies:
- Only users that are coaches for the coaching session are authorized to delete it
- We attempt to delete the associated Tiptap document. If that fails we do not delete the coaching session


### Changes
* Adds `DELETE /coaching_sessions/{coaching_session_id}
* Refactors `domain::coaching_sessions`


### Testing Strategy
 Tested locally against https://github.com/refactor-group/refactor-platform-fe/pull/100
