### PR TITLE
Add a Let's Encrypt SSL cert renewal script and cronjob

### DIFF
--- a/.github/workflows/build_and_push_nonproduction_images.yml
+++ b/.github/workflows/build_and_push_nonproduction_images.yml
@@ -23,11 +23,11 @@ jobs:
       # Checkout code
       - uses: actions/checkout@v4
 
-      # Enable QEMU for multi-arch builds (arm64 on x86)
+      # Enable QEMU for multi-arch builds (arm64 on x86) - TEMPORARILY DISABLED FOR SPEED
       - name: Set up Rust + QEMU
         uses: docker/setup-qemu-action@v2
         with:
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
 
       # Install Rust and cache artifacts
       - name: Set up Rust
@@ -95,7 +95,7 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64  # ✅ Key multi-arch setting
+          platforms: linux/amd64  # TEMPORARILY DISABLED ARM64 FOR SPEED
           push: true
           provenance: true
           tags: ${{ steps.tags.outputs.backend_tags }}

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -161,6 +161,15 @@ jobs:
               echo "INFO: $1"
             }
 
+            # Cleanup function to ensure service gets restarted even on failure
+            cleanup() {
+              echo "INFO: 🔄 Ensuring Refactor Platform service is running..."
+              sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"
+            }
+
+            # Set trap to run cleanup on any exit (success or failure)
+            trap cleanup EXIT
+
             log_info '📦 Starting deployment from branch: ${{ github.ref_name }}...'
             cd /home/deploy
             curl -O https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/docker-compose.yaml
@@ -172,6 +181,9 @@ jobs:
                 exit 1
             fi
 
+            log_info "🛑 Stopping Refactor Platform service before nginx setup..."
+            sudo systemctl stop refactor-platform.service
+            
             log_info "Creating nginx directories..."
             if ! mkdir -p nginx/conf.d nginx/logs nginx/scripts nginx/html/.well-known/acme-challenge; then
               echo "ERROR: Failed to create nginx directories"
@@ -315,9 +327,6 @@ jobs:
             # Verify docker-compose configuration
             docker compose config --quiet
             # Check config without output unless error
-
-            log_info "🛑 Stopping Refactor Platform service..."
-            sudo systemctl stop refactor-platform.service
 
             log_info "🚀 Starting Refactor Platform service..."
             sudo systemctl start refactor-platform.service

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -213,8 +213,15 @@ jobs:
             # Download refactor platform nginx let's encrypt ssl cert renewal script
             # Remove existing file first to avoid permission issues
             rm -f nginx/scripts/renew-certs.sh 2>/dev/null || true
+            # Debug: Check directory state before download
+            echo "DEBUG: Directory state before download:"
+            ls -la nginx/scripts/
+            # Test if directory is writable
+            touch nginx/scripts/test.tmp && rm nginx/scripts/test.tmp || echo "DEBUG: Directory not writable"
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
                 echo "ERROR: Failed to download renew-certs.sh"
+                echo "DEBUG: Directory state after failed download:"
+                ls -la nginx/scripts/
                 exit 1
             fi
 

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -211,6 +211,8 @@ jobs:
             fi
 
             # Download refactor platform nginx let's encrypt ssl cert renewal script
+            # Remove existing file first to avoid permission issues
+            rm -f nginx/scripts/renew-certs.sh 2>/dev/null || true
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
                 echo "ERROR: Failed to download renew-certs.sh"
                 exit 1

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -181,24 +181,14 @@ jobs:
               fi
             }
 
-            # CRITICAL: Verify we're running on the target server, not GitHub Actions runner
-            echo "===== SSH CONNECTION DIAGNOSTICS ====="
-            echo "DEBUG: Hostname: $(hostname)"
-            echo "DEBUG: Current user: $(whoami)"
-            echo "DEBUG: Home directory: $HOME"
-            echo "DEBUG: Current working directory: $(pwd)"
-            echo "DEBUG: Available disk space:"
-            df -h / | head -2
-            echo "DEBUG: Network interfaces:"
-            ip addr show | grep -E "inet|UP" | head -5
-            echo "========================================="
-
-            # Verify we're on the target server (not GitHub Actions runner)
+            # Verify SSH execution is working correctly
             if [[ "$(hostname)" == *"runner"* ]] || [[ "$(pwd)" == *"runner"* ]]; then
                 echo "FATAL ERROR: Script is running on GitHub Actions runner instead of target server!"
                 echo "SSH connection failed - aborting deployment"
                 exit 1
             fi
+            
+            echo "INFO: Connected to deployment target successfully"
 
             echo 'INFO: 📦 Starting deployment from branch: ${{ github.ref_name }}...'
             
@@ -227,76 +217,23 @@ jobs:
             echo "INFO: 🛑 Stopping Refactor Platform service before nginx setup..."
             sudo systemctl stop refactor-platform.service
             
+            # Set trap early to ensure service restart on any failure during nginx setup
+            trap 'echo "INFO: 🔄 Ensuring Refactor Platform service is running..."; if systemctl list-unit-files | grep -q "refactor-platform.service"; then sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"; else echo "WARNING: refactor-platform.service not found during cleanup"; fi' EXIT
+            
             echo "INFO: Creating nginx directories..."
             if ! mkdir -p nginx/conf.d nginx/logs nginx/scripts nginx/html/.well-known/acme-challenge; then
               echo "ERROR: Failed to create nginx directories"
               exit 1
             fi
 
-            # Debug: Verify all directories were created
-            echo "DEBUG: Checking created directories:"
-            ls -la nginx/
-            echo "DEBUG: Checking scripts directory specifically:"
-            ls -la nginx/scripts/ || echo "DEBUG: scripts directory missing"
-
             echo "INFO: Setting initial directory permissions..."
             # Ensure current user owns the nginx directory tree
             chown -R $(whoami):$(whoami) nginx/ 2>/dev/null || true
-            echo "DEBUG: Before chmod - checking scripts directory:"
-            ls -la nginx/scripts/ || echo "DEBUG: scripts directory missing before chmod"
             # Set restrictive directory permissions initially
             find nginx -type d -exec chmod 755 {} \;
-            echo "DEBUG: After chmod - checking scripts directory:"
-            ls -la nginx/scripts/ || echo "DEBUG: scripts directory missing after chmod"
 
             echo "INFO: Downloading nginx configuration files..."
 
-            # COMPREHENSIVE DEBUGGING - Remove after issue is resolved
-            echo "=================== COMPREHENSIVE DEBUG START ==================="
-            echo "DEBUG: Current working directory: $(pwd)"
-            echo "DEBUG: Current user: $(whoami)"
-            echo "DEBUG: Current groups: $(groups)"
-            echo "DEBUG: Available disk space:"
-            df -h . | head -2
-            echo "DEBUG: Complete nginx structure before downloads:"
-            find nginx -ls 2>/dev/null || echo "DEBUG: find command failed"
-            echo "DEBUG: Running processes that might interfere:"
-            ps aux | grep -E "(nginx|docker|systemd)" | head -10
-            echo "DEBUG: Docker container status:"
-            docker ps -a 2>/dev/null | head -5 || echo "DEBUG: Docker not accessible"
-            echo "DEBUG: Mount points that could affect nginx directory:"
-            mount | grep -E "(nginx|/home)" || echo "DEBUG: No relevant mounts found"
-            echo "DEBUG: File system type:"
-            df -T . | tail -1
-            echo "DEBUG: Testing directory stability with delay:"
-            ls -la nginx/scripts/ || echo "DEBUG: scripts missing at checkpoint 1"
-            sleep 1
-            ls -la nginx/scripts/ || echo "DEBUG: scripts missing at checkpoint 2"  
-            echo "DEBUG: Attempting to recreate scripts directory:"
-            mkdir -p nginx/scripts
-            ls -la nginx/scripts/ || echo "DEBUG: Failed to recreate scripts directory"
-            echo "DEBUG: Testing file creation in scripts:"
-            touch nginx/scripts/debug-test.txt 2>/dev/null && echo "DEBUG: File creation successful" || echo "DEBUG: File creation failed"
-            ls -la nginx/scripts/
-            echo "=================== COMPREHENSIVE DEBUG END ==================="
-
-            # FINAL DEBUG: Monitor what happens in the critical moment
-            echo "DEBUG: Starting critical monitoring..."
-            ls -la nginx/scripts/ || echo "DEBUG: scripts missing before monitoring"
-            
-            # Monitor background processes during this critical window
-            (ps aux | grep -E "(logrotate|cron|systemd)" | head -5) &
-            
-            # Check for any systemd timers or services that might interfere
-            echo "DEBUG: Active systemd timers:"
-            systemctl list-timers --all 2>/dev/null | grep -E "(nginx|log|clean)" | head -3 || echo "DEBUG: No relevant timers"
-            
-            echo "DEBUG: Checking for file watchers or background processes:"
-            lsof /home/deploy/nginx 2>/dev/null | head -5 || echo "DEBUG: No processes have nginx directory open"
-            
-            # One final check right before download
-            echo "DEBUG: Final directory check:"
-            ls -la nginx/scripts/ || echo "DEBUG: scripts missing at final check"
 
             # Download main nginx config
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/nginx.conf" -o nginx/nginx.conf; then
@@ -375,9 +312,6 @@ jobs:
 
             echo "INFO: Nginx setup completed successfully!"
 
-            # Now set trap to ensure service restart on any subsequent failure  
-            trap 'echo "INFO: 🔄 Ensuring Refactor Platform service is running..."; if systemctl list-unit-files | grep -q "refactor-platform.service"; then sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"; else echo "WARNING: refactor-platform.service not found during cleanup"; fi' EXIT
-
             echo "INFO: 🔧 Matching .env permissions to docker-compose.yaml..."
             # Update env file permissions
             # Copy permissions from compose file
@@ -416,28 +350,21 @@ jobs:
 
             echo "INFO: 🔍 Validating config..."
             # Verify docker-compose configuration
-            echo "DEBUG: Current directory: $(pwd)"
-            echo "DEBUG: Files in current directory:"
-            ls -la *.yaml 2>/dev/null || echo "No YAML files found"
             if [ -f docker-compose.yaml ]; then
                 docker compose config --quiet
             else
                 echo "WARNING: docker-compose.yaml not found, skipping config validation"
             fi
-            # Check config without output unless error
 
             echo "INFO: 🚀 Starting Refactor Platform service..."
             
             # Verify systemd service exists before attempting to start
             if systemctl list-unit-files | grep -q "refactor-platform.service"; then
-                echo "DEBUG: refactor-platform.service found"
                 sudo systemctl start refactor-platform.service
             else
                 echo "ERROR: refactor-platform.service not found"
-                echo "DEBUG: Available services matching 'refactor':"
+                echo "Available services matching 'refactor':"
                 systemctl list-unit-files | grep -i refactor || echo "No refactor services found"
-                echo "DEBUG: All systemd service files:"
-                systemctl list-unit-files | head -10
                 exit 1
             fi
 

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -1,39 +1,39 @@
-name: Deploy to DigitalOcean via Tailscale  # Workflow name displayed in GitHub UI
+name: Deploy to DigitalOcean via Tailscale # Workflow name displayed in GitHub UI
 # Deploys the latest stable tagged container images to production servers.
 
 # Manual trigger with debug ssh option
 on:
-  workflow_dispatch:  # Manual trigger via GitHub UI
+  workflow_dispatch: # Manual trigger via GitHub UI
     inputs:
-      enable_ssh_debugging:  # Optional debugging parameter useful to debug the ssh connection to the server
-        description: 'Enable verbose SSH debugging'  # Help text shown in UI
-        required: false  # Not required to run the workflow
-        default: false  # Disabled by default
-        type: boolean  # Simple checkbox in the UI
+      enable_ssh_debugging: # Optional debugging parameter useful to debug the ssh connection to the server
+        description: "Enable verbose SSH debugging" # Help text shown in UI
+        required: false # Not required to run the workflow
+        default: false # Disabled by default
+        type: boolean # Simple checkbox in the UI
 
 permissions:
-  contents: read  # Minimal permissions required for this workflow
+  contents: read # Minimal permissions required for this workflow
 
 jobs:
   deploy:
-    name: Manual Deploy Over Tailscale  # Display name for this job
+    name: Manual Deploy Over Tailscale # Display name for this job
     runs-on: ubuntu-24.04
-    environment: production             # Use the production environment settings
+    environment: production # Use the production environment settings
 
     steps:
       # Step 1: Setup Tailscale on the GitHub Actions runner
-      - name: Set up Tailscale  # Connect to the Tailscale network
-        uses: tailscale/github-action@v3  # Official Tailscale GitHub Action
+      - name: Set up Tailscale # Connect to the Tailscale network
+        uses: tailscale/github-action@v3 # Official Tailscale GitHub Action
         with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}  # OAuth client ID for Tailscale
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}  # OAuth client secret for Tailscale
-          tags: tag:github-actions  # Tag to identify this connection in Tailscale
-          version: latest  # Use the latest version of Tailscale
-          use-cache: 'true'  # Cache Tailscale binary for faster startup
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }} # OAuth client ID for Tailscale
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }} # OAuth client secret for Tailscale
+          tags: tag:github-actions # Tag to identify this connection in Tailscale
+          version: latest # Use the latest version of Tailscale
+          use-cache: "true" # Cache Tailscale binary for faster startup
 
       # Step 2: (Debug only) Verifies SSH ED25519 SSH key
-      - name: Debug ED25519 Key  # SSH key debugging step
-        if: ${{ inputs.enable_ssh_debugging == true }}  # Only run when debugging is enabled
+      - name: Debug ED25519 Key # SSH key debugging step
+        if: ${{ inputs.enable_ssh_debugging == true }} # Only run when debugging is enabled
         run: |
           mkdir -p ~/.ssh
           # Create SSH directory if it doesn't exist
@@ -51,7 +51,7 @@ jobs:
           # Test connection with verbose output
 
       # Step 3: Create .env File Locally
-      - name: Create .env File on Server  # Create environment file for deployment
+      - name: Create .env File on Server # Create environment file for deployment
         run: |
           cat > envfile <<EOF
           # Start heredoc to create env file
@@ -199,7 +199,7 @@ jobs:
 
             # Verify the main nginx config file was downloaded and is not empty
             if [ ! -s nginx/nginx.conf ]; then
-                log_error "Downloaded nginx.conf is empty or doesn't exist"
+                log_error "Downloaded nginx.conf is empty or could not be created"
                 exit 1
             fi
 
@@ -211,9 +211,23 @@ jobs:
 
             # Verify the platform config file was downloaded and is not empty
             if [ ! -s nginx/conf.d/refactor-platform.conf ]; then
-                log_error "Downloaded refactor-platform.conf is empty or doesn't exist"
+                log_error "Downloaded refactor-platform.conf is empty or could not be created"
                 exit 1
             fi
+
+            # Download refactor platform nginx let's encrypt ssl cert renewal script
+            if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
+                log_error "Failed to download renew-certs.sh"
+                exit 1
+            fi
+
+            # Verify the renew certs script file was downloaded and is not empty
+            if [ ! -s nginx/scripts/renew-certs.sh ]; then
+                log_error "Downloaded renew-certs.sh script is empty or could not be created"
+                exit 1
+            fi
+
+            chmod 770 nginx/scripts/renew-certs.sh
 
             log_info "Nginx setup completed successfully!"
 

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -234,6 +234,24 @@ jobs:
             ls -la nginx/scripts/
             echo "=================== COMPREHENSIVE DEBUG END ==================="
 
+            # FINAL DEBUG: Monitor what happens in the critical moment
+            echo "DEBUG: Starting critical monitoring..."
+            ls -la nginx/scripts/ || echo "DEBUG: scripts missing before monitoring"
+            
+            # Monitor background processes during this critical window
+            (ps aux | grep -E "(logrotate|cron|systemd)" | head -5) &
+            
+            # Check for any systemd timers or services that might interfere
+            echo "DEBUG: Active systemd timers:"
+            systemctl list-timers --all 2>/dev/null | grep -E "(nginx|log|clean)" | head -3 || echo "DEBUG: No relevant timers"
+            
+            echo "DEBUG: Checking for file watchers or background processes:"
+            lsof /home/deploy/nginx 2>/dev/null | head -5 || echo "DEBUG: No processes have nginx directory open"
+            
+            # One final check right before download
+            echo "DEBUG: Final directory check:"
+            ls -la nginx/scripts/ || echo "DEBUG: scripts missing at final check"
+
             # Download main nginx config
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/nginx.conf" -o nginx/nginx.conf; then
                 echo "ERROR: Failed to download nginx.conf"
@@ -259,18 +277,26 @@ jobs:
             fi
 
             # Download refactor platform nginx let's encrypt ssl cert renewal script
+            # Handle potential directory issues with robust retry logic
+            echo "DEBUG: Preparing to download renew-certs.sh..."
+            
+            # Ensure scripts directory exists (recreate if needed)
+            if [ ! -d nginx/scripts ]; then
+                echo "DEBUG: Scripts directory missing, recreating..."
+                mkdir -p nginx/scripts
+            fi
+            
             # Remove existing file first to avoid permission issues
             rm -f nginx/scripts/renew-certs.sh 2>/dev/null || true
-            # Debug: Check directory state before download
-            echo "DEBUG: Directory state before download:"
-            ls -la nginx/scripts/
-            # Test if directory is writable
-            touch nginx/scripts/test.tmp && rm nginx/scripts/test.tmp || echo "DEBUG: Directory not writable"
+            
+            # Download with retry if directory disappears
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
-                echo "ERROR: Failed to download renew-certs.sh"
-                echo "DEBUG: Directory state after failed download:"
-                ls -la nginx/scripts/
-                exit 1
+                echo "DEBUG: First download attempt failed, recreating directory and retrying..."
+                mkdir -p nginx/scripts
+                if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
+                    echo "ERROR: Failed to download renew-certs.sh after retry"
+                    exit 1
+                fi
             fi
 
             # Verify the renew certs script file was downloaded and is not empty

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -147,12 +147,26 @@ jobs:
           ssh-keyscan -H ${{ secrets.DO_TAILSCALE_NAME }} >> ~/.ssh/known_hosts
           # Add dynamic host key
 
+          # Test SSH connection first
+          echo "Testing SSH connection to ${{ secrets.DO_TAILSCALE_NAME }}..."
+          if ! ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10 -i ~/.ssh/id_ed25519 ${{ secrets.DO_USERNAME }}@${{ secrets.DO_TAILSCALE_NAME }} 'echo "SSH connection successful"'; then
+            echo "ERROR: SSH connection failed to ${{ secrets.DO_TAILSCALE_NAME }}"
+            echo "Checking SSH configuration..."
+            ssh -vvv -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=10 -i ~/.ssh/id_ed25519 ${{ secrets.DO_USERNAME }}@${{ secrets.DO_TAILSCALE_NAME }} 'echo "test"' || true
+            exit 1
+          fi
+
           # Copy .env to server
-          scp -o StrictHostKeyChecking=accept-new -i ~/.ssh/id_ed25519 envfile ${{ secrets.DO_USERNAME }}@${{ secrets.DO_TAILSCALE_NAME }}:/home/deploy/.env
+          echo "Copying .env file to server..."
+          if ! scp -o StrictHostKeyChecking=accept-new -o ConnectTimeout=10 -i ~/.ssh/id_ed25519 envfile ${{ secrets.DO_USERNAME }}@${{ secrets.DO_TAILSCALE_NAME }}:/home/deploy/.env; then
+            echo "ERROR: Failed to copy .env file"
+            exit 1
+          fi
           # Upload env file
 
           # SSH and deploy
-          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -i ~/.ssh/id_ed25519 ${{ secrets.DO_USERNAME }}@${{ secrets.DO_TAILSCALE_NAME }} '
+          echo "Starting main deployment script..."
+          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=30 -i ~/.ssh/id_ed25519 ${{ secrets.DO_USERNAME }}@${{ secrets.DO_TAILSCALE_NAME }} '
             set -e
             # Exit immediately if any command fails
 

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -156,11 +156,6 @@ jobs:
             set -e
             # Exit immediately if any command fails
 
-            # Function to log errors
-            log_error() {
-              echo "ERROR: $1"
-            }
-
             # Function to log info
             log_info() {
               echo "INFO: $1"
@@ -173,57 +168,57 @@ jobs:
 
             # Check if docker-compose.yaml exists before using it as reference
             if [ ! -f docker-compose.yaml ]; then
-                log_error "docker-compose.yaml not found - cannot set permissions"
+                echo "ERROR: docker-compose.yaml not found - cannot set permissions"
                 exit 1
             fi
 
             log_info "Creating nginx directories..."
-            if ! mkdir -p nginx/conf.d nginx/logs; then
-              log_error "Failed to create nginx directories"
+            if ! mkdir -p nginx/conf.d nginx/logs nginx/scripts nginx/html/.well-known/acme-challenge; then
+              echo "ERROR: Failed to create nginx directories"
               exit 1
             fi
 
             log_info "Setting permissions..."
             # Set directory permissions
             find nginx -type d -exec chmod 770 {} \;
-            # Set file permissions  
-            find nginx -type f -exec chmod 660 {} \;
+            # Set file permissions (only if they exist and are writable)
+            find nginx -type f -exec chmod 660 {} \; 2>/dev/null || true
 
             log_info "Downloading nginx configuration files..."
 
             # Download main nginx config
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/nginx.conf" -o nginx/nginx.conf; then
-                log_error "Failed to download nginx.conf"
+                echo "ERROR: Failed to download nginx.conf"
                 exit 1
             fi
 
             # Verify the main nginx config file was downloaded and is not empty
             if [ ! -s nginx/nginx.conf ]; then
-                log_error "Downloaded nginx.conf is empty or could not be created"
+                echo "ERROR: Downloaded nginx.conf is empty or could not be created"
                 exit 1
             fi
 
             # Download refactor platform nginx reverse proxy config
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/conf.d/refactor-platform.conf" -o nginx/conf.d/refactor-platform.conf; then
-                log_error "Failed to download refactor-platform.conf"
+                echo "ERROR: Failed to download refactor-platform.conf"
                 exit 1
             fi
 
             # Verify the platform config file was downloaded and is not empty
             if [ ! -s nginx/conf.d/refactor-platform.conf ]; then
-                log_error "Downloaded refactor-platform.conf is empty or could not be created"
+                echo "ERROR: Downloaded refactor-platform.conf is empty or could not be created"
                 exit 1
             fi
 
             # Download refactor platform nginx let's encrypt ssl cert renewal script
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
-                log_error "Failed to download renew-certs.sh"
+                echo "ERROR: Failed to download renew-certs.sh"
                 exit 1
             fi
 
             # Verify the renew certs script file was downloaded and is not empty
             if [ ! -s nginx/scripts/renew-certs.sh ]; then
-                log_error "Downloaded renew-certs.sh script is empty or could not be created"
+                echo "ERROR: Downloaded renew-certs.sh script is empty or could not be created"
                 exit 1
             fi
 
@@ -287,7 +282,7 @@ jobs:
             if docker ps | grep -q rust-app; then
               log_info "✅ Deployment succeeded! rust-app is running."
             else
-              log_error "⚠️ Missing container for rust-app. Logs follow:"
+              echo "ERROR: ⚠️ Missing container for rust-app. Logs follow:"
               # Show backend logs
               docker logs rust-app --tail 30 2>/dev/null || echo "❌ Backend logs unavailable"
             fi

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -353,7 +353,8 @@ jobs:
             if [ -f docker-compose.yaml ]; then
                 docker compose config --quiet
             else
-                echo "WARNING: docker-compose.yaml not found, skipping config validation"
+                echo "ERROR: docker-compose.yaml not found - cannot validate configuration"
+                exit 1
             fi
 
             echo "INFO: 🚀 Starting Refactor Platform service..."

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -330,8 +330,8 @@ jobs:
 
             echo "INFO: Nginx setup completed successfully!"
 
-            # Now set trap to ensure service restart on any subsequent failure
-            trap cleanup EXIT
+            # Now set trap to ensure service restart on any subsequent failure  
+            trap 'echo "INFO: 🔄 Ensuring Refactor Platform service is running..."; sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"' EXIT
 
             echo "INFO: 🔧 Matching .env permissions to docker-compose.yaml..."
             # Update env file permissions
@@ -371,7 +371,14 @@ jobs:
 
             echo "INFO: 🔍 Validating config..."
             # Verify docker-compose configuration
-            docker compose config --quiet
+            echo "DEBUG: Current directory: $(pwd)"
+            echo "DEBUG: Files in current directory:"
+            ls -la *.yaml 2>/dev/null || echo "No YAML files found"
+            if [ -f docker-compose.yaml ]; then
+                docker compose config --quiet
+            else
+                echo "WARNING: docker-compose.yaml not found, skipping config validation"
+            fi
             # Check config without output unless error
 
             echo "INFO: 🚀 Starting Refactor Platform service..."

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -178,6 +178,12 @@ jobs:
               exit 1
             fi
 
+            # Debug: Verify all directories were created
+            echo "DEBUG: Checking created directories:"
+            ls -la nginx/
+            echo "DEBUG: Checking scripts directory specifically:"
+            ls -la nginx/scripts/ || echo "DEBUG: scripts directory missing"
+
             log_info "Setting initial directory permissions..."
             # Ensure current user owns the nginx directory tree
             chown -R $(whoami):$(whoami) nginx/ 2>/dev/null || true

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -238,10 +238,6 @@ jobs:
             # Copy ownership from compose file
             chown --reference=docker-compose.yaml .env
 
-            log_info "📋 Showing masked .env:"
-            # Display environment with sensitive data masked
-            sed "s/POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=***/g; s/TIPTAP_AUTH_KEY=.*/TIPTAP_AUTH_KEY=***/g; s/TIPTAP_JWT_SIGNING_KEY=.*/TIPTAP_JWT_SIGNING_KEY=***/g" .env
-
             log_info "📥 Logging into GHCR..."
             # Login to GitHub Container Registry
             echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -178,11 +178,11 @@ jobs:
               exit 1
             fi
 
-            log_info "Setting permissions..."
-            # Set directory permissions
-            find nginx -type d -exec chmod 770 {} \;
-            # Set file permissions (only if they exist and are writable)
-            find nginx -type f -exec chmod 660 {} \; 2>/dev/null || true
+            log_info "Setting initial directory permissions..."
+            # Ensure current user owns the nginx directory tree
+            chown -R $(whoami):$(whoami) nginx/ 2>/dev/null || true
+            # Set restrictive directory permissions initially
+            find nginx -type d -exec chmod 755 {} \;
 
             log_info "Downloading nginx configuration files..."
 
@@ -222,6 +222,14 @@ jobs:
                 exit 1
             fi
 
+            chmod 770 nginx/scripts/renew-certs.sh
+
+            log_info "Setting final directory permissions..."
+            # Set final directory permissions to allow group write access
+            find nginx -type d -exec chmod 770 {} \;
+            # Set file permissions for downloaded files
+            find nginx -type f -exec chmod 660 {} \; 2>/dev/null || true
+            # Make the renewal script executable
             chmod 770 nginx/scripts/renew-certs.sh
 
             log_info "Nginx setup completed successfully!"

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -167,9 +167,6 @@ jobs:
               sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"
             }
 
-            # Set trap to run cleanup on any exit (success or failure)
-            trap cleanup EXIT
-
             log_info '📦 Starting deployment from branch: ${{ github.ref_name }}...'
             cd /home/deploy
             curl -O https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/docker-compose.yaml
@@ -293,6 +290,9 @@ jobs:
             chmod 770 nginx/scripts/renew-certs.sh
 
             log_info "Nginx setup completed successfully!"
+
+            # Now set trap to ensure service restart on any subsequent failure
+            trap cleanup EXIT
 
             log_info "🔧 Matching .env permissions to docker-compose.yaml..."
             # Update env file permissions

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -314,14 +314,19 @@ jobs:
             echo "INFO: Nginx setup completed successfully!"
 
             # Now set trap to ensure service restart on any subsequent failure
-            trap cleanup EXIT
+            # trap cleanup EXIT
 
             echo "INFO: 🔧 Matching .env permissions to docker-compose.yaml..."
             # Update env file permissions
             # Copy permissions from compose file
-            chmod --reference=docker-compose.yaml .env
-            # Copy ownership from compose file
-            chown --reference=docker-compose.yaml .env
+            if [ -f docker-compose.yaml ]; then
+                chmod --reference=docker-compose.yaml .env
+                # Copy ownership from compose file
+                chown --reference=docker-compose.yaml .env
+            else
+                echo "WARNING: docker-compose.yaml not found, setting default .env permissions"
+                chmod 640 .env
+            fi
 
             echo "INFO: 📥 Logging into GHCR..."
             # Login to GitHub Container Registry

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -261,11 +261,11 @@ jobs:
 
             # Download refactor platform nginx let's encrypt ssl cert renewal script
             # Handle potential directory issues with robust retry logic
-            echo "DEBUG: Preparing to download renew-certs.sh..."
+            echo "INFO: Preparing to download renew-certs.sh..."
             
             # Ensure scripts directory exists (recreate if needed)
             if [ ! -d nginx/scripts ]; then
-                echo "DEBUG: Scripts directory missing, recreating..."
+                echo "INFO: Scripts directory missing, recreating..."
                 mkdir -p nginx/scripts
             fi
             
@@ -274,7 +274,7 @@ jobs:
             
             # Download with retry if directory disappears
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
-                echo "DEBUG: First download attempt failed, recreating directory and retrying..."
+                echo "INFO: First download attempt failed, recreating directory and retrying..."
                 mkdir -p nginx/scripts
                 if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
                     echo "ERROR: Failed to download renew-certs.sh after retry"

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -166,7 +166,7 @@ jobs:
 
           # SSH and deploy
           echo "Starting main deployment script..."
-          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=30 -i ~/.ssh/id_ed25519 ${{ secrets.DO_USERNAME }}@${{ secrets.DO_TAILSCALE_NAME }} '
+          ssh -o StrictHostKeyChecking=accept-new -o BatchMode=yes -o ConnectTimeout=30 -i ~/.ssh/id_ed25519 ${{ secrets.DO_USERNAME }}@${{ secrets.DO_TAILSCALE_NAME }} 'bash -s' << 'DEPLOY_SCRIPT_EOF'
             set -e
             # Exit immediately if any command fails
 
@@ -464,4 +464,4 @@ jobs:
 
             echo "INFO: 🎉 Deployment complete."
             # Final deployment message
-          '
+          DEPLOY_SCRIPT_EOF

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -187,8 +187,12 @@ jobs:
             log_info "Setting initial directory permissions..."
             # Ensure current user owns the nginx directory tree
             chown -R $(whoami):$(whoami) nginx/ 2>/dev/null || true
+            echo "DEBUG: Before chmod - checking scripts directory:"
+            ls -la nginx/scripts/ || echo "DEBUG: scripts directory missing before chmod"
             # Set restrictive directory permissions initially
             find nginx -type d -exec chmod 755 {} \;
+            echo "DEBUG: After chmod - checking scripts directory:"
+            ls -la nginx/scripts/ || echo "DEBUG: scripts directory missing after chmod"
 
             log_info "Downloading nginx configuration files..."
 

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -272,15 +272,20 @@ jobs:
             # Remove existing file first to avoid permission issues
             rm -f nginx/scripts/renew-certs.sh 2>/dev/null || true
             
-            # Download with retry if directory disappears
-            if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
-                echo "INFO: First download attempt failed, recreating directory and retrying..."
-                mkdir -p nginx/scripts
-                if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
-                    echo "ERROR: Failed to download renew-certs.sh after retry"
+            # Download with exponential backoff retry logic
+            for attempt in {1..3}; do
+                if curl -fsSL --retry 2 "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/scripts/renew-certs.sh" -o nginx/scripts/renew-certs.sh; then
+                    echo "INFO: Successfully downloaded renew-certs.sh on attempt $attempt"
+                    break
+                elif [ $attempt -eq 3 ]; then
+                    echo "ERROR: Failed to download renew-certs.sh after 3 attempts"
                     exit 1
+                else
+                    echo "INFO: Download attempt $attempt failed, recreating directory and retrying in $((attempt * 2)) seconds..."
+                    mkdir -p nginx/scripts
+                    sleep $((attempt * 2))
                 fi
-            fi
+            done
 
             # Verify the renew certs script file was downloaded and is not empty
             if [ ! -s nginx/scripts/renew-certs.sh ]; then

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -160,11 +160,42 @@ jobs:
             # Cleanup function to ensure service gets restarted even on failure
             cleanup() {
               echo "INFO: 🔄 Ensuring Refactor Platform service is running..."
-              sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"
+              if systemctl list-unit-files | grep -q "refactor-platform.service"; then
+                sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"
+              else
+                echo "WARNING: refactor-platform.service not found during cleanup"
+              fi
             }
 
+            # CRITICAL: Verify we're running on the target server, not GitHub Actions runner
+            echo "===== SSH CONNECTION DIAGNOSTICS ====="
+            echo "DEBUG: Hostname: $(hostname)"
+            echo "DEBUG: Current user: $(whoami)"
+            echo "DEBUG: Home directory: $HOME"
+            echo "DEBUG: Current working directory: $(pwd)"
+            echo "DEBUG: Available disk space:"
+            df -h / | head -2
+            echo "DEBUG: Network interfaces:"
+            ip addr show | grep -E "inet|UP" | head -5
+            echo "========================================="
+
+            # Verify we're on the target server (not GitHub Actions runner)
+            if [[ "$(hostname)" == *"runner"* ]] || [[ "$(pwd)" == *"runner"* ]]; then
+                echo "FATAL ERROR: Script is running on GitHub Actions runner instead of target server!"
+                echo "SSH connection failed - aborting deployment"
+                exit 1
+            fi
+
             echo 'INFO: 📦 Starting deployment from branch: ${{ github.ref_name }}...'
-            cd /home/deploy
+            
+            # Ensure we're in the correct directory
+            cd /home/deploy || { 
+                echo "FATAL ERROR: Cannot change to /home/deploy directory"
+                echo "Current directory: $(pwd)"
+                echo "Directory contents:"
+                ls -la
+                exit 1
+            }
             curl -O https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/docker-compose.yaml
             if [ -f docker-compose.yaml ]; then
                 chmod 640 docker-compose.yaml
@@ -331,7 +362,7 @@ jobs:
             echo "INFO: Nginx setup completed successfully!"
 
             # Now set trap to ensure service restart on any subsequent failure  
-            trap 'echo "INFO: 🔄 Ensuring Refactor Platform service is running..."; sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"' EXIT
+            trap 'echo "INFO: 🔄 Ensuring Refactor Platform service is running..."; if systemctl list-unit-files | grep -q "refactor-platform.service"; then sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"; else echo "WARNING: refactor-platform.service not found during cleanup"; fi' EXIT
 
             echo "INFO: 🔧 Matching .env permissions to docker-compose.yaml..."
             # Update env file permissions
@@ -382,7 +413,19 @@ jobs:
             # Check config without output unless error
 
             echo "INFO: 🚀 Starting Refactor Platform service..."
-            sudo systemctl start refactor-platform.service
+            
+            # Verify systemd service exists before attempting to start
+            if systemctl list-unit-files | grep -q "refactor-platform.service"; then
+                echo "DEBUG: refactor-platform.service found"
+                sudo systemctl start refactor-platform.service
+            else
+                echo "ERROR: refactor-platform.service not found"
+                echo "DEBUG: Available services matching 'refactor':"
+                systemctl list-unit-files | grep -i refactor || echo "No refactor services found"
+                echo "DEBUG: All systemd service files:"
+                systemctl list-unit-files | head -10
+                exit 1
+            fi
 
             echo "INFO: ⏳ Waiting for startup..."
             # Wait for containers to reach steady state

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -166,7 +166,12 @@ jobs:
             echo 'INFO: 📦 Starting deployment from branch: ${{ github.ref_name }}...'
             cd /home/deploy
             curl -O https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/docker-compose.yaml
-            chmod 640 docker-compose.yaml
+            if [ -f docker-compose.yaml ]; then
+                chmod 640 docker-compose.yaml
+            else
+                echo "ERROR: Failed to download docker-compose.yaml"
+                exit 1
+            fi
 
             # Check if docker-compose.yaml exists before using it as reference
             if [ ! -f docker-compose.yaml ]; then
@@ -301,31 +306,45 @@ jobs:
                 exit 1
             fi
 
-            chmod 770 nginx/scripts/renew-certs.sh
+            if [ -f nginx/scripts/renew-certs.sh ]; then
+                chmod 770 nginx/scripts/renew-certs.sh
+            else
+                echo "WARNING: renew-certs.sh not found for initial chmod"
+            fi
 
             echo "INFO: Setting final directory permissions..."
             # Set final directory permissions to allow group write access
-            find nginx -type d -exec chmod 770 {} \;
-            # Set file permissions for downloaded files
-            find nginx -type f -exec chmod 660 {} \; 2>/dev/null || true
-            # Make the renewal script executable
-            chmod 770 nginx/scripts/renew-certs.sh
+            if [ -d nginx ]; then
+                find nginx -type d -exec chmod 770 {} \;
+                # Set file permissions for downloaded files
+                find nginx -type f -exec chmod 660 {} \; 2>/dev/null || true
+                # Make the renewal script executable
+                if [ -f nginx/scripts/renew-certs.sh ]; then
+                    chmod 770 nginx/scripts/renew-certs.sh
+                else
+                    echo "WARNING: renew-certs.sh not found for final chmod"
+                fi
+            else
+                echo "WARNING: nginx directory not found for final permissions"
+            fi
 
             echo "INFO: Nginx setup completed successfully!"
 
             # Now set trap to ensure service restart on any subsequent failure
-            # trap cleanup EXIT
+            trap cleanup EXIT
 
             echo "INFO: 🔧 Matching .env permissions to docker-compose.yaml..."
             # Update env file permissions
             # Copy permissions from compose file
-            if [ -f docker-compose.yaml ]; then
+            if [ -f docker-compose.yaml ] && [ -f .env ]; then
                 chmod --reference=docker-compose.yaml .env
                 # Copy ownership from compose file
                 chown --reference=docker-compose.yaml .env
-            else
+            elif [ -f .env ]; then
                 echo "WARNING: docker-compose.yaml not found, setting default .env permissions"
                 chmod 640 .env
+            else
+                echo "WARNING: .env file not found, skipping permission setting"
             fi
 
             echo "INFO: 📥 Logging into GHCR..."

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -295,14 +295,14 @@ jobs:
             fi
 
             echo "INFO: Setting final directory permissions..."
-            # Set final directory permissions to allow group write access
+            # Set final directory permissions to allow nginx to serve ACME challenges
             if [ -d nginx ]; then
-                find nginx -type d -exec chmod 770 {} \;
+                find nginx -type d -exec chmod 755 {} \;
                 # Set file permissions for downloaded files
-                find nginx -type f -exec chmod 660 {} \; 2>/dev/null || true
+                find nginx -type f -exec chmod 644 {} \; 2>/dev/null || true
                 # Make the renewal script executable
                 if [ -f nginx/scripts/renew-certs.sh ]; then
-                    chmod 770 nginx/scripts/renew-certs.sh
+                    chmod 755 nginx/scripts/renew-certs.sh
                 else
                     echo "WARNING: renew-certs.sh not found for final chmod"
                 fi

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -156,10 +156,6 @@ jobs:
             set -e
             # Exit immediately if any command fails
 
-            # Function to log info
-            log_info() {
-              echo "INFO: $1"
-            }
 
             # Cleanup function to ensure service gets restarted even on failure
             cleanup() {
@@ -167,7 +163,7 @@ jobs:
               sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"
             }
 
-            log_info '📦 Starting deployment from branch: ${{ github.ref_name }}...'
+            echo 'INFO: 📦 Starting deployment from branch: ${{ github.ref_name }}...'
             cd /home/deploy
             curl -O https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/docker-compose.yaml
             chmod 640 docker-compose.yaml
@@ -178,10 +174,10 @@ jobs:
                 exit 1
             fi
 
-            log_info "🛑 Stopping Refactor Platform service before nginx setup..."
+            echo "INFO: 🛑 Stopping Refactor Platform service before nginx setup..."
             sudo systemctl stop refactor-platform.service
             
-            log_info "Creating nginx directories..."
+            echo "INFO: Creating nginx directories..."
             if ! mkdir -p nginx/conf.d nginx/logs nginx/scripts nginx/html/.well-known/acme-challenge; then
               echo "ERROR: Failed to create nginx directories"
               exit 1
@@ -193,7 +189,7 @@ jobs:
             echo "DEBUG: Checking scripts directory specifically:"
             ls -la nginx/scripts/ || echo "DEBUG: scripts directory missing"
 
-            log_info "Setting initial directory permissions..."
+            echo "INFO: Setting initial directory permissions..."
             # Ensure current user owns the nginx directory tree
             chown -R $(whoami):$(whoami) nginx/ 2>/dev/null || true
             echo "DEBUG: Before chmod - checking scripts directory:"
@@ -203,7 +199,7 @@ jobs:
             echo "DEBUG: After chmod - checking scripts directory:"
             ls -la nginx/scripts/ || echo "DEBUG: scripts directory missing after chmod"
 
-            log_info "Downloading nginx configuration files..."
+            echo "INFO: Downloading nginx configuration files..."
 
             # COMPREHENSIVE DEBUGGING - Remove after issue is resolved
             echo "=================== COMPREHENSIVE DEBUG START ==================="
@@ -307,7 +303,7 @@ jobs:
 
             chmod 770 nginx/scripts/renew-certs.sh
 
-            log_info "Setting final directory permissions..."
+            echo "INFO: Setting final directory permissions..."
             # Set final directory permissions to allow group write access
             find nginx -type d -exec chmod 770 {} \;
             # Set file permissions for downloaded files
@@ -315,69 +311,69 @@ jobs:
             # Make the renewal script executable
             chmod 770 nginx/scripts/renew-certs.sh
 
-            log_info "Nginx setup completed successfully!"
+            echo "INFO: Nginx setup completed successfully!"
 
             # Now set trap to ensure service restart on any subsequent failure
             trap cleanup EXIT
 
-            log_info "🔧 Matching .env permissions to docker-compose.yaml..."
+            echo "INFO: 🔧 Matching .env permissions to docker-compose.yaml..."
             # Update env file permissions
             # Copy permissions from compose file
             chmod --reference=docker-compose.yaml .env
             # Copy ownership from compose file
             chown --reference=docker-compose.yaml .env
 
-            log_info "📥 Logging into GHCR..."
+            echo "INFO: 📥 Logging into GHCR..."
             # Login to GitHub Container Registry
             echo ${{ secrets.GHCR_PAT }} | docker login ghcr.io -u ${{ secrets.GHCR_USERNAME }} --password-stdin
             # Docker login
 
-            log_info "📥 Pulling images..."
+            echo "INFO: 📥 Pulling images..."
             # Pull Docker images
             if [ -n "${{ vars.BACKEND_IMAGE_NAME }}" ]; then
               # Check if backend image is set
-              log_info "Pulling backend image: ${{ vars.BACKEND_IMAGE_NAME }}"
+              echo "INFO: Pulling backend image: ${{ vars.BACKEND_IMAGE_NAME }}"
               # Announce image pull
               docker pull ${{ vars.BACKEND_IMAGE_NAME }}
               # Pull backend image
             fi
             if [ -n "${{ vars.FRONTEND_IMAGE_NAME }}" ]; then
               # Check if frontend image is set
-              log_info "Pulling frontend image: ${{ vars.FRONTEND_IMAGE_NAME }}"
+              echo "INFO: Pulling frontend image: ${{ vars.FRONTEND_IMAGE_NAME }}"
               # Announce image pull
               docker pull ${{ vars.FRONTEND_IMAGE_NAME }}
               # Pull frontend image
             fi
 
-            log_info "🔍 Validating config..."
+            echo "INFO: 🔍 Validating config..."
             # Verify docker-compose configuration
             docker compose config --quiet
             # Check config without output unless error
 
-            log_info "🚀 Starting Refactor Platform service..."
+            echo "INFO: 🚀 Starting Refactor Platform service..."
             sudo systemctl start refactor-platform.service
 
-            log_info "⏳ Waiting for startup..."
+            echo "INFO: ⏳ Waiting for startup..."
             # Wait for containers to reach steady state
             sleep 3
 
-            log_info "🩺 Checking service and status..."
+            echo "INFO: 🩺 Checking service and status..."
             systemctl status refactor-platform.service
             # Check container status
             docker ps -a
             # List all containers
 
-            log_info "🩺 Verifying app status..."
+            echo "INFO: 🩺 Verifying app status..."
             # Verify application health
-            log_info "🩺 Checking rust-app service status..."
+            echo "INFO: 🩺 Checking rust-app service status..."
             if docker ps | grep -q rust-app; then
-              log_info "✅ Deployment succeeded! rust-app is running."
+              echo "INFO: ✅ Deployment succeeded! rust-app is running."
             else
               echo "ERROR: ⚠️ Missing container for rust-app. Logs follow:"
               # Show backend logs
               docker logs rust-app --tail 30 2>/dev/null || echo "❌ Backend logs unavailable"
             fi
 
-            log_info "🎉 Deployment complete."
+            echo "INFO: 🎉 Deployment complete."
             # Final deployment message
           '

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -158,7 +158,7 @@ jobs:
 
             # Function to log errors
             log_error() {
-              echo "ERROR: $1" >&2
+              echo "ERROR: $1"
             }
 
             # Function to log info

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -218,7 +218,7 @@ jobs:
             sudo systemctl stop refactor-platform.service
             
             # Set trap early to ensure service restart on any failure during nginx setup
-            trap 'echo "INFO: 🔄 Ensuring Refactor Platform service is running..."; if systemctl list-unit-files | grep -q "refactor-platform.service"; then sudo systemctl start refactor-platform.service 2>/dev/null || echo "WARNING: Failed to restart service"; else echo "WARNING: refactor-platform.service not found during cleanup"; fi' EXIT
+            trap cleanup EXIT
             
             echo "INFO: Creating nginx directories..."
             if ! mkdir -p nginx/conf.d nginx/logs nginx/scripts nginx/html/.well-known/acme-challenge; then

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -196,6 +196,35 @@ jobs:
 
             log_info "Downloading nginx configuration files..."
 
+            # COMPREHENSIVE DEBUGGING - Remove after issue is resolved
+            echo "=================== COMPREHENSIVE DEBUG START ==================="
+            echo "DEBUG: Current working directory: $(pwd)"
+            echo "DEBUG: Current user: $(whoami)"
+            echo "DEBUG: Current groups: $(groups)"
+            echo "DEBUG: Available disk space:"
+            df -h . | head -2
+            echo "DEBUG: Complete nginx structure before downloads:"
+            find nginx -ls 2>/dev/null || echo "DEBUG: find command failed"
+            echo "DEBUG: Running processes that might interfere:"
+            ps aux | grep -E "(nginx|docker|systemd)" | head -10
+            echo "DEBUG: Docker container status:"
+            docker ps -a 2>/dev/null | head -5 || echo "DEBUG: Docker not accessible"
+            echo "DEBUG: Mount points that could affect nginx directory:"
+            mount | grep -E "(nginx|/home)" || echo "DEBUG: No relevant mounts found"
+            echo "DEBUG: File system type:"
+            df -T . | tail -1
+            echo "DEBUG: Testing directory stability with delay:"
+            ls -la nginx/scripts/ || echo "DEBUG: scripts missing at checkpoint 1"
+            sleep 1
+            ls -la nginx/scripts/ || echo "DEBUG: scripts missing at checkpoint 2"  
+            echo "DEBUG: Attempting to recreate scripts directory:"
+            mkdir -p nginx/scripts
+            ls -la nginx/scripts/ || echo "DEBUG: Failed to recreate scripts directory"
+            echo "DEBUG: Testing file creation in scripts:"
+            touch nginx/scripts/debug-test.txt 2>/dev/null && echo "DEBUG: File creation successful" || echo "DEBUG: File creation failed"
+            ls -la nginx/scripts/
+            echo "=================== COMPREHENSIVE DEBUG END ==================="
+
             # Download main nginx config
             if ! curl -fsSL "https://raw.githubusercontent.com/refactor-group/refactor-platform-rs/refs/heads/${{ github.ref_name }}/nginx/nginx.conf" -o nginx/nginx.conf; then
                 echo "ERROR: Failed to download nginx.conf"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,7 +17,9 @@ services:
       - /etc/letsencrypt/live/refactor.engineer/:/etc/letsencrypt/live/refactor.engineer/:ro
       - /etc/letsencrypt/archive/refactor.engineer/:/etc/letsencrypt/archive/refactor.engineer/:ro
       - ${SSL_DHPARAMS_PATH}:/etc/letsencrypt/ssl-dhparams.pem:ro
-      # Optional: nginx logs for debugging
+      # For SSL certbot renewal
+      - ./nginx/html:/var/www/html:ro
+      # nginx logs (access/error) for debugging
       - ./nginx/logs:/var/log/nginx
     depends_on:
       rust-app:

--- a/nginx/conf.d/refactor-platform.conf
+++ b/nginx/conf.d/refactor-platform.conf
@@ -19,7 +19,7 @@ server {
     
     # Allow Let's Encrypt ACME challenge
     location /.well-known/acme-challenge/ {
-        root /var/www/certbot;
+        root /var/www/html;
     }
     
     # Redirect everything else to HTTPS

--- a/nginx/scripts/renew-certs.sh
+++ b/nginx/scripts/renew-certs.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+  # /usr/local/bin/renew-certs.sh
+  # Let's Encrypt certificate renewal script for containerized nginx
+
+  # Set strict error handling
+  set -euo pipefail
+
+  # Define paths
+  WEBROOT_PATH="./nginx/html"
+  CONTAINER_NAME="nginx-reverse-proxy"
+
+  # Function to log messages
+  log() {
+      echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1"
+  }
+
+  # Check if container is running
+  if ! docker ps --filter "name=${CONTAINER_NAME}" --filter "status=running" --quiet | grep -q .; then
+      log "ERROR: Container ${CONTAINER_NAME} is not running"
+      exit 1
+  fi
+
+  log "Starting certificate renewal process"
+
+  # Attempt to renew certificates
+  if certbot renew --webroot -w "${WEBROOT_PATH}" --quiet; then
+      log "Certificate renewal successful"
+
+      # Reload nginx configuration
+      if docker exec "${CONTAINER_NAME}" nginx -s reload; then
+          log "nginx configuration reloaded successfully"
+      else
+          log "ERROR: Failed to reload nginx configuration"
+          exit 1
+      fi
+
+      log "Certificate renewal process completed successfully"
+  else
+      log "ERROR: Certificate renewal failed"
+      exit 1
+  fi

--- a/nginx/scripts/renew-certs.sh
+++ b/nginx/scripts/renew-certs.sh
@@ -22,8 +22,8 @@
 
   log "Starting certificate renewal process"
 
-  # Attempt to renew certificates
-  if certbot renew --webroot -w "${WEBROOT_PATH}" --quiet; then
+  # Attempt to renew certificates (requires sudo for system directories)
+  if sudo certbot renew --webroot -w "${WEBROOT_PATH}" --quiet; then
       log "Certificate renewal successful"
 
       # Reload nginx configuration


### PR DESCRIPTION
## Description
This PR adds a Let's Encrypt SSL cert renewal script, installs it into the deployment process, and sets up a cronjob to run this script twice a day.


#### GitHub Issue: N/A

### Changes
* Adds a Let's Encrypt SSL cert renewal script called renew-cert.sh
* Adds it to deploy_to_do.yml deployment script to install on the DO droplet
* Adds a new cronjob to run this script every 12 hours

### Testing Strategy

1. Test the deployment updates by changing the production env var `BACKEND_IMAGE_NAME` to `ghcr.io/refactor-group/refactor-platform-rs/improve_lets_encrypt_ssl_cert_renewal:latest`

2. Kick off a deployment from GitHub Actions making sure to deploy with the branch `improve_lets_encrypt_ssl_cert_renewal`

3. Test the renewal script in dry-run mode (won't actually renew, just checks):
`sudo certbot renew --webroot -w ./nginx/html --dry-run`

4. If that works, test your actual renewal script:
`./nginx/scripts/renew-certs.sh`

5. Check that the log file was created:
`cat nginx/logs/letsencrypt-renewal.log`

6. Verify nginx is still running and serving your site:
```
docker ps | grep nginx
curl -I https://refactor.engineer
```

7. Make sure to change the production env var `BACKEND_IMAGE_NAME` back to `ghcr.io/refactor-group/refactor-platform-rs/main:latest`

### Concerns
None