### PR TITLE
Add missing email notification env vars to deploy workflow

### DIFF
--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -117,7 +117,13 @@ jobs:
           # -------- Mailersend Config
           # Template ID for welcome emails
           WELCOME_EMAIL_TEMPLATE_ID=${{ vars.WELCOME_EMAIL_TEMPLATE_ID }}
+          # Template ID for session-scheduled notification emails
+          SESSION_SCHEDULED_EMAIL_TEMPLATE_ID=${{ vars.SESSION_SCHEDULED_EMAIL_TEMPLATE_ID }}
+          # Template ID for action-assigned notification emails
+          ACTION_ASSIGNED_EMAIL_TEMPLATE_ID=${{ vars.ACTION_ASSIGNED_EMAIL_TEMPLATE_ID }}
           MAILERSEND_API_KEY=${{ secrets.MAILERSEND_API_KEY }}
+          # Base URL of the frontend app, used to construct links in emails
+          FRONTEND_BASE_URL=${{ vars.FRONTEND_BASE_URL }}
 
           # -------- Frontend Config
           # Docker image for frontend


### PR DESCRIPTION
## Description
The session-scheduled email template ID, action-assigned email template ID, and frontend base URL environment variables were not being passed to the production container in the deploy workflow. This caused email notifications to silently not send in production, even though the application code was working correctly locally.

### Changes
* Added `SESSION_SCHEDULED_EMAIL_TEMPLATE_ID` to deploy workflow (sourced from GitHub vars)
* Added `ACTION_ASSIGNED_EMAIL_TEMPLATE_ID` to deploy workflow (sourced from GitHub vars)
* Added `FRONTEND_BASE_URL` to deploy workflow (sourced from GitHub vars)

### Testing Strategy
1. Verify the three new GitHub repository variables are set in Settings → Secrets and variables → Actions → Variables
2. Deploy to production and trigger a session-scheduled or action-assigned event
3. Confirm the email notification is received with correct links

### Concerns
* The corresponding GitHub repository variables (`SESSION_SCHEDULED_EMAIL_TEMPLATE_ID`, `ACTION_ASSIGNED_EMAIL_TEMPLATE_ID`, `FRONTEND_BASE_URL`) must be configured before deploying, otherwise the values will be empty and notifications will still be skipped