### PR TITLE
re-add user_roles migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ dbml-error.log
 
 # nginx log files
 nginx/logs/
+
+# serena files
+.serena/

--- a/docs/db/refactor_platform_rs.dbml
+++ b/docs/db/refactor_platform_rs.dbml
@@ -40,6 +40,21 @@ Table refactor_platform.users {
   updated_at timestamptz [not null, default: `now()`, note: 'The last date and time fields were changed']
 }
 
+Table refactor_platform.user_roles {
+  id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
+  role refactor_platform.role [not null]
+  organization_id uuid [note: 'The organization joined to the user']
+  user_id uuid [not null, note: 'The user joined to the organization']
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`, note: 'The last date and time fields were changed']
+}
+
+enum refactor_platform.role {
+  user
+  admin
+  super_admin
+}
+
 Table refactor_platform.organizations_users {
   id uuid [primary key, unique, not null, default: `gen_random_uuid()`]
   organization_id uuid [not null, note: 'The organization joined to the user']
@@ -146,3 +161,7 @@ Ref: refactor_platform.actions.coaching_session_id > refactor_platform.coaching_
 // organizations_users relationships
 Ref: refactor_platform.organizations_users.organization_id > refactor_platform.organizations.id
 Ref: refactor_platform.organizations_users.user_id > refactor_platform.users.id
+
+//user_roles relationships
+Ref: refactor_platform.user_roles.organization_id > refactor_platform.organizations.id
+Ref: refactor_platform.user_roles.user_id > refactor_platform.users.id

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -8,6 +8,7 @@ mod m20250611_115337_promote_admin_user_to_admin_role;
 mod m20250705_200000_add_timezone_to_users;
 mod m20250730_000000_add_coaching_sessions_sorting_indexes;
 mod m20250801_000000_add_sorting_indexes;
+mod m20251007_093603_add_user_roles_table_and_super_admin;
 
 pub struct Migrator;
 
@@ -23,6 +24,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250705_200000_add_timezone_to_users::Migration),
             Box::new(m20250730_000000_add_coaching_sessions_sorting_indexes::Migration),
             Box::new(m20250801_000000_add_sorting_indexes::Migration),
+            Box::new(m20251007_093603_add_user_roles_table_and_super_admin::Migration),
         ]
     }
 }

--- a/migration/src/m20251007_093603_add_user_roles_table_and_super_admin.rs
+++ b/migration/src/m20251007_093603_add_user_roles_table_and_super_admin.rs
@@ -1,0 +1,95 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // 1. Add super_admin variant to the existing role enum
+        // Note: We use execute_unprepared() instead of SeaORM's schema builder because:
+        // - PostgreSQL's ALTER TYPE ... ADD VALUE has special transaction restrictions
+        // - It cannot be executed in a transaction block that has other commands
+        // - execute_unprepared() gives us direct control over the SQL execution
+        // - The IF NOT EXISTS clause makes it safe for re-runs
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "ALTER TYPE refactor_platform.role ADD VALUE IF NOT EXISTS 'super_admin'",
+            )
+            .await?;
+
+        // 2. Create the user_roles table
+        // We continue using execute_unprepared() for consistency and to ensure
+        // proper PostgreSQL schema qualification (refactor_platform.user_roles)
+        let create_table_sql = "CREATE TABLE IF NOT EXISTS refactor_platform.user_roles (
+            id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+            role refactor_platform.role NOT NULL,
+            organization_id UUID,
+            user_id UUID NOT NULL,
+            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+            CONSTRAINT fk_user_roles_organization 
+                FOREIGN KEY (organization_id) 
+                REFERENCES refactor_platform.organizations(id) 
+                ON DELETE CASCADE 
+                ON UPDATE CASCADE,
+            CONSTRAINT fk_user_roles_user 
+                FOREIGN KEY (user_id) 
+                REFERENCES refactor_platform.users(id) 
+                ON DELETE CASCADE 
+                ON UPDATE CASCADE
+        )";
+
+        manager
+            .get_connection()
+            .execute_unprepared(create_table_sql)
+            .await?;
+
+        // 3. Create partial unique indexes to prevent duplicate role assignments
+        // This handles NULL organization_id properly (for super_admin roles)
+
+        // Partial index for organization-scoped roles (where organization_id is NOT NULL)
+        let create_org_index_sql =
+            "CREATE UNIQUE INDEX IF NOT EXISTS user_roles_user_org_role_unique 
+            ON refactor_platform.user_roles(user_id, organization_id, role)
+            WHERE organization_id IS NOT NULL";
+
+        manager
+            .get_connection()
+            .execute_unprepared(create_org_index_sql)
+            .await?;
+
+        // Partial index for global roles (prevents duplicate global roles for same user)
+        // This includes super_admin and any other future global roles
+        let create_global_role_index_sql =
+            "CREATE UNIQUE INDEX IF NOT EXISTS user_roles_user_global_role_unique 
+            ON refactor_platform.user_roles(user_id, role)
+            WHERE organization_id IS NULL";
+
+        manager
+            .get_connection()
+            .execute_unprepared(create_global_role_index_sql)
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Drop the user_roles table (this will also drop the indexes and foreign keys)
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TABLE IF EXISTS refactor_platform.user_roles")
+            .await?;
+
+        // Note: We cannot remove the 'super_admin' value from the enum in PostgreSQL
+        // once it has been added. This is a PostgreSQL limitation.
+        // If you need to truly remove it, you would need to:
+        // 1. Create a new enum type without 'super_admin'
+        // 2. Update all columns using the old type to use the new type
+        // 3. Drop the old enum type
+        // This is complex and risky, so we'll leave the enum value in place.
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description

This PR redefines the migrations to add `super_admin` and `user_roles`

The plan is to deploy this branch without the corresponding changes to the application code (which broke production when the migrations didn't run) and continue to troubleshoot why migrations aren't being applied in production. 

#### GitHub Issue: #185 

### Changes
* redefines migrations


### Testing Strategy
I tested this by running the migrations locally and testing that my local user could still log in and perform operations

