### PR TITLE
Add coaching_relationship_id filter to user actions endpoint

### DIFF
--- a/web/src/controller/user/action_controller.rs
+++ b/web/src/controller/user/action_controller.rs
@@ -26,6 +26,7 @@ use log::*;
         ("user_id" = Id, Path, description = "User ID to retrieve actions for"),
         ("scope" = Option<String>, Query, description = "Scope: 'sessions' (default) or 'assigned'"),
         ("coaching_session_id" = Option<Id>, Query, description = "Filter by coaching session"),
+        ("coaching_relationship_id" = Option<Id>, Query, description = "Filter by coaching relationship"),
         ("assignee_filter" = Option<String>, Query, description = "Filter: 'all' (default), 'assigned', or 'unassigned'"),
         ("status" = Option<String>, Query, description = "Filter by action status"),
         ("sort_by" = Option<String>, Query, description = "Sort by: 'due_by', 'created_at', 'updated_at'"),
@@ -67,6 +68,7 @@ pub async fn index(
             Scope::Sessions => ActionApi::Scope::Sessions,
         },
         coaching_session_id: params.coaching_session_id,
+        coaching_relationship_id: params.coaching_relationship_id,
         status: params.status,
         assignee_filter: match params.assignee_filter {
             AssigneeFilter::All => ActionApi::AssigneeFilter::All,

--- a/web/src/params/user/action.rs
+++ b/web/src/params/user/action.rs
@@ -68,6 +68,8 @@ pub(crate) struct IndexParams {
     pub(crate) scope: Scope,
     /// Optional: filter to a specific coaching session
     pub(crate) coaching_session_id: Option<Id>,
+    /// Optional: filter to a specific coaching relationship
+    pub(crate) coaching_relationship_id: Option<Id>,
     /// Optional: filter by assignee status (all, assigned, unassigned)
     #[serde(default)]
     pub(crate) assignee_filter: AssigneeFilter,


### PR DESCRIPTION
## Description

Add optional `coaching_relationship_id` query parameter to `GET /users/{user_id}/actions`, enabling server-side filtering of actions by coaching relationship. Mirrors the existing pattern on `GET /users/{user_id}/coaching_sessions`.

#### GitHub Issue: Related to refactor-group/refactor-platform-fe#286

**Frontend PR:** refactor-group/refactor-platform-fe#290

### Changes

* Add `coaching_relationship_id` optional filter across entity_api, web params, and controller layers
* Conditionally join `coaching_sessions` table for `Scope::Assigned` (already joined for `Scope::Sessions`)
* Add 2 unit tests covering both scopes with the new filter

### Testing Strategy

* 2 new unit tests pass for both `Scope::Sessions` and `Scope::Assigned` with relationship filter
* Full test suite green, `cargo clippy` and `cargo fmt` clean
* Manual: `GET /users/{id}/actions?coaching_relationship_id={uuid}` returns only actions from that relationship's sessions

### Concerns

* None — backward-compatible optional query parameter