### PR TITLE
Moves setup.sql into a SeaORM migration

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,6 @@ services:
       - "${POSTGRES_PORT}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-      - ./migration/src/setup.sql:/docker-entrypoint-initdb.d/0-setup.sql
     networks:
       - backend_network
     healthcheck:

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -1,5 +1,6 @@
 pub use sea_orm_migration::prelude::*;
 
+mod m20240210_153056_create_schema_and_base_db_setup;
 mod m20240211_174355_base_migration;
 mod m20250509_164646_add_initial_non_prod_user;
 
@@ -9,6 +10,7 @@ pub struct Migrator;
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
         vec![
+            Box::new(m20240210_153056_create_schema_and_base_db_setup::Migration),
             Box::new(m20240211_174355_base_migration::Migration),
             Box::new(m20250509_164646_add_initial_non_prod_user::Migration),
         ]

--- a/migration/src/m20240210_153056_create_schema_and_base_db_setup.rs
+++ b/migration/src/m20240210_153056_create_schema_and_base_db_setup.rs
@@ -1,0 +1,80 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Create the platform's schema
+        manager
+            .get_connection()
+            .execute_unprepared("CREATE SCHEMA IF NOT EXISTS refactor_platform;")
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("SET search_path TO refactor_platform, public;")
+            .await?;
+
+        // Add the Postgresql extensions that we use
+        manager
+            .get_connection()
+            .execute_unprepared("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";")
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("CREATE EXTENSION IF NOT EXISTS \"pgcrypto\";")
+            .await?;
+
+        // Create the base DB user that will execute all platform queries
+        manager
+            .get_connection()
+            .execute_unprepared(r#"
+                DO $$ BEGIN
+                    GRANT ALL PRIVILEGES ON DATABASE refactor TO refactor;
+                    GRANT ALL ON SCHEMA refactor_platform TO refactor;
+
+                    ALTER DEFAULT PRIVILEGES IN SCHEMA refactor_platform GRANT ALL ON TABLES TO refactor;
+                    ALTER DEFAULT PRIVILEGES IN SCHEMA refactor_platform GRANT ALL ON SEQUENCES TO refactor;
+                    ALTER DEFAULT PRIVILEGES IN SCHEMA refactor_platform GRANT ALL ON FUNCTIONS TO refactor;
+                END $$;
+            "#)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Revoke default privileges first
+        manager
+            .get_connection()
+            .execute_unprepared(r#"
+                DO $$ BEGIN
+                    ALTER DEFAULT PRIVILEGES IN SCHEMA refactor_platform REVOKE ALL ON FUNCTIONS FROM refactor;
+                    ALTER DEFAULT PRIVILEGES IN SCHEMA refactor_platform REVOKE ALL ON SEQUENCES FROM refactor;
+                    ALTER DEFAULT PRIVILEGES IN SCHEMA refactor_platform REVOKE ALL ON TABLES FROM refactor;
+                    REVOKE ALL ON SCHEMA refactor_platform FROM refactor;
+                    REVOKE ALL PRIVILEGES ON DATABASE refactor FROM refactor;
+                END $$;
+            "#)
+            .await?;
+
+        // Drop the schema (CASCADE will remove all objects in it)
+        manager
+            .get_connection()
+            .execute_unprepared("DROP SCHEMA IF EXISTS refactor_platform CASCADE;")
+            .await?;
+
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Post {
+    Table,
+    Id,
+    Title,
+    Text,
+}

--- a/migration/src/m20240210_153056_create_schema_and_base_db_setup.rs
+++ b/migration/src/m20240210_153056_create_schema_and_base_db_setup.rs
@@ -17,17 +17,6 @@ impl MigrationTrait for Migration {
             .execute_unprepared("SET search_path TO refactor_platform, public;")
             .await?;
 
-        // Add the Postgresql extensions that we use
-        manager
-            .get_connection()
-            .execute_unprepared("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\";")
-            .await?;
-
-        manager
-            .get_connection()
-            .execute_unprepared("CREATE EXTENSION IF NOT EXISTS \"pgcrypto\";")
-            .await?;
-
         // Create the base DB user that will execute all platform queries
         manager
             .get_connection()


### PR DESCRIPTION
## Description
This PR moves setup.sql into a SeaORM migration so that the refactor_platform schema is setup consistently across development, staging and production environments.


#### GitHub Issue: None

### Changes
* Moves setup.sql into m20240210_153056_create_schema_and_base_db_setup.rs as a SeaORM migration

### Testing Strategy
1. Build the container images with `docker compose --verbose --env-file .env.local up`


### Concerns
Needs production testing still on our DO Droplet.
