### PR TITLE
Add Claude Code commands and coding standards for Rust backend

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,44 @@
+# refactor-platform-rs Project Instructions
+
+## Mandatory File Consultations
+
+**Code Implementation/Editing** → Read `.claude/coding-standards.md` FIRST
+**Pull Request Operations** → Read `.claude/pr-instructions.md` FIRST
+**Database Migrations** → Read the Database Migrations section below FIRST
+
+## Rules
+- Project standards override global defaults on conflict
+- Validate all code against standards before task completion
+- PR reviews require both files if coding standards referenced
+- Always run `cargo clippy` and `cargo fmt` before committing
+- Always skip adding Claude attribution for commits or PRs (no "Generated with Claude Code" or "Co-Authored-By: Claude" footers)
+
+## Database Migrations
+
+**CRITICAL: PostgreSQL Type Ownership** - When creating any PostgreSQL type (enum, composite, etc.) using `create_type()`, you MUST immediately follow it with `ALTER TYPE refactor_platform.<type_name> OWNER TO refactor`.
+
+**Why this is required:** SeaORM's `create_type()` generates unqualified SQL (e.g., `CREATE TYPE role` instead of `CREATE TYPE refactor_platform.role`). PostgreSQL assigns ownership to the user executing the CREATE TYPE command. If the type is created by a superuser (like `doadmin`) but later migrations run as the `refactor` user, those migrations will fail with "must be owner of type" errors when attempting to ALTER the type.
+
+**For existing types without proper ownership:** A database superuser must manually run `ALTER TYPE refactor_platform.<type_name> OWNER TO refactor;` before migrations can modify those types.
+
+## Project Structure
+
+```
+refactor-platform-rs/
+├── entity/        # SeaORM entity definitions
+├── entity_api/    # Entity API layer
+├── domain/        # Domain logic and business rules
+├── service/       # Service layer
+├── web/           # Axum web handlers and routes
+├── migration/     # SeaORM database migrations
+└── src/           # Main application entry point
+```
+
+## Toolchain
+
+- **Build/Run**: `cargo build`, `cargo run`
+- **Testing**: `cargo test`
+- **Linting**: `cargo clippy`
+- **Formatting**: `cargo fmt`
+- **Database**: SeaORM with PostgreSQL
+- **Web Framework**: Axum

--- a/.claude/coding-standards.md
+++ b/.claude/coding-standards.md
@@ -1,0 +1,153 @@
+# Coding Standards
+
+This document outlines coding conventions and standards for the refactor-platform-rs project.
+
+## Rust Conventions
+
+### Import Organization
+
+Organize `use` statements in the following order, separated by blank lines:
+
+```rust
+// 1. Standard library
+use std::collections::HashMap;
+use std::sync::Arc;
+
+// 2. External crates
+use axum::{extract::State, Json};
+use sea_orm::{EntityTrait, QueryFilter};
+use serde::{Deserialize, Serialize};
+
+// 3. Internal modules (crate)
+use crate::domain::models::User;
+use crate::service::user_service;
+
+// ❌ Incorrect - mixed ordering
+use crate::domain::models::User;
+use std::sync::Arc;
+use axum::Json;
+```
+
+**Rationale**:
+- Improves code readability by grouping related imports
+- Makes it easy to identify external dependencies
+- Consistent with Rust community conventions
+
+### Naming Conventions
+
+- Use `snake_case` for functions, variables, and modules: `get_user_by_id`, `user_service`
+- Use `PascalCase` for types, traits, and enums: `UserService`, `EntityTrait`, `ConnectionState`
+- Use `SCREAMING_SNAKE_CASE` for constants: `MAX_CONNECTIONS`, `DEFAULT_TIMEOUT`
+
+```rust
+// ✅ Correct
+const MAX_RETRIES: u32 = 3;
+
+enum ConnectionState {
+    Connecting,
+    Connected,
+    Disconnected,
+}
+
+struct UserService {
+    db_pool: DatabaseConnection,
+}
+
+fn get_active_users() -> Vec<User> { ... }
+
+// ❌ Incorrect
+const max_retries: u32 = 3;
+enum connectionState { ... }
+struct user_service { ... }
+fn GetActiveUsers() -> Vec<User> { ... }
+```
+
+### Error Handling
+
+- Use `Result<T, E>` for fallible operations
+- Prefer the `?` operator for error propagation
+- Create domain-specific error types when appropriate
+- Avoid `.unwrap()` and `.expect()` in production code paths
+
+```rust
+// ✅ Good - proper error handling
+pub async fn find_user(id: Id) -> Result<Option<User>, DbErr> {
+    let user = users::Entity::find_by_id(id)
+        .one(&db)
+        .await?;
+    Ok(user)
+}
+
+// ❌ Bad - panics on error
+pub async fn find_user(id: Id) -> User {
+    users::Entity::find_by_id(id)
+        .one(&db)
+        .await
+        .unwrap()
+        .unwrap()
+}
+```
+
+### Async Patterns
+
+- Use `async fn` for asynchronous operations
+- Prefer `.await` at call sites rather than spawning tasks unnecessarily
+- Be mindful of blocking operations in async contexts
+
+```rust
+// ✅ Good - async handler
+pub async fn get_user(
+    State(app_state): State<AppState>,
+    Path(id): Path<Id>,
+) -> Result<Json<User>, AppError> {
+    let user = user_service::find_by_id(&app_state.db, id).await?;
+    Ok(Json(user))
+}
+```
+
+## Module Organization
+
+### Layer Responsibilities
+
+- **entity/**: SeaORM entity definitions (generated/maintained)
+- **entity_api/**: CRUD operations and entity-level queries
+- **domain/**: Business logic, domain models, validation rules
+- **service/**: Orchestration layer, complex operations spanning multiple entities
+- **web/**: HTTP handlers, request/response types, routing
+
+### Visibility Rules
+
+- Keep module internals private by default
+- Export only what's needed via `pub` or `pub(crate)`
+- Use `mod.rs` or inline modules to organize related code
+
+## Documentation
+
+- Add doc comments (`///`) for public APIs
+- Explain *why* something is done, not just *what*
+- Document error conditions and edge cases
+
+```rust
+/// Finds a user by their unique identifier.
+///
+/// # Errors
+///
+/// Returns `DbErr` if the database query fails.
+/// Returns `None` in the `Ok` variant if no user exists with the given ID.
+pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Option<User>, DbErr> {
+    // ...
+}
+```
+
+## Code Review Checklist
+
+When reviewing or writing code, ensure:
+
+- [ ] Imports are organized (std, external, internal)
+- [ ] Naming follows Rust conventions
+- [ ] Error handling uses `Result` and `?` operator appropriately
+- [ ] No `.unwrap()` or `.expect()` in production code paths
+- [ ] Async operations don't block the runtime
+- [ ] Public APIs have doc comments
+- [ ] Code passes `cargo clippy` without warnings
+- [ ] Code is formatted with `cargo fmt`

--- a/.claude/commands/accessibility-review.md
+++ b/.claude/commands/accessibility-review.md
@@ -1,0 +1,31 @@
+Review this Rust backend API code for API accessibility and consumer-friendliness:
+
+**HTTP STATUS CODES**
+- Appropriate status codes for success (200, 201, 204)
+- Correct error codes (400, 401, 403, 404, 422, 500)
+- Consistent status code usage across similar endpoints
+
+**ERROR RESPONSES**
+- Clear, actionable error messages
+- Consistent error response structure
+- Proper error codes/identifiers for client handling
+- Localization-ready error messages
+
+**API DISCOVERABILITY**
+- OpenAPI/Swagger documentation completeness
+- Endpoint naming clarity and consistency
+- Resource relationship clarity
+- Proper use of HTTP methods (GET, POST, PUT, PATCH, DELETE)
+
+**RESPONSE FORMATTING**
+- Consistent JSON response structures
+- Pagination metadata for list endpoints
+- HATEOAS links where appropriate
+- Content-Type headers properly set
+
+**RATE LIMITING & HEADERS**
+- Rate limit headers (X-RateLimit-*)
+- Retry-After headers on 429 responses
+- Request ID headers for debugging
+
+Provide specific improvements for API consumer experience.

--- a/.claude/commands/api-review.md
+++ b/.claude/commands/api-review.md
@@ -1,0 +1,69 @@
+Review these Axum API handlers and routes for:
+
+**RESTFUL ENDPOINT DESIGN**
+- Resource-based URLs (nouns, not verbs): `/users`, `/coaching-sessions`
+- Proper HTTP method semantics:
+  - GET: Read (idempotent, cacheable)
+  - POST: Create new resource
+  - PUT: Full replacement of resource
+  - PATCH: Partial update of resource
+  - DELETE: Remove resource
+- Nested resources for relationships: `/users/{id}/coaching-sessions`
+- Consistent pluralization of resource names
+- Use query params for filtering/sorting: `?status=active&sort=created_at`
+- Avoid action verbs in URLs (prefer `POST /orders/{id}/cancel` over `POST /cancelOrder`)
+
+**URL NAMING CONVENTIONS**
+- Use kebab-case for multi-word resources: `/coaching-sessions` not `/coachingSessions`
+- Use path parameters for identifiers: `/users/{user_id}`
+- Use query parameters for optional filters: `?include=relationships`
+- Version APIs appropriately: `/api/v1/...` or header-based
+
+**RESPONSE PATTERNS**
+- Return created resource on POST (with 201 + Location header)
+- Return updated resource on PUT/PATCH (with 200)
+- Return 204 No Content on successful DELETE
+- Use 404 for missing resources, 410 for deliberately removed
+- Pagination pattern: `{ data: [...], meta: { total, page, per_page } }`
+
+**HANDLER PATTERNS**
+- Proper use of extractors (State, Path, Query, Json)
+- Extractor ordering (rejection-prone extractors last)
+- Response type consistency
+- Handler function size and complexity
+
+**REQUEST VALIDATION**
+- Input validation with serde/validator
+- Request body size limits
+- Query parameter validation
+- Path parameter type safety
+
+**DATABASE OPERATIONS**
+- SeaORM query patterns
+- N+1 query prevention
+- Transaction usage for multi-step operations
+- Connection pool usage (avoid holding connections)
+
+**ERROR HANDLING**
+- Proper error type conversions
+- AppError/ApiError pattern usage
+- Error response consistency
+- Logging of errors without exposing internals
+
+**AUTHENTICATION & AUTHORIZATION**
+- Middleware placement and ordering
+- Token validation
+- Permission checks at handler level
+- Session management
+
+**CORS & SECURITY HEADERS**
+- CORS configuration appropriateness
+- Security headers (CSP, X-Frame-Options, etc.)
+- Cookie settings (HttpOnly, Secure, SameSite)
+
+**RESPONSE FORMATTING**
+- Consistent JSON structures
+- Proper HTTP status codes
+- Content-Type headers
+
+Focus on security, performance, and maintainability.

--- a/.claude/commands/architecture-review.md
+++ b/.claude/commands/architecture-review.md
@@ -1,0 +1,46 @@
+Review the Rust code architecture and design patterns:
+
+**MODULE DESIGN**
+- Single responsibility principle adherence
+- Module size and complexity
+- Proper visibility (pub, pub(crate), private)
+- Clear module boundaries and dependencies
+
+**LAYER SEPARATION**
+- entity/ - SeaORM entities only
+- entity_api/ - CRUD and entity queries
+- domain/ - Business logic and validation
+- service/ - Orchestration and complex operations
+- web/ - HTTP concerns only
+
+**TRAIT USAGE**
+- Trait abstraction appropriateness
+- Trait object vs generics decisions
+- Default implementations where sensible
+- Trait bounds clarity
+
+**ERROR DESIGN**
+- Custom error type hierarchy
+- Error conversion implementations (From, Into)
+- Error propagation patterns
+- Context preservation in errors
+
+**STATE MANAGEMENT**
+- AppState design in Axum
+- Shared state via Arc where needed
+- Database connection handling
+- Configuration management
+
+**DEPENDENCY PATTERNS**
+- Constructor injection vs State extractor
+- Testability of components
+- Mock-friendly interfaces
+- Circular dependency prevention
+
+**TESTING CONSIDERATIONS**
+- Unit testability of business logic
+- Integration test patterns
+- Database test isolation
+- Mock/stub patterns in Rust
+
+Identify refactoring opportunities and architectural improvements.

--- a/.claude/commands/bug-hunt.md
+++ b/.claude/commands/bug-hunt.md
@@ -1,0 +1,42 @@
+Quickly scan this Rust code for potential bugs and runtime errors:
+
+**PANIC RISKS**
+- `.unwrap()` on Option/Result without safety guarantees
+- `.expect()` in production code paths
+- Index access without bounds checking
+- Integer overflow in release builds
+
+**ERROR HANDLING**
+- Unhandled Result values (missing `?` or explicit handling)
+- Error branches that silently drop information
+- Incorrect error type conversions
+
+**ASYNC ISSUES**
+- Deadlock potential with locks across await points
+- Blocking operations in async context
+- Missing `.await` on futures
+- Spawned tasks without proper error handling
+
+**MEMORY & LIFETIME**
+- Use-after-move bugs
+- Incorrect lifetime annotations
+- Arc/Rc cycles causing memory leaks
+- Large stack allocations
+
+**DATABASE**
+- SQL injection via raw queries
+- Missing transaction boundaries
+- N+1 query patterns
+- Unclosed database connections
+
+**CONCURRENCY**
+- Data races with shared mutable state
+- Mutex poisoning not handled
+- Channel send/recv without proper error handling
+
+**OUTPUT FORMAT**: Use Markdown with:
+- 🐛 **Bug**: for bugs found
+- ✅ **Clean**: for clean code sections
+- Use code blocks for code snippets
+
+Be concise - only list actual bugs, not style issues.

--- a/.claude/commands/comprehensive-review.md
+++ b/.claude/commands/comprehensive-review.md
@@ -1,0 +1,32 @@
+Please perform a comprehensive code review of this Rust/Axum/SeaORM pull request.
+
+## Review Areas
+
+Apply the criteria from each of the following specialized reviews:
+
+1. **Security** → See `.claude/commands/security-review.md`
+2. **Performance** → See `.claude/commands/performance-review.md`
+3. **API Design** → See `.claude/commands/api-review.md`
+4. **Architecture** → See `.claude/commands/architecture-review.md`
+5. **Rust Idioms** → See `.claude/commands/rust-review.md`
+6. **Bug Detection** → See `.claude/commands/bug-hunt.md`
+7. **Database Migrations** → See `.claude/commands/migration-review.md` (if applicable)
+
+## Priority Levels
+
+Categorize findings by severity:
+- **Critical**: Security vulnerabilities, data loss risks, panics in production paths
+- **High**: Performance bottlenecks, incorrect behavior, missing error handling
+- **Medium**: Code quality issues, maintainability concerns, missing tests
+- **Low**: Style inconsistencies, minor optimizations, documentation gaps
+
+## Output Format
+
+For each issue found:
+1. Specify the severity (Critical/High/Medium/Low)
+2. Reference which review area it falls under
+3. Explain the issue clearly
+4. Provide specific fix recommendations
+5. Include code examples where helpful
+
+Only comment on significant issues. Be concise but thorough.

--- a/.claude/commands/load-context.md
+++ b/.claude/commands/load-context.md
@@ -1,0 +1,25 @@
+## Context Loading Commands
+
+**`/load-context $ARGUMENTS`**
+```yaml
+---
+command: "/load-context"
+category: "Analysis & Investigation"
+purpose: "Comprehensive project context loading with architecture and dependency analysis"
+wave-enabled: false
+performance-profile: "complex"
+---
+```
+- **Auto-Persona**: Analyzer, Architect
+- **MCP Integration**: Context7 (documentation), Serena (code analysis)
+- **Tool Orchestration**: [Read, Grep, Glob, Bash, TodoWrite]
+- **Combined Operations**:
+  - Project architecture analysis: `/analyze @. --scope project --c7 --focus architecture`
+  - Dependency analysis: `/analyze Cargo.toml --focus dependencies --c7 --think`
+- **Arguments**: `[target]`, `@<path>`, `--<flags>`
+- **Purpose**: Loads comprehensive project context including existing patterns, dependencies, and architecture decisions to inform implementation choices
+
+**Usage Examples**:
+- `/load-context` - Full project context loading
+- `/load-context --focus patterns` - Focus on existing code patterns
+- `/load-context --focus tech-stack` - Focus on technology stack and dependencies

--- a/.claude/commands/migration-review.md
+++ b/.claude/commands/migration-review.md
@@ -1,0 +1,51 @@
+Review this database migration for correctness, safety, and best practices:
+
+**SCHEMA CHANGES**
+- Table/column naming conventions (snake_case)
+- Proper foreign key relationships and ON DELETE behavior
+- Index usage and optimization for common queries
+- Nullable vs NOT NULL decisions with sensible defaults
+- Data type appropriateness (e.g., UUID vs serial, timestamptz vs timestamp)
+
+**POSTGRESQL TYPE OWNERSHIP**
+- ⚠️ CRITICAL: Verify `ALTER TYPE refactor_platform.<type_name> OWNER TO refactor` after any `create_type()`
+- Schema qualification for custom types
+- Enum type modifications (adding values is safe, removing is not)
+
+**MIGRATION SAFETY**
+- Reversibility: Does `down()` properly undo `up()`?
+- Data preservation during ALTER operations
+- Lock considerations for large tables (avoid long-held locks)
+- Idempotency: Can migration be safely re-run?
+- Backward compatibility with running application code
+
+**SEED DATA**
+- Development vs production seed data separation
+- Referential integrity in seed data order
+- Proper cleanup in down migrations
+- Avoid hardcoded IDs that may conflict
+
+**SEAORM PATTERNS**
+- 📚 **Use Context7 MCP to check latest SeaORM migration API usage**
+- Proper use of `manager.create_table()`, `alter_table()`, `drop_table()`
+- Correct column definitions with `ColumnDef::new()`
+- Foreign key constraint definitions
+- Index creation with appropriate columns
+
+**ENTITY SYNCHRONIZATION**
+- Entity struct matches migration schema
+- ActiveModel derives are correct
+- Relation definitions match foreign keys
+- Column attributes (e.g., `column_name`) are accurate
+
+**PERFORMANCE CONSIDERATIONS**
+- Large data migrations should be batched
+- Index creation on large tables (consider CONCURRENTLY)
+- Avoid full table scans in data migrations
+
+**ROLLBACK PLAN**
+- Is rollback tested and documented?
+- Data backup considerations before destructive changes
+- Feature flags for gradual rollout if needed
+
+Provide specific feedback on migration safety and correctness.

--- a/.claude/commands/performance-review.md
+++ b/.claude/commands/performance-review.md
@@ -1,0 +1,49 @@
+Review this Rust/Axum/SeaORM code for performance and efficiency:
+
+**MEMORY & ALLOCATIONS**
+- Unnecessary clones and allocations
+- String vs &str usage optimization
+- Vec pre-allocation with `with_capacity`
+- Avoiding temporary allocations in hot paths
+- Box vs inline storage decisions
+
+**DATABASE PERFORMANCE**
+- N+1 query detection and prevention
+- Missing database indexes
+- Inefficient query patterns
+- Connection pool sizing and usage
+- Transaction scope optimization
+- Batch operations vs individual queries
+
+**ASYNC RUNTIME**
+- Blocking operations in async context
+- Task spawning appropriateness
+- Future combinators efficiency
+- Channel buffer sizing
+- Proper use of `tokio::spawn` vs direct await
+
+**SERIALIZATION**
+- Serde optimization (skip_serializing_if, etc.)
+- Response payload size
+- Unnecessary serialization/deserialization cycles
+- Zero-copy patterns where applicable
+
+**CACHING OPPORTUNITIES**
+- Repeated expensive computations
+- Database query caching potential
+- Static data that could be cached
+- Cache invalidation considerations
+
+**API EFFICIENCY**
+- Pagination implementation
+- Partial response support (field selection)
+- Compression (gzip/brotli)
+- Connection keep-alive settings
+
+**RUST-SPECIFIC OPTIMIZATIONS**
+- Iterator vs loop performance
+- Cow<str> for conditional ownership
+- SmallVec for small collections
+- Lazy initialization patterns
+
+Rate each area and suggest specific improvements with benchmarking recommendations.

--- a/.claude/commands/rust-review.md
+++ b/.claude/commands/rust-review.md
@@ -1,0 +1,82 @@
+Perform a Rust-focused review of this code for idiomatic patterns and language best practices:
+
+**OWNERSHIP & BORROWING**
+- Unnecessary clones that could be borrows
+- Missing borrows that cause moves
+- Lifetime elision opportunities
+- Proper use of `&self` vs `self` vs `&mut self`
+
+**LIFETIME ANNOTATIONS**
+- Correct lifetime bounds
+- Lifetime elision where possible
+- Static lifetime usage appropriateness
+- Higher-ranked trait bounds (HRTB) when needed
+
+**ERROR HANDLING**
+- 📚 **Use Context7 MCP to check latest thiserror/anyhow patterns**
+- `Result<T, E>` vs `Option<T>` appropriateness
+- Error type design (thiserror, anyhow patterns)
+- `?` operator usage and propagation
+- Custom error context with `.context()` or `.map_err()`
+- Avoiding `.unwrap()` and `.expect()` in library code
+
+**TYPE SYSTEM**
+- Newtype patterns for type safety
+- Generic type parameter bounds
+- Associated types vs generic parameters
+- Phantom types for compile-time guarantees
+- Type aliases for readability
+
+**TRAIT DESIGN**
+- Trait coherence and orphan rules
+- Default implementations
+- Supertraits and trait bounds
+- Object safety considerations
+- Blanket implementations
+
+**PATTERN MATCHING**
+- Exhaustive matching
+- Guard clauses
+- Destructuring patterns
+- `if let` vs `match` appropriateness
+- `matches!` macro usage
+
+**ITERATORS & CLOSURES**
+- Iterator adapter chains
+- `collect()` type inference
+- Closure capture modes (move, borrow)
+- `impl Fn` vs `dyn Fn` vs generics
+
+**SERDE PATTERNS**
+- 📚 **Use Context7 MCP to check latest serde API usage**
+- Derive macro attributes
+- Custom serialization/deserialization
+- `skip_serializing_if` and other field attributes
+- Rename strategies and case conventions
+
+**ASYNC PATTERNS**
+- 📚 **Use Context7 MCP to check latest tokio API usage**
+- Future combinators and async traits
+- Spawn vs direct await decisions
+- Cancellation safety
+- Async closure patterns
+
+**MACROS**
+- Macro hygiene
+- Declarative vs procedural appropriateness
+- Derive macro usage
+- Avoiding macro overuse
+
+**UNSAFE CODE**
+- Justification for unsafe blocks
+- Invariant documentation
+- Minimizing unsafe scope
+- Safe abstractions over unsafe
+
+**CLIPPY & STYLE**
+- Clippy lint compliance
+- Naming conventions (snake_case, PascalCase)
+- Module organization
+- Documentation completeness
+
+Suggest idiomatic improvements with code examples.

--- a/.claude/commands/security-review.md
+++ b/.claude/commands/security-review.md
@@ -1,0 +1,52 @@
+Conduct a security-focused review of this Rust/Axum/SeaORM code. Check for:
+
+**INJECTION VULNERABILITIES**
+- SQL injection via raw queries or string interpolation
+- Command injection in system calls
+- Path traversal in file operations
+- Log injection attacks
+
+**AUTHENTICATION & AUTHORIZATION**
+- Insecure session/token management
+- Missing authorization checks on endpoints
+- Token exposure or leakage in logs/responses
+- Privilege escalation risks
+- JWT validation completeness (exp, iss, aud)
+
+**DATA EXPOSURE**
+- Hardcoded secrets, API keys, or credentials
+- Sensitive data in error messages
+- PII in logs or debug output
+- Overly permissive response data (returning full entities)
+
+**INPUT VALIDATION**
+- Missing or incomplete input validation
+- Type coercion vulnerabilities
+- Boundary condition handling
+- Malformed data handling
+
+**CRYPTOGRAPHY**
+- Weak hashing algorithms
+- Insecure random number generation
+- Missing encryption for sensitive data
+- Improper key management
+
+**AXUM/WEB SPECIFIC**
+- CORS misconfiguration
+- Missing security headers
+- Cookie security attributes (HttpOnly, Secure, SameSite)
+- Rate limiting gaps
+- Request size limits
+
+**RUST SPECIFIC**
+- Unsafe code blocks and their justification
+- Integer overflow in security contexts
+- Time-of-check to time-of-use (TOCTOU) issues
+- Panic paths that could cause DoS
+
+**DATABASE SECURITY**
+- Connection string exposure
+- Excessive database permissions
+- Missing row-level security considerations
+
+Provide specific recommendations for each finding with code examples.

--- a/.claude/pr-instructions.md
+++ b/.claude/pr-instructions.md
@@ -6,7 +6,7 @@ When creating pull requests for this repository:
 2. Output the PR description in a markdown code block for easy copying
 3. Keep descriptions concise and focused
 4. Only include sections that are relevant to the changes
-5. For UI changes, always specify what screenshots would be helpful
+5. For database migrations, note any breaking changes or required manual steps
 6. Always output the pull request text as markdown format
 
 The template is located at: `.github/pull_request_template.md`

--- a/Claude.md
+++ b/Claude.md
@@ -1,9 +1,0 @@
-# Claude Code Guidelines
-
-## Database Migrations
-
-**CRITICAL: PostgreSQL Type Ownership** - When creating any PostgreSQL type (enum, composite, etc.) using `create_type()`, you MUST immediately follow it with `ALTER TYPE refactor_platform.<type_name> OWNER TO refactor`.
-
-**Why this is required:** SeaORM's `create_type()` generates unqualified SQL (e.g., `CREATE TYPE role` instead of `CREATE TYPE refactor_platform.role`). PostgreSQL assigns ownership to the user executing the CREATE TYPE command. If the type is created by a superuser (like `doadmin`) but later migrations run as the `refactor` user, those migrations will fail with "must be owner of type" errors when attempting to ALTER the type.
-
-**For existing types without proper ownership:** A database superuser must manually run `ALTER TYPE refactor_platform.<type_name> OWNER TO refactor;` before migrations can modify those types.


### PR DESCRIPTION
## Description
Adapt the frontend's `.claude/` configuration for the Rust backend, providing Claude Code with project-specific guidance for code reviews, coding standards, and development workflows.

### Changes
* Add `.claude/CLAUDE.md` with project instructions and database migration guidelines (consolidated from root)
* Add `.claude/coding-standards.md` with Rust conventions (imports, naming, error handling, async patterns)
* Add 10 slash commands for specialized code reviews:
  - `api-review.md` - REST patterns, Axum handlers, request validation
  - `architecture-review.md` - Layer separation, trait design, state management
  - `bug-hunt.md` - Panic risks, async issues, memory/lifetime problems
  - `comprehensive-review.md` - References all other reviews (DRY)
  - `performance-review.md` - Memory, database, async runtime efficiency
  - `security-review.md` - Injection, auth, data exposure, Rust-specific
  - `rust-review.md` - Ownership, lifetimes, idioms (Context7 for crates)
  - `migration-review.md` - PostgreSQL types, SeaORM patterns (Context7)
  - `accessibility-review.md` - API consumer-friendliness
  - `load-context.md` - Project context loading with Context7 + Serena
* Update `.claude/pr-instructions.md` for backend context (migrations note)
* Delete root `Claude.md` (content moved to `.claude/CLAUDE.md`)

### Testing Strategy
Run the slash commands (e.g., `/api-review`, `/rust-review`) on code changes to verify they provide relevant review criteria for Rust/Axum/SeaORM code.

### Concerns
None - these are documentation/configuration files only.