### PR TITLE
Make sure that failed login attempts are returned as 401 Unauthorized

### DIFF
--- a/domain/src/error.rs
+++ b/domain/src/error.rs
@@ -40,6 +40,7 @@ pub enum InternalErrorKind {
 pub enum EntityErrorKind {
     NotFound,
     Invalid,
+    Unauthenticated,
     DbTransaction,
     Other(String),
 }
@@ -71,6 +72,7 @@ impl From<EntityApiError> for Error {
         let entity_error_kind = match err.error_kind {
             EntityApiErrorKind::RecordNotFound => EntityErrorKind::NotFound,
             EntityApiErrorKind::InvalidQueryTerm => EntityErrorKind::Invalid,
+            EntityApiErrorKind::RecordUnauthenticated => EntityErrorKind::Unauthenticated,
             _ => EntityErrorKind::Other("EntityErrorKind".to_string()),
         };
 

--- a/web/src/controller/user_session_controller.rs
+++ b/web/src/controller/user_session_controller.rs
@@ -48,11 +48,11 @@ pub async fn login(
                 source: None,
                 error_kind: domain::error::DomainErrorKind::Internal(
                     domain::error::InternalErrorKind::Entity(
-                        domain::error::EntityErrorKind::Unauthenticated
-                    )
+                        domain::error::EntityErrorKind::Unauthenticated,
+                    ),
                 ),
             }));
-        },
+        }
         Err(auth_error) => {
             // axum_login errors contain our entity_api::Error in the error field
             warn!("Authentication failed: {:?}", auth_error);
@@ -60,11 +60,11 @@ pub async fn login(
                 source: Some(Box::new(auth_error)),
                 error_kind: domain::error::DomainErrorKind::Internal(
                     domain::error::InternalErrorKind::Entity(
-                        domain::error::EntityErrorKind::Unauthenticated
-                    )
+                        domain::error::EntityErrorKind::Unauthenticated,
+                    ),
                 ),
             }));
-        },
+        }
     };
 
     if let Err(login_error) = auth_session.login(&user).await {
@@ -72,7 +72,7 @@ pub async fn login(
         return Err(WebError::from(domain::error::Error {
             source: Some(Box::new(login_error)),
             error_kind: domain::error::DomainErrorKind::Internal(
-                domain::error::InternalErrorKind::Other("Session login failed".to_string())
+                domain::error::InternalErrorKind::Other("Session login failed".to_string()),
             ),
         }));
     }

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -88,6 +88,13 @@ impl Error {
                 );
                 (StatusCode::NOT_FOUND, "NOT FOUND").into_response()
             }
+            EntityErrorKind::Unauthenticated => {
+                warn!(
+                    "EntityErrorKind::Unauthenticated: Responding with 401 Unauthorized. Error: {:?}",
+                    self
+                );
+                (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response()
+            }
             EntityErrorKind::DbTransaction => {
                 warn!(
                     "EntityErrorKind::DbTransaction: Responding with 500 Internal Server Error. Error: {:?}",


### PR DESCRIPTION
## Description
This PR ensures that failed login attempts are returned as HTTP statuscode UNAUTHORIZED (401), not a 500 internal server error.


#### GitHub Issue: Relates to the frontend bug #122

### Changes
* Makes the `EntityErrorKind::Unauthenticated` actually pass through the domain layer

### Testing Strategy
1. Try logging in from the frontend with invalid credentials (try both a valid email/invalid password, and an invalid email/password set combination)
2. Observe in the backend logging that you see `[WARN] EntityErrorKind::Unauthenticated: Responding with 401 Unauthorized. Error: Domain(Error { source: Some(Error { source: None, error_kind: RecordUnauthenticated }), error_kind: Internal(Entity(Unauthenticated)) })`
3. If you're using the paired frontend branch, you should see it display the error `Invalid email or password. Please try again.`


### Concerns
None
