### PR TITLE
Implement changes to switch primary domain to be myrefactor.com

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,8 @@ services:
       # Mount your letsencrypt SSL certs
       - /etc/letsencrypt/live/refactor.engineer/:/etc/letsencrypt/live/refactor.engineer/:ro
       - /etc/letsencrypt/archive/refactor.engineer/:/etc/letsencrypt/archive/refactor.engineer/:ro
+      - /etc/letsencrypt/live/myrefactor.com/:/etc/letsencrypt/live/myrefactor.com/:ro
+      - /etc/letsencrypt/archive/myrefactor.com/:/etc/letsencrypt/archive/myrefactor.com/:ro
       - ${SSL_DHPARAMS_PATH}:/etc/letsencrypt/ssl-dhparams.pem:ro
       # For SSL certbot renewal
       - ./nginx/html:/var/www/html:ro

--- a/nginx/conf.d/refactor-platform.conf
+++ b/nginx/conf.d/refactor-platform.conf
@@ -1,4 +1,5 @@
-# Site-specific configuration for refactor.engineer
+# Primary domain configuration for myrefactor.com
+# refactor.engineer will redirect to myrefactor.com
 
 # Use Docker's internal DNS resolver
 resolver 127.0.0.11 valid=30s;
@@ -15,7 +16,7 @@ upstream frontend {
 # Redirect all HTTP traffic to HTTPS
 server {
     listen 80;
-    server_name refactor.engineer www.refactor.engineer;
+    server_name myrefactor.com www.myrefactor.com refactor.engineer www.refactor.engineer;
     
     # Allow Let's Encrypt ACME challenge
     location /.well-known/acme-challenge/ {
@@ -24,11 +25,20 @@ server {
     
     # Redirect everything else to HTTPS
     location / {
+        # Redirect refactor.engineer to myrefactor.com
+        if ($host ~* ^(www\.)?refactor\.engineer$) {
+            return 301 https://myrefactor.com$request_uri;
+        }
+        # Redirect www.myrefactor.com to myrefactor.com
+        if ($host = www.myrefactor.com) {
+            return 301 https://myrefactor.com$request_uri;
+        }
+        # Default redirect to HTTPS
         return 301 https://$host$request_uri;
     }
 }
 
-# Main HTTPS server block
+# Redirect HTTPS refactor.engineer to myrefactor.com
 server {
     listen 443 ssl;
     http2 on;
@@ -37,6 +47,40 @@ server {
     # SSL Certificate configuration
     ssl_certificate /etc/letsencrypt/live/refactor.engineer/fullchain.pem;
     ssl_certificate_key /etc/letsencrypt/live/refactor.engineer/privkey.pem;
+    
+    # Additional SSL security
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    
+    # Permanent redirect to myrefactor.com
+    return 301 https://myrefactor.com$request_uri;
+}
+
+# Redirect www.myrefactor.com to myrefactor.com
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name www.myrefactor.com;
+
+    # SSL Certificate configuration
+    ssl_certificate /etc/letsencrypt/live/myrefactor.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/myrefactor.com/privkey.pem;
+    
+    # Additional SSL security
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+    
+    # Redirect to non-www
+    return 301 https://myrefactor.com$request_uri;
+}
+
+# Main HTTPS server block for myrefactor.com (primary domain)
+server {
+    listen 443 ssl;
+    http2 on;
+    server_name myrefactor.com;
+
+    # SSL Certificate configuration
+    ssl_certificate /etc/letsencrypt/live/myrefactor.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/myrefactor.com/privkey.pem;
     
     # Additional SSL security
     ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
@@ -70,8 +114,7 @@ server {
         
         # Handle CORS preflight requests
         if ($request_method = 'OPTIONS') {
-            add_header 'Access-Control-Allow-Origin' 'https://refactor.engineer' always;
-            add_header 'Access-Control-Allow-Origin' 'https://www.refactor.engineer' always;
+            add_header 'Access-Control-Allow-Origin' 'https://myrefactor.com' always;
             add_header 'Access-Control-Allow-Methods' 'GET, POST, OPTIONS, PUT, DELETE, PATCH' always;
             add_header 'Access-Control-Allow-Headers' 'DNT,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type,Range,Authorization,x-version' always;
             add_header 'Access-Control-Allow-Credentials' 'true' always;
@@ -82,8 +125,7 @@ server {
         }
         
         # Add CORS headers for actual requests
-        add_header 'Access-Control-Allow-Origin' 'https://refactor.engineer' always;
-        add_header 'Access-Control-Allow-Origin' 'https://www.refactor.engineer' always;
+        add_header 'Access-Control-Allow-Origin' 'https://myrefactor.com' always;
         add_header 'Access-Control-Allow-Credentials' 'true' always;
     }
 

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -63,7 +63,7 @@ pub async fn init_server(app_state: AppState) -> Result<()> {
 
     if app_state.config.is_production() {
         info!("Server starting... listening for internal connections on http://{host}:{port}");
-        info!("External access available via HTTPS proxy at https://refactor.engineer");
+        info!("External access available via HTTPS proxy at https://myrefactor.com");
     } else {
         info!("Server starting... listening for connections on http://{host}:{port}");
     }


### PR DESCRIPTION
## Description
Switch the primary domain from refactor.engineer to myrefactor.com. The old domain will redirect all traffic to the new domain.

#### GitHub Issue: Closes #167

### Changes
* Updated Nginx configuration to serve myrefactor.com as primary domain and redirect refactor.engineer traffic
* Added Docker volume mounts for myrefactor.com SSL certificates in docker-compose.yaml
* Updated backend server log to display myrefactor.com as the primary domain
* Simplified CORS configuration in all .env files to only allow myrefactor.com origin
* Updated production .env to use myrefactor.com as BACKEND_SERVICE_HOST
* Added setup-ssl-myrefactor.sh script to obtain Let's Encrypt certificates
* Added deploy-domain-switch.sh script to verify deployment success

### Testing Strategy
1. Run `setup-ssl-myrefactor.sh` on the server to obtain SSL certificates for myrefactor.com
2. Deploy via GitHub Actions workflow
3. Run `deploy-domain-switch.sh` to verify the domain switch
4. Manual testing:
   - Verify https://myrefactor.com loads successfully
   - Verify https://refactor.engineer redirects to myrefactor.com
   - Test login and authentication flow on new domain
   - Verify API calls work correctly from myrefactor.com

### Concerns
* SSL certificates must be obtained on the server before deployment (setup-ssl-myrefactor.sh handles this)
* Existing users may need to clear cookies/cache if they experience issues after the switch
* Monitor for any CORS-related issues after deployment
