### PR TITLE
Remove public from the DB search_path and revoke all CREATE privilege…

### DIFF
--- a/migration/src/m20240210_153056_create_schema_and_base_db_setup.rs
+++ b/migration/src/m20240210_153056_create_schema_and_base_db_setup.rs
@@ -14,7 +14,7 @@ impl MigrationTrait for Migration {
 
         manager
             .get_connection()
-            .execute_unprepared("SET search_path TO refactor_platform, public;")
+            .execute_unprepared("SET search_path TO refactor_platform;")
             .await?;
 
         // Create the base DB user that will execute all platform queries
@@ -30,6 +30,12 @@ impl MigrationTrait for Migration {
                     ALTER DEFAULT PRIVILEGES IN SCHEMA refactor_platform GRANT ALL ON FUNCTIONS TO refactor;
                 END $$;
             "#)
+            .await?;
+
+        // Revoke all public CREATE privileges to the public schema, which plugs a significant security concern
+        manager
+            .get_connection()
+            .execute_unprepared("REVOKE CREATE ON SCHEMA public FROM PUBLIC;")
             .await?;
 
         Ok(())


### PR DESCRIPTION
## Description
This PR removes the `public` schema from the DB `search_path` and revokes all `CREATE` privileges on the `public` schema.


#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

### Changes
* Remove `public` schema from the DB `search_path` and revoke all `CREATE` privileges on the `public` schema

### Testing Strategy
1. Re-run all migrations from scratch making sure they all apply cleanly
2. Also test re-running removing all migrations (i.e. `down`) to ensure they all un-apply cleanly


### Concerns
None
