### PR TITLE
Add get coaching session by id

### DIFF
--- a/docs/release-notes/RELEASE_NOTES_1.0.0-beta1.md
+++ b/docs/release-notes/RELEASE_NOTES_1.0.0-beta1.md
@@ -1,0 +1,185 @@
+# 🚀 Refactor Platform v1.0.0-beta1
+
+**First Public Beta Release**
+
+We're excited to announce the first public beta release of the Refactor Coaching & Mentorship Platform! This Rust-based backend provides a comprehensive web API for coaching and mentoring software engineers, designed for professional coaches, informal mentors, and engineering leaders.
+
+## 🎯 What's New
+
+### 🏗️ **Core Platform Architecture**
+
+- **Layered Architecture**: Clean separation between web, domain, entity API, and data layers
+- **Domain-Driven Design**: Business logic centralized in the domain layer with clear entity relationships
+- **Repository Pattern**: Abstracted database operations through the entity API layer
+- **RESTful API**: Comprehensive HTTP API with OpenAPI documentation
+
+### 👥 **User Management & Authentication**
+
+- **Session-based Authentication**: Secure cookie-based user sessions with `axum-login`
+- **Role-based Access Control**: Admin and user roles with granular permissions
+- **User Profiles**: Complete user management with profile updates and password changes
+- **Organization Membership**: Users can belong to multiple organizations
+
+### 🏢 **Organization Management**
+
+- **Multi-tenant Architecture**: Support for multiple coaching organizations
+- **Organization Administration**: Create, update, and manage coaching organizations
+- **User Assignment**: Add and remove users from organizations
+- **Hierarchical Permissions**: Organization-scoped access controls
+
+### 🤝 **Coaching Relationship Management**
+
+- **Coach-Coachee Relationships**: Formal relationship tracking between coaches and coachees
+- **Relationship Lifecycle**: Create, manage, and archive coaching relationships
+- **Cross-organizational Support**: Relationships can span multiple organizations
+
+### 📝 **Coaching Session Management**
+
+- **Session Tracking**: Schedule and document coaching sessions
+- **Session Notes**: Rich text note-taking with TipTap integration for collaborative editing
+- **Session History**: Complete timeline of coaching interactions
+
+### 🎯 **Goal & Action Management**
+
+- **Overarching Goals**: Long-term objectives for coaching relationships
+- **Action Items**: Specific, trackable commitments and next steps
+- **Status Tracking**: Monitor progress with customizable status workflows (Not Started, In Progress, Completed, Won't Do)
+- **Due Date Management**: Time-bound action items with deadline tracking
+
+### 📋 **Agreements & Documentation**
+
+- **Coaching Agreements**: Formal agreements and contracts management
+- **Document Lifecycle**: Create, update, and manage coaching documentation
+- **Structured Data**: Consistent data models across all coaching artifacts
+
+### 🔗 **External Integrations**
+
+- **TipTap Cloud**: Real-time collaborative document editing
+- **JWT Token Generation**: Secure token-based authentication for external services
+- **API Versioning**: Built-in support for API evolution and backward compatibility
+
+## 🛠️ **Technical Highlights**
+
+### 🦀 **Modern Rust Stack**
+
+- **Axum Web Framework**: High-performance async web server
+- **SeaORM**: Type-safe database operations with PostgreSQL
+- **Tokio Runtime**: Efficient async/await concurrency
+- **UUID-based IDs**: Globally unique identifiers for all entities
+
+### 📊 **Database & Migrations**
+
+- **PostgreSQL Backend**: Robust relational database with full ACID compliance
+- **Schema Migrations**: Versioned database schema with rollback support
+- **Connection Pooling**: Efficient database connection management
+- **SSL Support**: Secure database connections for production environments
+
+### 🚀 **Production-Ready Deployment**
+
+- **Docker Containerization**: Multi-stage builds for optimized container images
+- **Docker Compose**: Complete local development and production deployment setup
+- **Health Checks**: Built-in health monitoring and service dependencies
+- **Environment Configuration**: Comprehensive environment variable management
+
+### 🔒 **Security Features**
+
+- **HTTPS/TLS**: Secure communication with SSL certificate management
+- **CORS Configuration**: Configurable cross-origin resource sharing
+- **Input Validation**: Comprehensive request validation and sanitization
+- **Error Handling**: Structured error responses with proper HTTP status codes
+
+### 📚 **API Documentation**
+
+- **OpenAPI/Swagger**: Auto-generated API documentation with RapiDoc
+- **Type Safety**: Full TypeScript-compatible API schemas
+- **Interactive Documentation**: Built-in API explorer and testing interface
+
+### 🔧 **Development Experience**
+
+- **Hot Reload**: Fast development iteration with cargo watch
+- **Database Seeding**: Test data generation for development
+- **Comprehensive Logging**: Structured logging with configurable levels
+- **Debug Tools**: Built-in debugging and diagnostic endpoints
+
+## 🚀 **Deployment & Infrastructure**
+
+### ☁️ **Cloud-Ready Architecture**
+
+- **DigitalOcean Integration**: Automated deployment to DigitalOcean infrastructure
+- **Tailscale Networking**: Secure private networking for deployments
+- **GitHub Actions**: Automated CI/CD with comprehensive testing
+- **Multi-Environment Support**: Separate staging and production environments
+
+### 🐳 **Container Orchestration**
+
+- **Multi-Service Setup**: Coordinated deployment of backend, frontend, and database
+- **Nginx Reverse Proxy**: Load balancing and SSL termination
+- **Database Migrations**: Automated schema migrations on deployment
+- **Environment Variables**: Comprehensive configuration management
+
+## 📖 **Documentation**
+
+This release includes comprehensive documentation:
+
+- **Architecture Diagrams**: Visual system overview and component relationships
+- **API Documentation**: Complete endpoint reference with examples
+- **Deployment Guides**: Step-by-step deployment instructions
+- **Development Setup**: Local development environment configuration
+- **Database Schema**: Entity-relationship diagrams and migration guides
+
+## 🧪 **What's Beta About This Release**
+
+This beta release is feature-complete for core coaching workflows but may have:
+
+- Minor API changes before v1.0.0 stable
+- Additional configuration options and fine-tuning
+- Performance optimizations based on real-world usage
+- Extended test coverage and edge case handling
+
+## 🔮 **What's Next**
+
+Looking ahead to v1.0.0 stable:
+
+- **Enhanced Reporting**: Analytics and progress tracking dashboards
+- **Notification System**: Email and in-app notifications for important events
+- **Advanced Permissions**: Fine-grained access controls and custom roles
+- **API Rate Limiting**: Production-scale request throttling
+- **Audit Logging**: Comprehensive activity tracking for compliance
+
+## 🚀 **Getting Started**
+
+### Prerequisites
+
+- Docker & Docker Compose
+- PostgreSQL (local or remote)
+- Rust 1.70+ (for local development)
+
+### Quick Start
+
+```bash
+git clone https://github.com/refactor-group/refactor-platform-rs.git
+cd refactor-platform-rs
+docker-compose --env-file .env.local up --build
+```
+
+Visit `http://localhost:4000/rapidoc` for interactive API documentation.
+
+### Configuration
+
+All configuration is managed through environment variables. See our [Environment Variables Guide](docs/runbooks/adding_new_environment_variables_backend.md) for complete configuration options.
+
+## 🤝 **Contributing**
+
+We welcome contributions! Please see our contributing guidelines and check out our [good first issues](https://github.com/refactor-group/refactor-platform-rs/labels/good%20first%20issue).
+
+## 📞 **Support**
+
+- **Documentation**: [docs/](docs/)
+- **Issues**: [GitHub Issues](https://github.com/refactor-group/refactor-platform-rs/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/refactor-group/refactor-platform-rs/discussions)
+
+---
+
+**Full Changelog**: https://github.com/refactor-group/refactor-platform-rs/commits/1.0.0-beta1
+
+_This beta release represents months of development creating a robust, scalable platform for coaching and mentoring software engineers. We're excited to get feedback from the community as we work toward our stable 1.0.0 release!_

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -19,7 +19,7 @@ struct SessionDate(NaiveDateTime);
 impl SessionDate {
     fn new(date: NaiveDateTime) -> Result<Self, Error> {
         let truncated = date.duration_trunc(TimeDelta::minutes(1)).map_err(|err| {
-            warn!("Failed to truncate date_time: {:?}", err);
+            warn!("Failed to truncate date_time: {err:?}");
             Error {
                 source: Some(Box::new(err)),
                 error_kind: DomainErrorKind::Internal(InternalErrorKind::Other(
@@ -48,10 +48,7 @@ pub async fn create(
     coaching_session_model.date = SessionDate::new(coaching_session_model.date)?.into_inner();
 
     let document_name = generate_document_name(&organization.slug, &coaching_relationship.slug);
-    info!(
-        "Attempting to create Tiptap document with name: {}",
-        document_name
-    );
+    info!("Attempting to create Tiptap document with name: {document_name}");
     coaching_session_model.collab_document_name = Some(document_name.clone());
 
     let tiptap = TiptapDocument::new(config).await?;

--- a/domain/src/error.rs
+++ b/domain/src/error.rs
@@ -54,7 +54,7 @@ pub enum ExternalErrorKind {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Domain Error: {:?}", self)
+        write!(f, "Domain Error: {self:?}")
     }
 }
 

--- a/domain/src/gateway/tiptap.rs
+++ b/domain/src/gateway/tiptap.rs
@@ -24,7 +24,7 @@ async fn build_auth_headers(config: &Config) -> Result<reqwest::header::HeaderMa
     })?;
     let mut headers = reqwest::header::HeaderMap::new();
     let mut auth_value = reqwest::header::HeaderValue::from_str(&auth_key).map_err(|err| {
-        warn!("Failed to create auth header value: {:?}", err);
+        warn!("Failed to create auth header value: {err:?}");
         Error {
             source: Some(Box::new(err)),
             error_kind: DomainErrorKind::Internal(InternalErrorKind::Other(
@@ -64,7 +64,7 @@ impl TiptapDocument {
             .send()
             .await
             .map_err(|e| {
-                warn!("Failed to send request: {:?}", e);
+                warn!("Failed to send request: {e:?}");
                 Error {
                     source: Some(Box::new(e)),
                     error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
@@ -75,7 +75,7 @@ impl TiptapDocument {
             Ok(())
         } else {
             let error_text = response.text().await.unwrap_or_default();
-            warn!("Failed to create Tiptap document: {}", error_text);
+            warn!("Failed to create Tiptap document: {error_text}");
             Err(Error {
                 source: None,
                 error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
@@ -86,7 +86,7 @@ impl TiptapDocument {
     pub async fn delete(&self, document_name: &str) -> Result<(), Error> {
         let url = self.format_url(document_name);
         let response = self.client.delete(url).send().await.map_err(|e| {
-            warn!("Failed to send request: {:?}", e);
+            warn!("Failed to send request: {e:?}");
             Error {
                 source: Some(Box::new(e)),
                 error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
@@ -97,10 +97,7 @@ impl TiptapDocument {
         if status.is_success() || status.as_u16() == 404 {
             Ok(())
         } else {
-            warn!(
-                "Failed to delete Tiptap document: {}, with status: {}",
-                document_name, status
-            );
+            warn!("Failed to delete Tiptap document: {document_name}, with status: {status}");
             Err(Error {
                 source: None,
                 error_kind: DomainErrorKind::External(ExternalErrorKind::Network),

--- a/domain/src/jwt/mod.rs
+++ b/domain/src/jwt/mod.rs
@@ -48,8 +48,7 @@ pub async fn generate_collab_token(
 
     let collab_document_name = coaching_session.collab_document_name.ok_or_else(|| {
         warn!(
-            "Failed to get collab document name from coaching session with ID: {}",
-            coaching_session_id
+            "Failed to get collab document name from coaching session with ID: {coaching_session_id}"
         );
         Error {
             source: None,

--- a/entity_api/src/action.rs
+++ b/entity_api/src/action.rs
@@ -14,7 +14,7 @@ pub async fn create(
     action_model: Model,
     user_id: Id,
 ) -> Result<Model, Error> {
-    debug!("New Action Model to be inserted: {:?}", action_model);
+    debug!("New Action Model to be inserted: {action_model:?}");
 
     let now = chrono::Utc::now();
 
@@ -38,7 +38,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 
     match result {
         Some(action) => {
-            debug!("Existing Action model to be Updated: {:?}", action);
+            debug!("Existing Action model to be Updated: {action:?}");
 
             let active_model: ActiveModel = ActiveModel {
                 id: Unchanged(action.id),
@@ -55,7 +55,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             Ok(active_model.update(db).await?.try_into_model()?)
         }
         None => {
-            error!("Action with id {} not found", id);
+            error!("Action with id {id} not found");
 
             Err(Error {
                 source: None,
@@ -74,7 +74,7 @@ pub async fn update_status(
 
     match result {
         Some(action) => {
-            debug!("Existing Action model to be Updated: {:?}", action);
+            debug!("Existing Action model to be Updated: {action:?}");
 
             let active_model: ActiveModel = ActiveModel {
                 id: Unchanged(action.id),
@@ -91,7 +91,7 @@ pub async fn update_status(
             Ok(active_model.update(db).await?.try_into_model()?)
         }
         None => {
-            error!("Action with id {} not found", id);
+            error!("Action with id {id} not found");
 
             Err(Error {
                 source: None,

--- a/entity_api/src/agreement.rs
+++ b/entity_api/src/agreement.rs
@@ -14,7 +14,7 @@ pub async fn create(
     agreement_model: Model,
     user_id: Id,
 ) -> Result<Model, Error> {
-    debug!("New Agreement Model to be inserted: {:?}", agreement_model);
+    debug!("New Agreement Model to be inserted: {agreement_model:?}");
 
     let now = chrono::Utc::now();
 
@@ -35,7 +35,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 
     match result {
         Some(agreement) => {
-            debug!("Existing Agreement model to be Updated: {:?}", agreement);
+            debug!("Existing Agreement model to be Updated: {agreement:?}");
 
             let active_model: ActiveModel = ActiveModel {
                 id: Unchanged(agreement.id),
@@ -49,7 +49,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             Ok(active_model.update(db).await?.try_into_model()?)
         }
         None => {
-            debug!("Agreement with id {} not found", id);
+            debug!("Agreement with id {id} not found");
 
             Err(Error {
                 source: None,

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -22,10 +22,7 @@ pub async fn create(
     organization_id: Id,
     coaching_relationship_model: Model,
 ) -> Result<CoachingRelationshipWithUserNames, Error> {
-    debug!(
-        "New Coaching Relationship Model to be inserted: {:?}",
-        coaching_relationship_model
-    );
+    debug!("New Coaching Relationship Model to be inserted: {coaching_relationship_model:?}");
 
     let coach = user::find_by_id(db, coaching_relationship_model.coach_id).await?;
     let coachee = user::find_by_id(db, coaching_relationship_model.coachee_id).await?;

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -11,10 +11,7 @@ pub async fn create(
     db: &DatabaseConnection,
     coaching_session_model: Model,
 ) -> Result<Model, Error> {
-    debug!(
-        "New Coaching Session Model to be inserted: {:?}",
-        coaching_session_model
-    );
+    debug!("New Coaching Session Model to be inserted: {coaching_session_model:?}");
 
     let now = chrono::Utc::now();
 

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -38,7 +38,7 @@ pub enum EntityApiErrorKind {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Entity API Error: {:?}", self)
+        write!(f, "Entity API Error: {self:?}")
     }
 }
 

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -16,7 +16,7 @@ pub async fn create(
     note_model: Model,
     user_id: Id,
 ) -> Result<Model, Error> {
-    debug!("New Note Model to be inserted: {:?}", note_model);
+    debug!("New Note Model to be inserted: {note_model:?}");
 
     let now = chrono::Utc::now();
 
@@ -37,7 +37,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 
     match result {
         Some(note) => {
-            debug!("Existing Note model to be Updated: {:?}", note);
+            debug!("Existing Note model to be Updated: {note:?}");
 
             let active_model: ActiveModel = ActiveModel {
                 id: Unchanged(note.id),
@@ -51,7 +51,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             Ok(active_model.update(db).await?.try_into_model()?)
         }
         None => {
-            error!("Note with id {} not found", id);
+            error!("Note with id {id} not found");
 
             Err(Error {
                 source: None,
@@ -64,12 +64,12 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>, Error> {
     match Entity::find_by_id(id).one(db).await {
         Ok(Some(note)) => {
-            debug!("Note found: {:?}", note);
+            debug!("Note found: {note:?}");
 
             Ok(Some(note))
         }
         Ok(None) => {
-            error!("Note with id {} not found", id);
+            error!("Note with id {id} not found");
 
             Err(Error {
                 source: None,
@@ -77,7 +77,7 @@ pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<Model>
             })
         }
         Err(err) => {
-            error!("Note with id {} not found and returned error {}", id, err);
+            error!("Note with id {id} not found and returned error {err}");
             Err(Error {
                 source: None,
                 error_kind: EntityApiErrorKind::RecordNotFound,

--- a/entity_api/src/organization.rs
+++ b/entity_api/src/organization.rs
@@ -12,10 +12,7 @@ use std::collections::HashMap;
 use log::*;
 
 pub async fn create(db: &impl ConnectionTrait, organization_model: Model) -> Result<Model, Error> {
-    debug!(
-        "New Organization Model to be inserted: {:?}",
-        organization_model
-    );
+    debug!("New Organization Model to be inserted: {organization_model:?}");
 
     let now = Utc::now();
     let name = organization_model.name;

--- a/entity_api/src/overarching_goal.rs
+++ b/entity_api/src/overarching_goal.rs
@@ -16,10 +16,7 @@ pub async fn create(
     overarching_goal_model: Model,
     user_id: Id,
 ) -> Result<Model, Error> {
-    debug!(
-        "New Overarching Goal Model to be inserted: {:?}",
-        overarching_goal_model
-    );
+    debug!("New Overarching Goal Model to be inserted: {overarching_goal_model:?}");
 
     let now = chrono::Utc::now();
 
@@ -47,10 +44,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
 
     match result {
         Some(overarching_goal) => {
-            debug!(
-                "Existing Overarching Goal model to be Updated: {:?}",
-                overarching_goal
-            );
+            debug!("Existing Overarching Goal model to be Updated: {overarching_goal:?}");
 
             // Automatically update status_changed_at if the last status and new status differ:
             let av_status_changed_at: ActiveValue<Option<DateTimeWithTimeZone>> =
@@ -77,7 +71,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, model: Model) -> Result<Mod
             Ok(active_model.update(db).await?.try_into_model()?)
         }
         None => {
-            error!("Overarching Goal with id {} not found", id);
+            error!("Overarching Goal with id {id} not found");
 
             Err(Error {
                 source: None,
@@ -96,10 +90,7 @@ pub async fn update_status(
 
     match result {
         Some(overarching_goal) => {
-            debug!(
-                "Existing Overarching Goal model to be Updated: {:?}",
-                overarching_goal
-            );
+            debug!("Existing Overarching Goal model to be Updated: {overarching_goal:?}");
 
             let active_model: ActiveModel = ActiveModel {
                 id: Unchanged(overarching_goal.id),
@@ -117,7 +108,7 @@ pub async fn update_status(
             Ok(active_model.update(db).await?.try_into_model()?)
         }
         None => {
-            error!("Overarching Goal with id {} not found", id);
+            error!("Overarching Goal with id {id} not found");
 
             Err(Error {
                 source: None,

--- a/entity_api/src/user.rs
+++ b/entity_api/src/user.rs
@@ -18,10 +18,7 @@ use utoipa::{IntoParams, ToSchema};
 pub use entity::users::Role;
 
 pub async fn create(db: &impl ConnectionTrait, user_model: Model) -> Result<Model, Error> {
-    debug!(
-        "New User Relationship Model to be inserted: {:?}",
-        user_model
-    );
+    debug!("New User Relationship Model to be inserted: {user_model:?}");
 
     let now = Utc::now();
 
@@ -72,7 +69,7 @@ pub async fn find_by_email(db: &impl ConnectionTrait, email: &str) -> Result<Opt
         .one(db)
         .await?;
 
-    debug!("User find_by_email result: {:?}", user);
+    debug!("User find_by_email result: {user:?}");
 
     Ok(user)
 }

--- a/web/src/controller/action_controller.rs
+++ b/web/src/controller/action_controller.rs
@@ -39,7 +39,7 @@ pub async fn create(
     State(app_state): State<AppState>,
     Json(action_model): Json<Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("POST Create a New Action from: {:?}", action_model);
+    debug!("POST Create a New Action from: {action_model:?}");
 
     let action = ActionApi::create(app_state.db_conn_ref(), action_model, user.id).await?;
 
@@ -69,7 +69,7 @@ pub async fn read(
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("GET Action by id: {}", id);
+    debug!("GET Action by id: {id}");
 
     let action = ActionApi::find_by_id(app_state.db_conn_ref(), id).await?;
 
@@ -102,11 +102,11 @@ pub async fn update(
     Path(id): Path<Id>,
     Json(action_model): Json<Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("PUT Update Action with id: {}", id);
+    debug!("PUT Update Action with id: {id}");
 
     let action = ActionApi::update(app_state.db_conn_ref(), id, action_model).await?;
 
-    debug!("Updated Action: {:?}", action);
+    debug!("Updated Action: {action:?}");
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), action)))
 }
@@ -136,12 +136,12 @@ pub async fn update_status(
     Path(id): Path<Id>,
     State(app_state): State<AppState>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("PUT Update Action Status with id: {}", id);
+    debug!("PUT Update Action Status with id: {id}");
 
     let action =
         ActionApi::update_status(app_state.db_conn_ref(), id, status.as_str().into()).await?;
 
-    debug!("Updated Action: {:?}", action);
+    debug!("Updated Action: {action:?}");
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), action)))
 }
@@ -171,11 +171,11 @@ pub async fn index(
     Query(params): Query<IndexParams>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET all Actions");
-    debug!("Filter Params: {:?}", params);
+    debug!("Filter Params: {params:?}");
 
     let actions = ActionApi::find_by(app_state.db_conn_ref(), params).await?;
 
-    debug!("Found Actions: {:?}", actions);
+    debug!("Found Actions: {actions:?}");
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), actions)))
 }
@@ -203,7 +203,7 @@ pub async fn delete(
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("DELETE Action by id: {}", id);
+    debug!("DELETE Action by id: {id}");
 
     ActionApi::delete_by_id(app_state.db_conn_ref(), id).await?;
     Ok(Json(json!({"id": id})))

--- a/web/src/controller/agreement_controller.rs
+++ b/web/src/controller/agreement_controller.rs
@@ -40,11 +40,11 @@ pub async fn create(
     State(app_state): State<AppState>,
     Json(agreement_model): Json<Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("POST Create a New Agreement from: {:?}", agreement_model);
+    debug!("POST Create a New Agreement from: {agreement_model:?}");
 
     let agreement = AgreementApi::create(app_state.db_conn_ref(), agreement_model, user.id).await?;
 
-    debug!("New Agreement: {:?}", agreement);
+    debug!("New Agreement: {agreement:?}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::CREATED.into(),
@@ -75,7 +75,7 @@ pub async fn read(
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("GET Agreement by id: {}", id);
+    debug!("GET Agreement by id: {id}");
 
     let agreement = AgreementApi::find_by_id(app_state.db_conn_ref(), id).await?;
 
@@ -108,11 +108,11 @@ pub async fn update(
     Path(id): Path<Id>,
     Json(agreement_model): Json<Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("PUT Update Agreement with id: {}", id);
+    debug!("PUT Update Agreement with id: {id}");
 
     let agreement = AgreementApi::update(app_state.db_conn_ref(), id, agreement_model).await?;
 
-    debug!("Updated Agreement: {:?}", agreement);
+    debug!("Updated Agreement: {agreement:?}");
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), agreement)))
 }
@@ -142,11 +142,11 @@ pub async fn index(
     Query(params): Query<IndexParams>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET all Agreements");
-    debug!("Filter Params: {:?}", params);
+    debug!("Filter Params: {params:?}");
 
     let agreements = AgreementApi::find_by(app_state.db_conn_ref(), params).await?;
 
-    debug!("Found Agreements: {:?}", agreements);
+    debug!("Found Agreements: {agreements:?}");
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), agreements)))
 }
@@ -174,7 +174,7 @@ pub async fn delete(
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("DELETE Agreement by id: {}", id);
+    debug!("DELETE Agreement by id: {id}");
 
     AgreementApi::delete_by_id(app_state.db_conn_ref(), id).await?;
     Ok(Json(json!({"id": id})))

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -39,7 +39,8 @@ pub async fn read(
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET Coaching Session by ID: {}", coaching_session_id);
 
-    let coaching_session = CoachingSessionApi::find_by_id(app_state.db_conn_ref(), coaching_session_id).await?;
+    let coaching_session =
+        CoachingSessionApi::find_by_id(app_state.db_conn_ref(), coaching_session_id).await?;
 
     debug!("Found Coaching Session: {:?}", coaching_session);
 

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -37,12 +37,12 @@ pub async fn read(
     State(app_state): State<AppState>,
     Path(coaching_session_id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("GET Coaching Session by ID: {}", coaching_session_id);
+    debug!("GET Coaching Session by ID: {coaching_session_id}");
 
     let coaching_session =
         CoachingSessionApi::find_by_id(app_state.db_conn_ref(), coaching_session_id).await?;
 
-    debug!("Found Coaching Session: {:?}", coaching_session);
+    debug!("Found Coaching Session: {coaching_session:?}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::OK.into(),
@@ -77,11 +77,11 @@ pub async fn index(
     Query(params): Query<IndexParams>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET all Coaching Sessions");
-    debug!("Filter Params: {:?}", params);
+    debug!("Filter Params: {params:?}");
 
     let coaching_sessions = CoachingSessionApi::find_by(app_state.db_conn_ref(), params).await?;
 
-    debug!("Found Coaching Sessions: {:?}", coaching_sessions);
+    debug!("Found Coaching Sessions: {coaching_sessions:?}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::OK.into(),
@@ -113,10 +113,7 @@ pub async fn create(
     State(app_state): State<AppState>,
     Json(coaching_sessions_model): Json<Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!(
-        "POST Create a new Coaching Session from: {:?}",
-        coaching_sessions_model
-    );
+    debug!("POST Create a new Coaching Session from: {coaching_sessions_model:?}");
 
     let coaching_session = CoachingSessionApi::create(
         app_state.db_conn_ref(),
@@ -125,7 +122,7 @@ pub async fn create(
     )
     .await?;
 
-    debug!("New Coaching Session: {:?}", coaching_session);
+    debug!("New Coaching Session: {coaching_session:?}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::CREATED.into(),

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -13,6 +13,42 @@ use service::config::ApiVersion;
 
 use log::*;
 
+/// GET a Coaching Session by ID
+#[utoipa::path(
+    get,
+    path = "/coaching_sessions/{id}",
+    params(
+        ApiVersion,
+        ("id" = Id, Path, description = "Coaching Session ID to retrieve")
+    ),
+    responses(
+        (status = 200, description = "Successfully retrieved a Coaching Session", body = coaching_sessions::Model),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "Coaching Session not found"),
+        (status = 405, description = "Method not allowed")
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn read(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    State(app_state): State<AppState>,
+    Path(coaching_session_id): Path<Id>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("GET Coaching Session by ID: {}", coaching_session_id);
+
+    let coaching_session = CoachingSessionApi::find_by_id(app_state.db_conn_ref(), coaching_session_id).await?;
+
+    debug!("Found Coaching Session: {:?}", coaching_session);
+
+    Ok(Json(ApiResponse::new(
+        StatusCode::OK.into(),
+        coaching_session,
+    )))
+}
+
 #[utoipa::path(
     get,
     path = "/coaching_sessions",

--- a/web/src/controller/note_controller.rs
+++ b/web/src/controller/note_controller.rs
@@ -38,11 +38,11 @@ pub async fn create(
     State(app_state): State<AppState>,
     Json(note_model): Json<notes::Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("POST Create a New Note from: {:?}", note_model);
+    debug!("POST Create a New Note from: {note_model:?}");
 
     let note = NoteApi::create(app_state.db_conn_ref(), note_model, user.id).await?;
 
-    debug!("New Note: {:?}", note);
+    debug!("New Note: {note:?}");
 
     Ok(Json(ApiResponse::new(StatusCode::CREATED.into(), note)))
 }
@@ -73,11 +73,11 @@ pub async fn update(
     Path(id): Path<Id>,
     Json(note_model): Json<notes::Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("PUT Update Note with id: {}", id);
+    debug!("PUT Update Note with id: {id}");
 
     let note = NoteApi::update(app_state.db_conn_ref(), id, note_model).await?;
 
-    debug!("Updated Note: {:?}", note);
+    debug!("Updated Note: {note:?}");
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), note)))
 }
@@ -107,11 +107,11 @@ pub async fn index(
     Query(params): Query<HashMap<String, String>>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET all Notes");
-    debug!("Filter Params: {:?}", params);
+    debug!("Filter Params: {params:?}");
 
     let notes = NoteApi::find_by(app_state.db_conn_ref(), params).await?;
 
-    debug!("Found Notes: {:?}", notes);
+    debug!("Found Notes: {notes:?}");
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), notes)))
 }
@@ -139,7 +139,7 @@ pub async fn read(
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("GET Organization by id: {}", id);
+    debug!("GET Organization by id: {id}");
 
     let note: Option<notes::Model> = NoteApi::find_by_id(app_state.db_conn_ref(), id).await?;
 

--- a/web/src/controller/organization/coaching_relationship_controller.rs
+++ b/web/src/controller/organization/coaching_relationship_controller.rs
@@ -37,10 +37,7 @@ pub async fn create(
     AuthenticatedUser(_user): AuthenticatedUser,
     Json(coaching_relationship_model): Json<coaching_relationships::Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!(
-        "CREATE new Coaching Relationship from: {:?}",
-        coaching_relationship_model
-    );
+    debug!("CREATE new Coaching Relationship from: {coaching_relationship_model:?}");
 
     let coaching_relationship: CoachingRelationshipWithUserNames = CoachingRelationshipApi::create(
         app_state.db_conn_ref(),
@@ -87,7 +84,7 @@ pub async fn read(
     State(app_state): State<AppState>,
     Path((_organization_id, relationship_id)): Path<(Id, Id)>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("GET CoachingRelationship by id: {}", relationship_id);
+    debug!("GET CoachingRelationship by id: {relationship_id}");
 
     let relationship: Option<CoachingRelationshipWithUserNames> =
         CoachingRelationshipApi::get_relationship_with_user_names(
@@ -132,7 +129,7 @@ pub async fn index(
     )
     .await?;
 
-    debug!("Found CoachingRelationships: {:?}", coaching_relationships);
+    debug!("Found CoachingRelationships: {coaching_relationships:?}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::OK.into(),

--- a/web/src/controller/organization/user_controller.rs
+++ b/web/src/controller/organization/user_controller.rs
@@ -70,7 +70,7 @@ pub(crate) async fn create(
     let user =
         UserApi::create_by_organization(app_state.db_conn_ref(), organization_id, user_model)
             .await?;
-    info!("User created: {:?}", user);
+    info!("User created: {user:?}");
     Ok(Json(ApiResponse::new(StatusCode::CREATED.into(), user)))
 }
 
@@ -98,7 +98,7 @@ pub async fn delete(
     AuthenticatedUser(_authenticated_user): AuthenticatedUser,
     Path((_organization_id, user_id)): Path<(Id, Id)>,
 ) -> Result<impl IntoResponse, Error> {
-    info!("Deleting user: {:?}", user_id);
+    info!("Deleting user: {user_id:?}");
     UserApi::delete(app_state.db_conn_ref(), user_id).await?;
     Ok(Json(ApiResponse::<()>::no_content(
         StatusCode::NO_CONTENT.into(),

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -46,7 +46,7 @@ pub async fn index(
 
     let organizations = OrganizationApi::find_by(app_state.db_conn_ref(), params).await?;
 
-    debug!("Found Organizations: {:?}", organizations);
+    debug!("Found Organizations: {organizations:?}");
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), organizations)))
 }
@@ -74,7 +74,7 @@ pub async fn read(
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("GET Organization by id: {}", id);
+    debug!("GET Organization by id: {id}");
 
     let organization = OrganizationApi::find_by_id(app_state.db_conn_ref(), id).await?;
 
@@ -178,7 +178,7 @@ pub async fn delete(
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("DELETE Organization by id: {}", id);
+    debug!("DELETE Organization by id: {id}");
 
     OrganizationApi::delete_by_id(app_state.db_conn_ref(), id).await?;
     Ok(Json(json!({"id": id})))

--- a/web/src/controller/overarching_goal_controller.rs
+++ b/web/src/controller/overarching_goal_controller.rs
@@ -38,16 +38,13 @@ pub async fn create(
     State(app_state): State<AppState>,
     Json(overarching_goals_model): Json<Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!(
-        "POST Create a New Overarching Goal from: {:?}",
-        overarching_goals_model
-    );
+    debug!("POST Create a New Overarching Goal from: {overarching_goals_model:?}");
 
     let overarching_goals =
         OverarchingGoalApi::create(app_state.db_conn_ref(), overarching_goals_model, user.id)
             .await?;
 
-    debug!("New Overarching Goal: {:?}", overarching_goals);
+    debug!("New Overarching Goal: {overarching_goals:?}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::CREATED.into(),
@@ -78,7 +75,7 @@ pub async fn read(
     State(app_state): State<AppState>,
     Path(id): Path<Id>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("GET Overarching Goal by id: {}", id);
+    debug!("GET Overarching Goal by id: {id}");
 
     let overarching_goal = OverarchingGoalApi::find_by_id(app_state.db_conn_ref(), id).await?;
 
@@ -114,12 +111,12 @@ pub async fn update(
     Path(id): Path<Id>,
     Json(overarching_goals_model): Json<Model>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("PUT Update Overarching Goal with id: {}", id);
+    debug!("PUT Update Overarching Goal with id: {id}");
 
     let overarching_goals =
         OverarchingGoalApi::update(app_state.db_conn_ref(), id, overarching_goals_model).await?;
 
-    debug!("Updated Overarching Goal: {:?}", overarching_goals);
+    debug!("Updated Overarching Goal: {overarching_goals:?}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::OK.into(),
@@ -152,13 +149,13 @@ pub async fn update_status(
     Path(id): Path<Id>,
     State(app_state): State<AppState>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("PUT Update Overarching Goal Status with id: {}", id);
+    debug!("PUT Update Overarching Goal Status with id: {id}");
 
     let overarching_goal =
         OverarchingGoalApi::update_status(app_state.db_conn_ref(), id, status.as_str().into())
             .await?;
 
-    debug!("Updated Overarching Goal: {:?}", overarching_goal);
+    debug!("Updated Overarching Goal: {overarching_goal:?}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::OK.into(),
@@ -191,11 +188,11 @@ pub async fn index(
     Query(params): Query<IndexParams>,
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET all Overarching Goals");
-    debug!("Filter Params: {:?}", params);
+    debug!("Filter Params: {params:?}");
 
     let overarching_goals = OverarchingGoalApi::find_by(app_state.db_conn_ref(), params).await?;
 
-    debug!("Found Overarching Goals: {:?}", overarching_goals);
+    debug!("Found Overarching Goals: {overarching_goals:?}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::OK.into(),

--- a/web/src/controller/user_session_controller.rs
+++ b/web/src/controller/user_session_controller.rs
@@ -56,7 +56,7 @@ pub async fn login(
         Err(auth_error) => {
             // Convert axum_login error to WebError by creating domain error manually.
             // This maps EntityApiErrorKind::RecordUnauthenticated to a 401 through the web layer.
-            error!("Authentication failed with error: {:?}", auth_error);
+            error!("Authentication failed with error: {auth_error:?}");
             // TODO: replace this with a more idiomatic Rust 1-liner using from/into
             return Err(WebError::from(domain::error::Error {
                 source: Some(Box::new(auth_error)),
@@ -70,7 +70,7 @@ pub async fn login(
     };
 
     if let Err(login_error) = auth_session.login(&user).await {
-        warn!("Session login failed: {:?}", login_error);
+        warn!("Session login failed: {login_error:?}");
         return Err(WebError::from(domain::error::Error {
             source: Some(Box::new(login_error)),
             error_kind: domain::error::DomainErrorKind::Internal(
@@ -88,7 +88,7 @@ pub async fn login(
             "role": user.role,
     });
 
-    debug!("user_session_json: {}", user_session_json);
+    debug!("user_session_json: {user_session_json}");
 
     Ok(Json(ApiResponse::new(
         StatusCode::OK.into(),

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -64,15 +64,13 @@ impl Error {
             }
             InternalErrorKind::Config => {
                 warn!(
-                    "InternalErrorKind::Config: Responding with 500 Internal Server Error. Error: {:?}",
-                    self
+                    "InternalErrorKind::Config: Responding with 500 Internal Server Error. Error: {self:?}"
                 );
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
             InternalErrorKind::Other(_description) => {
                 warn!(
-                    "InternalErrorKind::Other: Responding with 500 Internal Server Error. Error:: {:?}",
-                    self
+                    "InternalErrorKind::Other: Responding with 500 Internal Server Error. Error:: {self:?}"
                 );
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
@@ -82,37 +80,30 @@ impl Error {
     fn handle_entity_error(&self, entity_error_kind: &EntityErrorKind) -> Response {
         match entity_error_kind {
             EntityErrorKind::NotFound => {
-                warn!(
-                    "EntityErrorKind::NotFound: Responding with 404 Not Found. Error: {:?}",
-                    self
-                );
+                warn!("EntityErrorKind::NotFound: Responding with 404 Not Found. Error: {self:?}");
                 (StatusCode::NOT_FOUND, "NOT FOUND").into_response()
             }
             EntityErrorKind::Unauthenticated => {
                 warn!(
-                    "EntityErrorKind::Unauthenticated: Responding with 401 Unauthorized. Error: {:?}",
-                    self
+                    "EntityErrorKind::Unauthenticated: Responding with 401 Unauthorized. Error: {self:?}"
                 );
                 (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response()
             }
             EntityErrorKind::DbTransaction => {
                 warn!(
-                    "EntityErrorKind::DbTransaction: Responding with 500 Internal Server Error. Error: {:?}",
-                    self
+                    "EntityErrorKind::DbTransaction: Responding with 500 Internal Server Error. Error: {self:?}"
                 );
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
             EntityErrorKind::Invalid => {
                 warn!(
-                    "EntityErrorKind::Invalid: Responding with 422 Unprocessable Entity. Error: {:?}",
-                    self
+                    "EntityErrorKind::Invalid: Responding with 422 Unprocessable Entity. Error: {self:?}"
                 );
                 (StatusCode::UNPROCESSABLE_ENTITY, "UNPROCESSABLE ENTITY").into_response()
             }
             EntityErrorKind::Other(_description) => {
                 warn!(
-                    "EntityErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}",
-                    self
+                    "EntityErrorKind::Other: Responding with 500 Internal Server Error. Error: {self:?}"
                 );
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
@@ -123,15 +114,13 @@ impl Error {
         match external_error_kind {
             ExternalErrorKind::Network => {
                 warn!(
-                    "ExternalErrorKind::Network: Responding with 502 Bad Gateway. Error: {:?}",
-                    self
+                    "ExternalErrorKind::Network: Responding with 502 Bad Gateway. Error: {self:?}"
                 );
                 (StatusCode::BAD_GATEWAY, "BAD GATEWAY").into_response()
             }
             ExternalErrorKind::Other(_description) => {
                 warn!(
-                    "ExternalErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}",
-                    self
+                    "ExternalErrorKind::Other: Responding with 500 Internal Server Error. Error: {self:?}"
                 );
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }
@@ -141,23 +130,16 @@ impl Error {
     fn handle_web_error(&self, web_error_kind: &WebErrorKind) -> Response {
         match web_error_kind {
             WebErrorKind::Input => {
-                warn!(
-                    "WebErrorKind::Input: Responding with 400 Bad Request. Error: {:?}",
-                    self
-                );
+                warn!("WebErrorKind::Input: Responding with 400 Bad Request. Error: {self:?}");
                 (StatusCode::BAD_REQUEST, "BAD REQUEST").into_response()
             }
             WebErrorKind::Auth => {
-                warn!(
-                    "WebErrorKind::Auth: Responding with 401 Unauthorized. Error: {:?}",
-                    self
-                );
+                warn!("WebErrorKind::Auth: Responding with 401 Unauthorized. Error: {self:?}");
                 (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response()
             }
             WebErrorKind::Other => {
                 warn!(
-                    "WebErrorKind::Other: Responding with 500 Internal Server Error. Error: {:?}",
-                    self
+                    "WebErrorKind::Other: Responding with 500 Internal Server Error. Error: {self:?}"
                 );
                 (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
             }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -79,7 +79,7 @@ pub async fn init_server(app_state: AppState) -> Result<()> {
         .iter()
         .filter_map(|origin| origin.parse().ok())
         .collect::<Vec<HeaderValue>>();
-    info!("allowed_origins: {:#?}", allowed_origins);
+    info!("allowed_origins: {allowed_origins:#?}");
 
     let cors_layer = CorsLayer::new()
         .allow_methods([

--- a/web/src/protect/actions.rs
+++ b/web/src/protect/actions.rs
@@ -42,7 +42,7 @@ pub(crate) async fn index(
             }
         }
         Err(e) => {
-            error!("Error authorizing overarching goals index{:?}", e);
+            error!("Error authorizing overarching goals index{e:?}");
 
             (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
         }

--- a/web/src/protect/agreements.rs
+++ b/web/src/protect/agreements.rs
@@ -37,7 +37,7 @@ pub(crate) async fn index(
             }
         }
         Err(e) => {
-            error!("Error authorizing overarching goals index{:?}", e);
+            error!("Error authorizing overarching goals index{e:?}");
 
             (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
         }

--- a/web/src/protect/coaching_sessions.rs
+++ b/web/src/protect/coaching_sessions.rs
@@ -57,9 +57,10 @@ pub(crate) async fn read(
     request: Request,
     next: Next,
 ) -> impl IntoResponse {
-    let checks: Vec<Predicate> = vec![
-        Predicate::new(UserCanAccessCoachingSession, vec![coaching_session_id]),
-    ];
+    let checks: Vec<Predicate> = vec![Predicate::new(
+        UserCanAccessCoachingSession,
+        vec![coaching_session_id],
+    )];
 
     crate::protect::authorize(&app_state, authenticated_user, request, next, checks).await
 }

--- a/web/src/protect/coaching_sessions.rs
+++ b/web/src/protect/coaching_sessions.rs
@@ -59,7 +59,7 @@ pub(crate) async fn read(
         match coaching_session::find_by_id(app_state.db_conn_ref(), coaching_session_id).await {
             Ok(session) => session,
             Err(e) => {
-                error!("Authorization error finding coaching session: {:?}", e);
+                error!("Authorization error finding coaching session: {e:?}");
                 return (StatusCode::NOT_FOUND, "NOT FOUND").into_response();
             }
         };
@@ -72,7 +72,7 @@ pub(crate) async fn read(
     {
         Ok(relationship) => relationship,
         Err(e) => {
-            error!("Authorization error finding coaching relationship: {:?}", e);
+            error!("Authorization error finding coaching relationship: {e:?}");
             return (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response();
         }
     };
@@ -100,7 +100,7 @@ pub(crate) async fn update(
         match coaching_session::find_by_id(app_state.db_conn_ref(), coaching_session_id).await {
             Ok(session) => session,
             Err(e) => {
-                error!("Authorization error finding coaching session: {:?}", e);
+                error!("Authorization error finding coaching session: {e:?}");
                 return (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response();
             }
         };
@@ -113,7 +113,7 @@ pub(crate) async fn update(
     {
         Ok(relationship) => relationship,
         Err(e) => {
-            error!("Authorization error finding coaching relationship: {:?}", e);
+            error!("Authorization error finding coaching relationship: {e:?}");
             return (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response();
         }
     };
@@ -141,7 +141,7 @@ pub(crate) async fn delete(
         match coaching_session::find_by_id(app_state.db_conn_ref(), coaching_session_id).await {
             Ok(session) => session,
             Err(e) => {
-                error!("Authorization error finding coaching session: {:?}", e);
+                error!("Authorization error finding coaching session: {e:?}");
                 return (StatusCode::NOT_FOUND, "NOT FOUND").into_response();
             }
         };
@@ -154,7 +154,7 @@ pub(crate) async fn delete(
     {
         Ok(relationship) => relationship,
         Err(e) => {
-            error!("Authorization error finding coaching relationship: {:?}", e);
+            error!("Authorization error finding coaching relationship: {e:?}");
             return (StatusCode::NOT_FOUND, "NOT FOUND").into_response();
         }
     };

--- a/web/src/protect/coaching_sessions.rs
+++ b/web/src/protect/coaching_sessions.rs
@@ -46,6 +46,46 @@ pub(crate) async fn index(
 
 /// Checks that coaching session record referenced by `coaching_session_id`
 ///     * exists
+///     * that the authenticated user is associated with it (coach or coachee)
+///  Intended to be given to axum::middleware::from_fn_with_state in the router
+pub(crate) async fn read(
+    State(app_state): State<AppState>,
+    AuthenticatedUser(user): AuthenticatedUser,
+    Path(coaching_session_id): Path<Id>,
+    request: Request,
+    next: Next,
+) -> impl IntoResponse {
+    let coaching_session =
+        match coaching_session::find_by_id(app_state.db_conn_ref(), coaching_session_id).await {
+            Ok(session) => session,
+            Err(e) => {
+                error!("Authorization error finding coaching session: {:?}", e);
+                return (StatusCode::NOT_FOUND, "NOT FOUND").into_response();
+            }
+        };
+
+    let coaching_relationship = match coaching_relationship::find_by_id(
+        app_state.db_conn_ref(),
+        coaching_session.coaching_relationship_id,
+    )
+    .await
+    {
+        Ok(relationship) => relationship,
+        Err(e) => {
+            error!("Authorization error finding coaching relationship: {:?}", e);
+            return (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response();
+        }
+    };
+
+    if coaching_relationship.coach_id == user.id || coaching_relationship.coachee_id == user.id {
+        next.run(request).await
+    } else {
+        (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response()
+    }
+}
+
+/// Checks that coaching session record referenced by `coaching_session_id`
+///     * exists
 ///     * that the authenticated user is associated with it.
 ///     * that the authenticated user is the coach
 ///  Intended to be given to axum::middleware::from_fn_with_state in the router

--- a/web/src/protect/jwt.rs
+++ b/web/src/protect/jwt.rs
@@ -37,7 +37,7 @@ pub(crate) async fn generate_collab_token(
             }
         }
         Err(e) => {
-            error!("Error authorizing collaboration token generation {:?}", e);
+            error!("Error authorizing collaboration token generation {e:?}");
 
             (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
         }

--- a/web/src/protect/mod.rs
+++ b/web/src/protect/mod.rs
@@ -176,9 +176,14 @@ impl Check for UserCanAccessCoachingSession {
         args: Vec<Id>,
     ) -> bool {
         let coaching_session_id = args[0];
-        
+
         // Get the coaching session
-        let coaching_session = match coaching_session::find_by_id(app_state.db_conn_ref(), coaching_session_id).await {
+        let coaching_session = match coaching_session::find_by_id(
+            app_state.db_conn_ref(),
+            coaching_session_id,
+        )
+        .await
+        {
             Ok(session) => session,
             Err(e) => {
                 error!("Error finding coaching session {coaching_session_id}: {e:?}");
@@ -190,15 +195,21 @@ impl Check for UserCanAccessCoachingSession {
         let coaching_relationship = match coaching_relationship::find_by_id(
             app_state.db_conn_ref(),
             coaching_session.coaching_relationship_id,
-        ).await {
+        )
+        .await
+        {
             Ok(relationship) => relationship,
             Err(e) => {
-                error!("Error finding coaching relationship {}: {e:?}", coaching_session.coaching_relationship_id);
+                error!(
+                    "Error finding coaching relationship {}: {e:?}",
+                    coaching_session.coaching_relationship_id
+                );
                 return false;
             }
         };
 
         // Check if user is coach or coachee
-        coaching_relationship.coach_id == authenticated_user.id || coaching_relationship.coachee_id == authenticated_user.id
+        coaching_relationship.coach_id == authenticated_user.id
+            || coaching_relationship.coachee_id == authenticated_user.id
     }
 }

--- a/web/src/protect/mod.rs
+++ b/web/src/protect/mod.rs
@@ -129,7 +129,7 @@ impl Check for UserInOrganization {
         match UserApi::find_by_organization(app_state.db_conn_ref(), organization_id).await {
             Ok(users) => users.iter().any(|user| user.id == authenticated_user.id),
             Err(_) => {
-                error!("Organization not found with ID {:?}", organization_id);
+                error!("Organization not found with ID {organization_id:?}");
                 false
             }
         }

--- a/web/src/protect/notes.rs
+++ b/web/src/protect/notes.rs
@@ -42,7 +42,7 @@ pub(crate) async fn index(
             }
         }
         Err(e) => {
-            error!("Error authorizing overarching goals index{:?}", e);
+            error!("Error authorizing overarching goals index{e:?}");
 
             (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
         }

--- a/web/src/protect/overarching_goals.rs
+++ b/web/src/protect/overarching_goals.rs
@@ -42,7 +42,7 @@ pub(crate) async fn index(
             }
         }
         Err(e) => {
-            error!("Error authorizing overarching goals index{:?}", e);
+            error!("Error authorizing overarching goals index{e:?}");
 
             (StatusCode::INTERNAL_SERVER_ERROR, "INTERNAL SERVER ERROR").into_response()
         }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -42,6 +42,7 @@ use self::organization::coaching_relationship_controller;
             agreement_controller::read,
             agreement_controller::delete,
             coaching_session_controller::index,
+            coaching_session_controller::read,
             coaching_session_controller::create,
             coaching_session_controller::update,
             coaching_session_controller::delete,
@@ -190,7 +191,19 @@ pub fn coaching_sessions_routes(app_state: AppState) -> Router {
                 )),
         )
         .merge(
-            // Put /coaching_sessions
+            // GET /coaching_sessions/:id
+            Router::new()
+                .route(
+                    "/coaching_sessions/:id",
+                    get(coaching_session_controller::read),
+                )
+                .route_layer(from_fn_with_state(
+                    app_state.clone(),
+                    protect::coaching_sessions::read,
+                )),
+        )
+        .merge(
+            // PUT /coaching_sessions/:id
             Router::new()
                 .route(
                     "/coaching_sessions/:id",


### PR DESCRIPTION
## Description
Add GET endpoint for retrieving a single coaching session by ID with proper authorization middleware to ensure users can only access coaching sessions they are associated with (as coach or coachee).

**GitHub Issue:** Related to frontend bugs [#79](https://github.com/refactor-group/refactor-platform-fe/issues/79) and [#78](https://github.com/refactor-group/refactor-platform-fe/issues/78)

### Changes

* Added new read function in coaching_session_controller.rs to handle GET requests for individual coaching sessions by ID
* Implemented OpenAPI documentation with utoipa::path macro including proper response codes and security requirements
* Created new authorization middleware read function in protect/coaching_sessions.rs to verify user access to the requested coaching session
* Added route configuration in router.rs for GET /coaching_sessions/:id with the new authorization middleware
* Authorization middleware checks that the coaching session exists and that the authenticated user is either the coach or coachee in the associated coaching relationship
* Adds docs/release-notes/ as a place to store all release notes, along with our first official release notes for 1.0.0-beta1

### Testing Strategy

1. Test GET /coaching_sessions/{valid_id} with authenticated user who is the coach - should return 200 with session data
2. Test GET /coaching_sessions/{valid_id} with authenticated user who is the coachee - should return 200 with session data
3. Test GET /coaching_sessions/{valid_id} with authenticated user who is neither coach nor coachee - should return 401 Unauthorized
4. Test GET /coaching_sessions/{invalid_id} - should return 404 Not Found
5. Test GET /coaching_sessions/{id} without authentication - should return 401 Unauthorized
6. Verify OpenAPI documentation is properly generated for the new endpoint

Concerns

* The authorization middleware performs two database queries (coaching session lookup + coaching relationship lookup) - consider if this could be optimized with a single join query for better performance
* Error handling returns different status codes (404 vs 401) depending on which lookup fails - ensure this doesn't leak information about existing coaching sessions to unauthorized users
* Consider if additional logging is needed for security audit trails when unauthorized access attempts are made
