### PR TITLE
Update to latest version of openssl and openssl-sys to patch moderate…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,9 +1908,9 @@ checksum = "c2806eaa3524762875e21c3dcd057bc4b7bfa01ce4da8d46be1cd43649e1cc6b"
 
 [[package]]
 name = "openssl"
-version = "0.10.71"
+version = "0.10.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e14130c6a98cd258fdcb0fb6d744152343ff729cbfcb28c656a9d12b999fbcd"
+checksum = "fedfea7d58a1f73118430a55da6a286e7b044961736ce96a16a17068ea25e5da"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1949,9 +1949,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.106"
+version = "0.9.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bb61ea9811cc39e3c2069f40b8b8e2e70d8569b361f879786cc7ed48b777cdd"
+checksum = "8288979acd84749c744a9014b4382d42b8f7b2592847b5afb2ed29e5d16ede07"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ clap = { version = "4.5.20", features = ["cargo", "derive", "env"] }
 log = "0.4.22"
 simplelog = { version = "0.12.2", features = ["paris"] }
 tokio = "1.41.0"
-openssl-sys = { version = "0.9.106", features = ["vendored"] }
+openssl-sys = { version = "0.9.107", features = ["vendored"] }
 
 [[bin]]
 name = "seed_db"


### PR DESCRIPTION
## Description
Updates openssl and openssl-sys to latest version that patches a moderate security hole that was recently found. Summarized here in this [Dependabot alert](https://github.com/refactor-group/refactor-platform-rs/security/dependabot/25).


#### GitHub Issue: N/A

### Changes
* Update version of openssl and openssl-sys packages to latest stable versions

### Testing Strategy
Ensure the backend still starts up without errors.


### Concerns
None
