### PR TITLE
Fix Database Rebuilds

### DIFF
--- a/docs/db/base_refactor_platform_rs.dbml
+++ b/docs/db/base_refactor_platform_rs.dbml
@@ -1,0 +1,143 @@
+// Use DBML to define your database structure
+// Docs: https://dbml.dbdiagram.io/docs
+
+// IMPORTANT: DO NOT UPDATE THIS FILE. IT MAINTAINS A STATIC SNAPSHOT OF THE DATABASE PRIOR TO MOVING TO INCREMENTAL seaORM MIGRATIONS
+// AND IS USED TO CREATE THE BASE SCHEMA WHEN REBUILDING THE DATABASE IN NON-PROD ENVIRONEMENTS.ß
+
+Table refactor_platform.organizations {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  name varchar [not null, note: 'The name of the organization that the coach <--> coachee belong to']
+  logo varchar [note: 'A URI pointing to the organization\'s logo icon file']
+  slug varchar [note: 'A human-friendly canonical name for a record. Considered immutable by convention. Must be unique.']
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`, note: 'The last date and time fields were changed']
+}
+
+// Coaching relationship type belonging to the refactor_platform schema
+// from the perspective of the coach
+Table refactor_platform.coaching_relationships {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  organization_id uuid [not null, note: 'The organization associated with this coaching relationship']
+  coach_id uuid [not null, note: 'The coach associated with this coaching relationship']
+  coachee_id uuid [not null, note: 'The coachee associated with this coaching relationship']
+  slug varchar [note: 'A human-friendly canonical name for a record. Considered immutable by convention. Must be unique.']
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`, note: 'The last date and time fields were changed']
+
+  Indexes {
+    (coach_id, coachee_id, organization_id) [unique, name: "coaching_relationships_coach_coachee_org"]
+  }
+}
+
+Table refactor_platform.users {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  email varchar [unique, not null]
+  first_name varchar
+  last_name varchar
+  display_name varchar [note: 'If a user wants to go by something other than first & last names']
+  password varchar [not null]
+  github_username varchar // Specifically GH for now, can generalize later
+  github_profile_url varchar
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`, note: 'The last date and time fields were changed']
+}
+
+Table refactor_platform.organizations_users {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  organization_id uuid [not null, note: 'The organization joined to the user']
+  user_id uuid [not null, note: 'The user joined to the organization']
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`, note: 'The last date and time fields were changed']
+
+  Indexes {
+    (organization_id, user_id) [unique, name: "organizations_users_org_user"]
+  }
+}
+
+Table refactor_platform.coaching_sessions {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  coaching_relationship_id uuid [not null, note: 'The coaching relationship (i.e. what coach & coachee under what organization) associated with this coaching session']
+  date timestamp [not null, note: 'The date and time of a session']
+  collab_document_name varchar
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`, note: 'The last date and time fields were changed']
+}
+
+Table refactor_platform.overarching_goals {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  user_id uuid [not null, note: 'User that created (owns) the overarching goal']
+  coaching_session_id uuid [note: 'The coaching session that an overarching goal is associated with']
+  title varchar [note: 'A short description of an overarching goal']
+  body varchar [note: 'Main text of the overarching goal supporting Markdown']
+  status refactor_platform.status [not null]
+  status_changed_at timestamptz
+  completed_at timestamptz [note: 'The date and time an overarching goal was completed']
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`, note: 'The last date and time fields were changed']
+}
+
+Table refactor_platform.notes {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  coaching_session_id uuid [not null]
+  body varchar [note: 'Main text of the note supporting Markdown']
+  user_id uuid [not null, note: 'User that created (owns) the note']
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`, note: 'The last date and time a note\'s fields were changed']
+}
+
+Table refactor_platform.agreements {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  coaching_session_id uuid [not null]
+  body varchar [note: 'Either a short or long description of an agreement reached between coach and coachee in a coaching session']
+  user_id uuid [not null, note: 'User that created (owns) the agreement']
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`, note: 'The last date and time an agreement\'s fields were changed']
+}
+
+Table refactor_platform.actions {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  // The first session where this action was created
+  // It will carry forward to every future session until
+  // its due_by is passed or it was completed by the coachee
+  coaching_session_id uuid [not null]
+  body varchar [note: 'Main text of the action supporting Markdown']
+  user_id uuid [not null, note: 'User that created (owns) the action']
+  due_by timestamptz
+  status refactor_platform.status [not null]
+  status_changed_at timestamptz [not null, default: `now()`]
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`]
+}
+
+enum refactor_platform.status {
+  not_started
+  in_progress
+  completed
+  wont_do
+}
+
+// coaching_relationships relationships
+Ref: refactor_platform.coaching_relationships.organization_id > refactor_platform.organizations.id
+Ref: refactor_platform.coaching_relationships.coachee_id > refactor_platform.users.id
+Ref: refactor_platform.coaching_relationships.coach_id > refactor_platform.users.id
+
+// coaching_sessions relationships
+Ref: refactor_platform.coaching_sessions.coaching_relationship_id > refactor_platform.coaching_relationships.id
+
+// overarching_goals relationships
+Ref: refactor_platform.overarching_goals.coaching_session_id > refactor_platform.coaching_sessions.id
+
+// notes relationships
+Ref: refactor_platform.notes.coaching_session_id > refactor_platform.coaching_sessions.id
+Ref: refactor_platform.notes.user_id > refactor_platform.users.id
+
+// agreements relationships
+Ref: refactor_platform.agreements.coaching_session_id > refactor_platform.coaching_sessions.id
+Ref: refactor_platform.agreements.user_id > refactor_platform.users.id
+
+// actions relationships
+Ref: refactor_platform.actions.coaching_session_id > refactor_platform.coaching_sessions.id
+
+// organizations_users relationships
+Ref: refactor_platform.organizations_users.organization_id > refactor_platform.organizations.id
+Ref: refactor_platform.organizations_users.user_id > refactor_platform.users.id

--- a/migration/README.md
+++ b/migration/README.md
@@ -4,7 +4,7 @@
 
 This project uses a two-phase approach to database migrations:
 
-1. **Initial Schema Setup**: The initial database schema is defined in `docs/db/refactor_platform_rs.dbml` using DBML (Database Markup Language). During the first stages of development, we used the `scripts/rebuild_db.sh` script to set up the entire schema at once. This script:
+1. **Initial Schema Setup**: The initial database schema is defined in `docs/db/base_refactor_platform_rs.dbml` using DBML (Database Markup Language). During the first stages of development, we used the `scripts/rebuild_db.sh` script to set up the entire schema at once. This script:
    - Converts the DBML to SQL
    - Creates necessary database objects (user, database, schema)
    - Applies the generated SQL as the first migration
@@ -12,6 +12,20 @@ This project uses a two-phase approach to database migrations:
 2. **Incremental Migrations**: As we move into production, we utilize SeaORM's built-in migration mechanisms for all subsequent schema changes. However, the `scripts/rebuild_db.sh` script remains available for:
    - First-time local environment setup
    - Rebuilding your local database from scratch
+
+### Important
+
+When updating or seeding records in migrations, always use raw SQL queries instead of SeaORM's ActiveModel or entity methods. This is critical for several reasons:
+
+1. **Schema Evolution**: Entity definitions in your codebase represent the current state of your database schema. When migrations are replayed (e.g., during database rebuilds), older migrations may reference entity fields that no longer exist or have changed type, causing compilation failures.
+
+2. **Type Safety vs. Migration Stability**: Rust's type system enforces that SeaORM entities match the current schema. However, migrations need to work with the schema as it existed at the time the migration was written, not the current schema state.
+
+3. **Deterministic Behavior**: Raw SQL ensures migrations behave identically regardless of when they're executed, preventing subtle bugs that can occur when entity-based code changes behavior due to schema evolution.
+
+4. **Compilation Independence**: Raw SQL migrations can be compiled and executed even when the current entity definitions don't match the historical schema state that the migration was designed to work with.
+
+
 
 ## Setting Up Migrations
 

--- a/migration/src/base_refactor_platform_rs.sql
+++ b/migration/src/base_refactor_platform_rs.sql
@@ -1,6 +1,6 @@
--- SQL dump generated using DBML (dbml-lang.org)
+-- SQL dump generated using DBML (dbml.dbdiagram.io)
 -- Database: PostgreSQL
--- Generated at: 2025-07-06T20:24:15.974Z
+-- Generated at: 2025-07-11T12:54:19.417Z
 
 
 CREATE TYPE "refactor_platform"."status" AS ENUM (

--- a/migration/src/m20240211_174355_base_migration.rs
+++ b/migration/src/m20240211_174355_base_migration.rs
@@ -15,7 +15,7 @@ impl MigrationTrait for Migration {
             DbErr::Migration(string)
         };
         let mut file =
-            File::open("migration/src/refactor_platform_rs.sql").map_err(stringify_err)?;
+            File::open("migration/src/base_refactor_platform_rs.sql").map_err(stringify_err)?;
 
         let mut sql = String::new();
 

--- a/scripts/rebuild_db.sh
+++ b/scripts/rebuild_db.sh
@@ -63,11 +63,11 @@ fi
 
 # Generating SQL for the migrations using dbml2sql
 echo "Generating SQL for the migrations..."
-dbml2sql docs/db/refactor_platform_rs.dbml -o migration/src/refactor_platform_rs.sql || { echo "Error generating SQL file"; exit 1; }
+dbml2sql docs/db/base_refactor_platform_rs.dbml -o migration/src/base_refactor_platform_rs.sql || { echo "Error generating SQL file"; exit 1; }
 
 # Remove the line to create a schema from the generated SQL file
 echo "Modifying the generated SQL file..."
-sed -i '' '/CREATE SCHEMA/d' migration/src/refactor_platform_rs.sql
+sed -i '' '/CREATE SCHEMA/d' migration/src/base_refactor_platform_rs.sql
 
 echo "Running the migrations..."
 DATABASE_URL=postgres://$DB_USER:password@localhost:5432/$DB_NAME sea-orm-cli migrate up -s $SCHEMA_NAME || { echo "Failed to run migrations"; exit 1; }


### PR DESCRIPTION
## Description

This PR fixes an issue where updates to our `refactor_platform_rs.dbml` file was breaking the migration process when rebuilding a database (local dev).

When running `scripts/rebuild_db.sh`, updates to the `refactor_platform_rs.dbml` were causing subsequent updates to `refactor_platform_rs.sql` and ultimately to the database schema. This was causing changes to be applied in the base migration prior to attempts to make the same changes in later migrations.

We likely still want to be able to document the _current_ state of the database at any given time and so I modified `scripts/rebuild_db.sh` to refer to `base_` files. These files will preserve a snapshot of the database prior to us moving to incremental migrations. 

These files should be considered static now.

I kept `refactor_platform_rs.dbml` at the current state so that we can continue to maintain up to date documentation on the database schema.

**Note:** I ran into a separate issue where the migration to update our admin user to the `admin` role started failing due to Rust's type system complaining due to  `entity::users::Model` having a `timezone` attribute prior to the column existing in the database. 

We have chosen to solve for this type of issue by using raw SQL when seeding records in migrations. There's some explanation in https://github.com/refactor-group/refactor-platform-rs/pull/153.  I overlooked this situation not realizing that the issue would apply to _all_ operations on actual records in migrations.


### Changes
* Adds `base_refactor_platform_rs.dbml` and `base_refactor_platform_rs.sql` along with updates to `scripts/rebuild_db.sh`
* Updates migration to use raw SQL


### Testing Strategy

Run `scripts/rebuild_db.sh` locally


### Concerns
Is there a way we can enforce raw SQL in migrations that operate on records?
