### PR TITLE
adds user id assignment to 1001 in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ FROM --platform=${BUILDPLATFORM} debian:bullseye-slim
 # Install Bash to support entrypoint.sh
 RUN apt-get update && apt-get install -y bash && rm -rf /var/lib/apt/lists/*
 
-# Create non-root user
-RUN useradd -m -s /bin/bash appuser
+# Create non-root user with 1001 UID and /bin/bash shell
+RUN useradd -m -u 1001 -s /bin/bash appuser
 WORKDIR /app
 
 # Copy the necessary release binaries


### PR DESCRIPTION
This pull request updates the `Dockerfile` to enhance user creation by specifying a fixed UID for the non-root user, ensuring consistency across environments.

#### GitHub Issue: [Fixes] #151 

### Changes
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L33-R34): Modified the `useradd` command to create the `appuser` with a fixed UID of `1001` and `/bin/bash` shell for better compatibility and consistency.

#### Testing Strategy
* deploying the new image to the production DO Droplet and testing if the user has permission to read the root certificate.
