### PR TITLE
Make sure the logs from the db-migrator container get output during d…

### DIFF
--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -391,6 +391,16 @@ jobs:
             docker ps -a
             # List all containers
 
+            echo "INFO: 📜 Checking migration logs..."
+            # Capture and display migration logs
+            if docker ps -a --format '{{.Names}}' | grep -q db-migrator; then
+              echo "=== DB Migration Logs ==="
+              docker logs db-migrator 2>&1 || echo "⚠️ No migration logs available"
+              echo "========================="
+            else
+              echo "⚠️ db-migrator container not found"
+            fi
+
             echo "INFO: 🩺 Verifying app status..."
             # Verify application health
             echo "INFO: 🩺 Checking rust-app service status..."


### PR DESCRIPTION
## Description
This PR ensures that the log output (stdout and stderr) get printed to the deployment log in general so we can see the results of running any migrations.


#### GitHub Issue: [Closes|Fixes|Resolves] #_your GitHub issue number here_

### Changes
* Output db-migrator's log output to the general deployment log output

### Testing Strategy
1. Deploy something
2. Notice that db-migrator's output now shows up (errors and non-error logs)


### Concerns
None
