### PR TITLE
Update DEFAULT_API_VERSION to 1.0.0-beta1

### DIFF
--- a/docs/runbooks/Container-README.md
+++ b/docs/runbooks/Container-README.md
@@ -40,7 +40,7 @@ BACKEND_INTERFACE=0.0.0.0                    # Interface for the Rust back-end
 BACKEND_SERVICE_PROTOCOL=http                # Protocol (usually http)
 BACKEND_SERVICE_PORT=4000                    # Derived service port
 BACKEND_SERVICE_HOST=localhost               # Hostname used by the service
-BACKEND_API_VERSION=0.0.1                    # API version
+BACKEND_API_VERSION=1.0.0-beta1              # API version to use between frontend and backend
 RUST_ENV=development                         # development, staging, production
 
 # ==============================

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -8,12 +8,12 @@ use std::fmt;
 use std::str::FromStr;
 use utoipa::IntoParams;
 
-type APiVersionList = [&'static str; 2];
+type APiVersionList = [&'static str; 1];
 
 const DEFAULT_API_VERSION: &str = "1.0.0-beta1";
 // Expand this array to include all valid API versions. Versions that have been
 // completely removed should be removed from this list - they're no longer valid.
-const API_VERSIONS: APiVersionList = ["0.0.1", DEFAULT_API_VERSION];
+const API_VERSIONS: APiVersionList = [DEFAULT_API_VERSION];
 
 static X_VERSION: &str = "x-version";
 

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -8,12 +8,12 @@ use std::fmt;
 use std::str::FromStr;
 use utoipa::IntoParams;
 
-type APiVersionList = [&'static str; 1];
+type APiVersionList = [&'static str; 2];
 
-const DEFAULT_API_VERSION: &str = "0.0.1";
+const DEFAULT_API_VERSION: &str = "1.0.0-beta1";
 // Expand this array to include all valid API versions. Versions that have been
 // completely removed should be removed from this list - they're no longer valid.
-const API_VERSIONS: APiVersionList = [DEFAULT_API_VERSION];
+const API_VERSIONS: APiVersionList = ["0.0.1", DEFAULT_API_VERSION];
 
 static X_VERSION: &str = "x-version";
 
@@ -21,7 +21,7 @@ static X_VERSION: &str = "x-version";
 #[into_params(parameter_in = Header)]
 pub struct ApiVersion {
     /// The version of the API to use for a request.
-    #[param(rename = "x-version", style = Simple, required, example = "0.0.1")]
+    #[param(rename = "x-version", style = Simple, required, example = "1.0.0-beta1")]
     pub version: Version,
 }
 


### PR DESCRIPTION
## Description
This PR updates the list of valid API versions to just be 1.0.0-beta1, replacing 0.0.1.


#### GitHub Issue: None

### Changes
* Replaces API version 0.0.1 with 1.0.0-beta1

### Testing Strategy
Update the BACKEND_API_VERSION environment variable and make sure the frontend still fully functions as normal.


### Concerns
None
