### PR TITLE
MAILERSEND_API_KEY should be set as a secret, not an env var

### DIFF
--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -115,7 +115,7 @@ jobs:
           # -------- Mailersend Config
           # Template ID for welcome emails
           WELCOME_EMAIL_TEMPLATE_ID=${{ vars.WELCOME_EMAIL_TEMPLATE_ID }}
-          MAILERSEND_API_KEY=${{ vars.MAILERSEND_API_KEY }}
+          MAILERSEND_API_KEY=${{ secrets.MAILERSEND_API_KEY }}
 
           # -------- Frontend Config
           # Docker image for frontend


### PR DESCRIPTION
## Description
This PR fixes the issue preventing new user email sending from working.


#### GitHub Issue: None

### Changes
* Change MAILERSEND_API_KEY to be a GitHub secret

### Testing Strategy
1. Create a new user under an org
2. This user should receive a new welcome email from hello@myrefactor.com

### Concerns
None
