### PR TITLE
Refactor the backend API to match what the frontend already correctly does for logout

### DIFF
--- a/web/src/controller/user_session_controller.rs
+++ b/web/src/controller/user_session_controller.rs
@@ -81,10 +81,10 @@ pub async fn login(
 /// Logs the user out of the platform by destroying their session.
 /// Test this with curl: curl -v \
 /// --header "Cookie: id=07bbbe54-bd35-425f-8e63-618a8d8612df" \
-/// --request GET http://localhost:4000/logout
+/// --request DELETE http://localhost:4000/user_sessions/:id
 #[utoipa::path(
 get,
-path = "/logout",
+path = "/delete",
 responses(
     (status = 200, description = "Successfully logged out"),
     (status = 401, description = "Unauthorized"),
@@ -94,8 +94,8 @@ security(
     ("cookie_auth" = [])
 )
 )]
-pub async fn logout(mut auth_session: AuthSession) -> impl IntoResponse {
-    debug!("UserSessionController::logout()");
+pub async fn delete(mut auth_session: AuthSession) -> impl IntoResponse {
+    trace!("UserSessionController::delete()");
     match auth_session.logout().await {
         Ok(_) => StatusCode::OK.into_response(),
         Err(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -66,7 +66,7 @@ use self::organization::coaching_relationship_controller;
             overarching_goal_controller::update_status,
             user_controller::update,
             user_session_controller::login,
-            user_session_controller::logout,
+            user_session_controller::delete,
             jwt_controller::generate_collab_token,
         ),
         components(
@@ -345,7 +345,7 @@ pub fn user_routes(app_state: AppState) -> Router {
 pub fn user_session_protected_routes() -> Router {
     Router::new()
         .route("/protected", get(user_session_controller::protected))
-        .route("/logout", delete(user_session_controller::logout))
+        .route("/user_sessions/:id", delete(user_session_controller::delete))
         .route_layer(login_required!(Backend, login_url = "/login"))
 }
 

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -345,7 +345,10 @@ pub fn user_routes(app_state: AppState) -> Router {
 pub fn user_session_protected_routes() -> Router {
     Router::new()
         .route("/protected", get(user_session_controller::protected))
-        .route("/user_sessions/:id", delete(user_session_controller::delete))
+        .route(
+            "/user_sessions/:id",
+            delete(user_session_controller::delete),
+        )
         .route_layer(login_required!(Backend, login_url = "/login"))
 }
 


### PR DESCRIPTION
## Description
This PR refactors the backend endpoint for logout and changes it to be deletion of a user_session with an id.


#### GitHub Issue: None

### Changes
* Refactors the backend API to match what the frontend already correctly expects for logout --> delete /user_sessions/:id

### Testing Strategy
1. Use this [frontend PR](https://github.com/refactor-group/refactor-platform-fe/pull/102) to test by logging in and then logging out with the UI


### Concerns
None
