### PR TITLE
Bump version to 1.0.0-beta2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -829,7 +829,7 @@ dependencies = [
 
 [[package]]
 name = "domain"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "chrono",
  "entity_api",
@@ -868,7 +868,7 @@ dependencies = [
 
 [[package]]
 name = "entity"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "axum-login",
  "chrono",
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "entity_api"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "async-trait",
  "axum-login",
@@ -1746,7 +1746,7 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "migration"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "async-std",
  "chrono",
@@ -2438,7 +2438,7 @@ dependencies = [
 
 [[package]]
 name = "refactor_platform_rs"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "clap",
  "entity_api",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "service"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "clap",
  "dotenvy",
@@ -4135,7 +4135,7 @@ dependencies = [
 
 [[package]]
 name = "web"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "refactor_platform_rs"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 edition = "2021"
 
 default-run = "refactor_platform_rs"

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "domain"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 edition = "2021"
 
 [dependencies]

--- a/entity/Cargo.toml
+++ b/entity/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 edition = "2021"
 
 [lib]

--- a/entity_api/Cargo.toml
+++ b/entity_api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "entity_api"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 edition = "2021"
 
 [dependencies]

--- a/migration/Cargo.toml
+++ b/migration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "migration"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 edition = "2021"
 publish = false
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "service"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "web"
-version = "1.0.0-beta1"
+version = "1.0.0-beta2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
## Description
This PR bumps the backend application version to 1.0.0-beta2.


#### GitHub Issue: None

### Changes
* Bump version to 1.0.0-beta2

### Screenshots / Videos Showing UI Changes (if applicable)


### Testing Strategy
N/A


### Concerns
N/A