### PR TITLE
replace axum-login middleware

### DIFF
--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -22,6 +22,7 @@ use tower_http::cors::CorsLayer;
 mod controller;
 mod error;
 pub(crate) mod extractors;
+pub(crate) mod middleware;
 pub(crate) mod params;
 pub(crate) mod protect;
 mod router;

--- a/web/src/middleware/auth.rs
+++ b/web/src/middleware/auth.rs
@@ -1,0 +1,87 @@
+use crate::AppState;
+use axum::{
+    extract::{Request, State},
+    http::StatusCode,
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use axum_login::AuthSession;
+
+/// Authentication middleware that returns 401 Unauthorized for unauthenticated requests.
+///
+/// This replaces axum-login's `login_required!` macro which redirects to login URLs.
+/// For API endpoints, we want to return proper HTTP status codes instead of redirects.
+pub async fn require_auth(
+    State(_app_state): State<AppState>,
+    auth_session: AuthSession<domain::user::Backend>,
+    request: Request,
+    next: Next,
+) -> Response {
+    match auth_session.user {
+        Some(_user) => {
+            // User is authenticated, continue to the handler
+            next.run(request).await
+        }
+        None => {
+            // User is not authenticated or session expired
+            (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+        }
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "mock")]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+        middleware::from_fn_with_state,
+        response::Response,
+        routing::get,
+        Router,
+    };
+    use axum_login::{
+        tower_sessions::{Expiry, MemoryStore, SessionManagerLayer},
+        AuthManagerLayerBuilder,
+    };
+    use domain::user::Backend;
+    use service::config::Config;
+    use std::sync::Arc;
+    use time::Duration;
+    use tower::ServiceExt;
+
+    async fn test_handler() -> &'static str {
+        "authenticated"
+    }
+
+    #[tokio::test]
+    async fn test_require_auth_with_no_session_returns_401() {
+        let config = Config::default();
+        let db = Arc::new(
+            sea_orm::MockDatabase::new(sea_orm::DatabaseBackend::Postgres).into_connection(),
+        );
+        let app_state = crate::AppState::new(config, &db);
+
+        // Set up session layer
+        let session_store = MemoryStore::default();
+        let session_layer = SessionManagerLayer::new(session_store)
+            .with_secure(false)
+            .with_expiry(Expiry::OnInactivity(Duration::days(1)));
+
+        let backend = Backend::new(&db);
+        let auth_layer = AuthManagerLayerBuilder::new(backend, session_layer).build();
+
+        let app = Router::new()
+            .route("/test", get(test_handler))
+            .route_layer(from_fn_with_state(app_state.clone(), require_auth))
+            .layer(auth_layer)
+            .with_state(app_state);
+
+        let request = Request::builder().uri("/test").body(Body::empty()).unwrap();
+
+        let response: Response = app.oneshot(request).await.unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/web/src/middleware/mod.rs
+++ b/web/src/middleware/mod.rs
@@ -1,0 +1,1 @@
+pub mod auth;

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -1,11 +1,11 @@
-use crate::{controller::health_check_controller, params, protect, AppState};
+use crate::{
+    controller::health_check_controller, middleware::auth::require_auth, params, protect, AppState,
+};
 use axum::{
     middleware::from_fn_with_state,
     routing::{delete, get, post, put},
     Router,
 };
-use axum_login::login_required;
-use domain::user::Backend;
 use tower_http::services::ServeDir;
 
 use crate::controller::{
@@ -125,7 +125,7 @@ pub fn define_routes(app_state: AppState) -> Router {
         .merge(user_routes(app_state.clone()))
         .merge(user_password_routes(app_state.clone()))
         .merge(user_session_routes())
-        .merge(user_session_protected_routes())
+        .merge(user_session_protected_routes(app_state.clone()))
         .merge(coaching_sessions_routes(app_state.clone()))
         .merge(jwt_routes(app_state.clone()))
         // **** FIXME: protect the OpenAPI web UI
@@ -149,7 +149,7 @@ fn action_routes(app_state: AppState) -> Router {
                     protect::actions::index,
                 )),
         )
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 
@@ -168,7 +168,7 @@ fn agreement_routes(app_state: AppState) -> Router {
         )
         .route("/agreements/:id", get(agreement_controller::read))
         .route("/agreements/:id", delete(agreement_controller::delete))
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 
@@ -226,7 +226,7 @@ pub fn coaching_sessions_routes(app_state: AppState) -> Router {
                     protect::coaching_sessions::delete,
                 )),
         )
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 
@@ -245,7 +245,7 @@ fn note_routes(app_state: AppState) -> Router {
                 .route_layer(from_fn_with_state(app_state.clone(), protect::notes::index)),
         )
         .route("/notes/:id", get(note_controller::read))
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 
@@ -275,7 +275,7 @@ fn organization_coaching_relationship_routes(app_state: AppState) -> Router {
             "/organizations/:organization_id/coaching_relationships/:relationship_id",
             get(organization::coaching_relationship_controller::read),
         )
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 
@@ -317,7 +317,7 @@ fn organization_user_routes(app_state: AppState) -> Router {
                     protect::organizations::users::delete,
                 )),
         )
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 pub fn organization_routes(app_state: AppState) -> Router {
@@ -334,7 +334,7 @@ pub fn organization_routes(app_state: AppState) -> Router {
             "/organizations/:id",
             delete(organization_controller::delete),
         )
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 
@@ -368,7 +368,7 @@ pub fn overarching_goal_routes(app_state: AppState) -> Router {
             "/overarching_goals/:id/status",
             put(overarching_goal_controller::update_status),
         )
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 
@@ -389,7 +389,7 @@ pub fn user_routes(app_state: AppState) -> Router {
                     protect::users::update,
                 )),
         )
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 
@@ -403,14 +403,15 @@ pub fn user_password_routes(app_state: AppState) -> Router {
             app_state.clone(),
             protect::users::passwords::update_password,
         ))
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 
-pub fn user_session_protected_routes() -> Router {
+pub fn user_session_protected_routes(app_state: AppState) -> Router {
     Router::new()
         .route("/delete", delete(user_session_controller::delete))
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
+        .with_state(app_state)
 }
 
 pub fn user_session_routes() -> Router {
@@ -427,7 +428,7 @@ fn jwt_routes(app_state: AppState) -> Router {
             app_state.clone(),
             protect::jwt::generate_collab_token,
         ))
-        .route_layer(login_required!(Backend, login_url = "/"))
+        .route_layer(from_fn_with_state(app_state.clone(), require_auth))
         .with_state(app_state)
 }
 


### PR DESCRIPTION
axum-login responds with a 307 redirect by default for unauthenticated requests. We would like to return a 401. This is semantically more correct for an API and allows clients to provide their own policies for how to handle unauthenticated requests.

## Description
_describe the intent of your changes here_


#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

### Changes
* ...
* ...
* ...

### Testing Strategy
_describe how you or someone else can test and verify the changes_


### Concerns
_describe any concerns that might be worth mentioning or discussing_
