### PR TITLE
Fix email tests that fail when MailerSend env vars are in .env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,7 +932,6 @@ dependencies = [
  "sea-orm",
  "serde",
  "serde_json",
- "serial_test",
  "service",
  "tokio",
 ]
@@ -3166,15 +3165,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "scc"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
-dependencies = [
- "sdd",
-]
-
-[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3198,12 +3188,6 @@ dependencies = [
  "ring",
  "untrusted 0.9.0",
 ]
-
-[[package]]
-name = "sdd"
-version = "3.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sea-bae"
@@ -3485,32 +3469,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serial_test"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0b343e184fc3b7bb44dff0705fffcf4b3756ba6aff420dddd8b24ca145e555"
-dependencies = [
- "futures-executor",
- "futures-util",
- "log",
- "once_cell",
- "parking_lot",
- "scc",
- "serial_test_derive",
-]
-
-[[package]]
-name = "serial_test_derive"
-version = "3.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f50427f258fb77356e4cd4aa0e87e2bd2c66dbcee41dc405282cae2bfc26c83"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.116",
 ]
 
 [[package]]

--- a/domain/Cargo.toml
+++ b/domain/Cargo.toml
@@ -24,7 +24,6 @@ features = ["debug-print", "runtime-tokio-native-tls", "sqlx-postgres"]
 
 [dev-dependencies]
 mockito = "1.6"
-serial_test = "3.1"
 
 [features]
 mock = ["entity_api/mock"]

--- a/domain/src/emails.rs
+++ b/domain/src/emails.rs
@@ -469,9 +469,7 @@ mod tests {
     use crate::{coaching_sessions, organizations, users, Id};
     use chrono::NaiveDate;
     use mockito::{Server, ServerGuard};
-    use serial_test::serial;
     use service::config::Config;
-    use std::env;
 
     async fn setup_test_server() -> ServerGuard {
         Server::new_async().await
@@ -544,54 +542,27 @@ mod tests {
     }
 
     fn create_config_with_mock(server_url: &str) -> Config {
-        env::set_var("MAILERSEND_API_KEY", "test_api_key_123");
-        env::set_var("WELCOME_EMAIL_TEMPLATE_ID", "template_123");
-        env::set_var("MAILERSEND_BASE_URL", format!("{server_url}/v1"));
-        Config::default()
+        Config::from_args([
+            "test",
+            "--mailersend-api-key=test_api_key_123",
+            "--welcome-email-template-id=template_123",
+            &format!("--mailersend-base-url={server_url}/v1"),
+        ])
     }
 
     fn create_full_config_with_mock(server_url: &str) -> Config {
-        env::set_var("MAILERSEND_API_KEY", "test_api_key_123");
-        env::set_var("WELCOME_EMAIL_TEMPLATE_ID", "template_123");
-        env::set_var(
-            "SESSION_SCHEDULED_EMAIL_TEMPLATE_ID",
-            "session_template_456",
-        );
-        env::set_var("ACTION_ASSIGNED_EMAIL_TEMPLATE_ID", "action_template_789");
-        env::set_var("FRONTEND_BASE_URL", "https://app.example.com");
-        env::set_var("MAILERSEND_BASE_URL", format!("{server_url}/v1"));
-        Config::default()
-    }
-
-    /// Helper struct to manage environment variables in tests
-    struct EnvGuard {
-        saved_vars: Vec<(String, Option<String>)>,
-    }
-
-    impl EnvGuard {
-        fn new(vars: &[&str]) -> Self {
-            let saved_vars = vars
-                .iter()
-                .map(|var| (var.to_string(), env::var(var).ok()))
-                .collect();
-            EnvGuard { saved_vars }
-        }
-    }
-
-    impl Drop for EnvGuard {
-        fn drop(&mut self) {
-            // Restore all saved environment variables
-            for (key, value) in &self.saved_vars {
-                match value {
-                    Some(val) => env::set_var(key, val),
-                    None => env::remove_var(key),
-                }
-            }
-        }
+        Config::from_args([
+            "test",
+            "--mailersend-api-key=test_api_key_123",
+            "--welcome-email-template-id=template_123",
+            "--session-scheduled-email-template-id=session_template_456",
+            "--action-assigned-email-template-id=action_template_789",
+            "--frontend-base-url=https://app.example.com",
+            &format!("--mailersend-base-url={server_url}/v1"),
+        ])
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_welcome_email_success() {
         let mut server = setup_test_server().await;
         let user = create_test_user();
@@ -631,15 +602,8 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_welcome_email_missing_api_key() {
-        let _guard = EnvGuard::new(&["MAILERSEND_API_KEY", "WELCOME_EMAIL_TEMPLATE_ID"]);
-
-        // Set test state
-        env::remove_var("MAILERSEND_API_KEY");
-        env::set_var("WELCOME_EMAIL_TEMPLATE_ID", "template_123");
-
-        let config = Config::default();
+        let config = Config::from_args(["test", "--welcome-email-template-id=template_123"]);
         assert!(
             config.mailersend_api_key().is_none(),
             "API key should be None"
@@ -659,15 +623,8 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_welcome_email_missing_template_id() {
-        let _guard = EnvGuard::new(&["MAILERSEND_API_KEY", "WELCOME_EMAIL_TEMPLATE_ID"]);
-
-        // Set test state
-        env::set_var("MAILERSEND_API_KEY", "test_api_key_123");
-        env::remove_var("WELCOME_EMAIL_TEMPLATE_ID");
-
-        let config = Config::default();
+        let config = Config::from_args(["test", "--mailersend-api-key=test_api_key_123"]);
         assert!(
             config.mailersend_api_key().is_some(),
             "API key should be present"
@@ -691,7 +648,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_welcome_email_http_error() {
         let mut server = setup_test_server().await;
         let user = create_test_user();
@@ -711,7 +667,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_welcome_email_server_slow_response() {
         let mut server = setup_test_server().await;
         let user = create_test_user();
@@ -734,7 +689,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_welcome_email_with_different_user_data() {
         let mut server = setup_test_server().await;
         let user = users::Model {
@@ -785,7 +739,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_welcome_email_validates_personalization() {
         let mut server = setup_test_server().await;
         let user = users::Model {
@@ -838,15 +791,7 @@ mod tests {
     // ── Session Scheduled Email Tests ──────────────────────────────────
 
     #[tokio::test]
-    #[serial]
     async fn test_send_session_scheduled_email_personalization() {
-        let _guard = EnvGuard::new(&[
-            "MAILERSEND_API_KEY",
-            "SESSION_SCHEDULED_EMAIL_TEMPLATE_ID",
-            "FRONTEND_BASE_URL",
-            "MAILERSEND_BASE_URL",
-        ]);
-
         let mut server = setup_test_server().await;
         let config = create_full_config_with_mock(&server.url());
 
@@ -899,15 +844,7 @@ mod tests {
     // ── Action Assigned Email Tests ────────────────────────────────────
 
     #[tokio::test]
-    #[serial]
     async fn test_send_action_assigned_email_success() {
-        let _guard = EnvGuard::new(&[
-            "MAILERSEND_API_KEY",
-            "ACTION_ASSIGNED_EMAIL_TEMPLATE_ID",
-            "FRONTEND_BASE_URL",
-            "MAILERSEND_BASE_URL",
-        ]);
-
         let mut server = setup_test_server().await;
         let config = create_full_config_with_mock(&server.url());
 
@@ -964,15 +901,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_action_assigned_email_no_due_date() {
-        let _guard = EnvGuard::new(&[
-            "MAILERSEND_API_KEY",
-            "ACTION_ASSIGNED_EMAIL_TEMPLATE_ID",
-            "FRONTEND_BASE_URL",
-            "MAILERSEND_BASE_URL",
-        ]);
-
         let mut server = setup_test_server().await;
         let config = create_full_config_with_mock(&server.url());
 
@@ -1023,15 +952,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_action_assigned_email_multiple_assignees() {
-        let _guard = EnvGuard::new(&[
-            "MAILERSEND_API_KEY",
-            "ACTION_ASSIGNED_EMAIL_TEMPLATE_ID",
-            "FRONTEND_BASE_URL",
-            "MAILERSEND_BASE_URL",
-        ]);
-
         let mut server = setup_test_server().await;
         let config = create_full_config_with_mock(&server.url());
 
@@ -1062,21 +983,14 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_action_assigned_email_missing_template_id() {
-        let _guard = EnvGuard::new(&[
-            "MAILERSEND_API_KEY",
-            "ACTION_ASSIGNED_EMAIL_TEMPLATE_ID",
-            "FRONTEND_BASE_URL",
-            "MAILERSEND_BASE_URL",
-        ]);
-
         let server = setup_test_server().await;
-        env::set_var("MAILERSEND_API_KEY", "test_api_key_123");
-        env::set_var("MAILERSEND_BASE_URL", format!("{}/v1", server.url()));
-        env::set_var("FRONTEND_BASE_URL", "https://app.example.com");
-        env::remove_var("ACTION_ASSIGNED_EMAIL_TEMPLATE_ID");
-        let config = Config::default();
+        let config = Config::from_args([
+            "test",
+            "--mailersend-api-key=test_api_key_123",
+            &format!("--mailersend-base-url={}/v1", server.url()),
+            "--frontend-base-url=https://app.example.com",
+        ]);
 
         let assigner = create_test_user_with("Alex", "Smith", "alex@example.com", "UTC");
         let assignee = create_test_user_with("Jane", "Doe", "jane@example.com", "UTC");
@@ -1103,15 +1017,7 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_send_action_assigned_email_empty_assignees_sends_nothing() {
-        let _guard = EnvGuard::new(&[
-            "MAILERSEND_API_KEY",
-            "ACTION_ASSIGNED_EMAIL_TEMPLATE_ID",
-            "FRONTEND_BASE_URL",
-            "MAILERSEND_BASE_URL",
-        ]);
-
         let mut server = setup_test_server().await;
         let config = create_full_config_with_mock(&server.url());
 
@@ -1155,7 +1061,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_build_session_url_success() {
         let server = setup_test_server().await;
         let email_config = create_test_email_config(
@@ -1178,7 +1083,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_build_session_url_custom_path_template() {
         let server = setup_test_server().await;
         let email_config = create_test_email_config(
@@ -1200,7 +1104,6 @@ mod tests {
     }
 
     #[tokio::test]
-    #[serial]
     async fn test_build_session_url_no_url_builder() {
         let server = setup_test_server().await;
         let email_config = create_test_email_config(&server.url(), None).await;

--- a/domain/src/gateway/mailersend.rs
+++ b/domain/src/gateway/mailersend.rs
@@ -325,18 +325,10 @@ async fn build_auth_headers(config: &Config) -> Result<reqwest::header::HeaderMa
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serial_test::serial;
     use service::config::Config;
 
     #[tokio::test]
-    #[serial]
     async fn test_mailersend_client_creation_fails_without_api_key() {
-        // Save current env state
-        let saved_api_key = std::env::var("MAILERSEND_API_KEY").ok();
-
-        // Ensure no API key is set
-        std::env::remove_var("MAILERSEND_API_KEY");
-
         let config = Config::default();
         assert!(
             config.mailersend_api_key().is_none(),
@@ -345,11 +337,6 @@ mod tests {
 
         let result = MailerSendClient::new(&config).await;
         assert!(result.is_err());
-
-        // Restore env state
-        if let Some(key) = saved_api_key {
-            std::env::set_var("MAILERSEND_API_KEY", key);
-        }
     }
 
     #[tokio::test]

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -1,7 +1,6 @@
 use clap::builder::TypedValueParser as _;
 use clap::parser::ValueSource;
 use clap::{CommandFactory, FromArgMatches, Parser};
-use dotenvy::dotenv;
 use log::{debug, warn, LevelFilter};
 use semver::{BuildMetadata, Prerelease, Version};
 use serde::Deserialize;
@@ -303,23 +302,49 @@ pub struct Config {
 }
 
 impl Default for Config {
+    /// Returns a `Config` with clap's compiled-in defaults. Does not read
+    /// real CLI args or `.env` files. Shell env vars are still read via
+    /// clap's `#[arg(env)]` attributes.
     fn default() -> Self {
-        Self::new()
+        Self::from_args(["refactor-platform-rs"])
     }
 }
 
 impl Config {
+    /// Parse config from real process CLI args and env vars.
+    ///
+    /// **Important:** Call [`service::load_env_file`] before this if you want
+    /// `.env` file values to be available. This method intentionally does not
+    /// load `.env` itself so that test code can use [`Config::default`] or
+    /// [`Config::from_args`] without side effects.
     pub fn new() -> Self {
-        // Load .env file first
-        dotenv().ok();
-        // Parse CLI args and env vars, retaining ArgMatches so we can
-        // inspect which values came from defaults vs explicit configuration
         let matches = Config::command().get_matches();
         let mut config =
             Config::from_arg_matches(&matches).expect("Failed to build Config from arg matches");
 
         config.capture_value_sources(&matches);
         Self::warn_untracked_fields(&matches);
+
+        config
+    }
+
+    /// Parse config from an explicit argument list. Does not read real CLI
+    /// args. Clap's `#[arg(env)]` fields still read from process env vars,
+    /// but `.env` is not loaded.
+    ///
+    /// Primarily useful for tests that need a `Config` with specific values.
+    pub fn from_args<I, T>(args: I) -> Self
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<std::ffi::OsString> + Clone,
+    {
+        let matches = Config::command()
+            .try_get_matches_from(args)
+            .expect("Failed to parse args");
+        let mut config =
+            Config::from_arg_matches(&matches).expect("Failed to build Config from arg matches");
+
+        config.capture_value_sources(&matches);
 
         config
     }
@@ -571,28 +596,9 @@ impl fmt::Display for ApiVersion {
 mod tests {
     use super::*;
 
-    /// Builds a Config from simulated CLI args, capturing value sources
-    /// the same way `Config::new()` does — but without parsing real process
-    /// args or loading `.env`.
-    fn config_from_args<I, T>(args: I) -> Config
-    where
-        I: IntoIterator<Item = T>,
-        T: Into<std::ffi::OsString> + Clone,
-    {
-        let matches = Config::command()
-            .try_get_matches_from(args)
-            .expect("Failed to parse test args");
-        let mut config =
-            Config::from_arg_matches(&matches).expect("Failed to build Config from arg matches");
-
-        config.capture_value_sources(&matches);
-
-        config
-    }
-
     #[test]
     fn unset_field_shows_default_value_and_suffix() {
-        let config = config_from_args(["test_binary"]);
+        let config = Config::from_args(["test_binary"]);
 
         assert_eq!(config.port.display_value(), "4000");
         assert_eq!(config.source_suffix("port"), " (default)");
@@ -600,7 +606,7 @@ mod tests {
 
     #[test]
     fn explicitly_set_field_shows_actual_value_without_suffix() {
-        let config = config_from_args(["test_binary", "--port", "8080"]);
+        let config = Config::from_args(["test_binary", "--port", "8080"]);
 
         assert_eq!(config.port.display_value(), "8080");
         assert_eq!(config.source_suffix("port"), "");

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -7,6 +7,15 @@ use tokio::time::Duration;
 pub mod config;
 pub mod logging;
 
+/// Load environment variables from the `.env` file into the process environment.
+///
+/// Call this at the application entry point (e.g. `main()`) before
+/// constructing [`Config`]. This is intentionally separate from `Config::new()`
+/// so that test code can construct configs without `.env` side effects.
+pub fn load_env_file() {
+    dotenvy::dotenv().ok();
+}
+
 pub async fn init_database(config: &Config) -> Result<DatabaseConnection, DbErr> {
     info!(
         "Database pool config: max_connections={}, min_connections={}, \

--- a/src/bin/seed_db.rs
+++ b/src/bin/seed_db.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
+    service::load_env_file();
     let config = Config::new();
     Logger::init_logger(&config as &Config);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,7 @@ async fn main() {
 }
 
 fn get_config() -> Config {
+    service::load_env_file();
     Config::new()
 }
 


### PR DESCRIPTION
## Description
Email tests that assert missing config values (no API key, no template ID) fail for engineers who have MailerSend env vars in their local `.env` file. The root cause: `Config::new()` calls `dotenv()` internally, which re-reads `.env` and restores vars that the test just removed via `env::remove_var`, causing assertion panics.

The fix separates `.env` loading from `Config` construction:

- **`Config::new()`** — production constructor; reads real CLI args and env vars but no longer calls `dotenv()` itself
- **`Config::default()`** — safe for tests; returns clap defaults via `from_args()` without reading real CLI args or `.env`
- **`Config::from_args([...])`** — new public method for tests that need specific config values
- **`service::load_env_file()`** — explicit `.env` loading, called at application entry points (`main.rs`, `seed_db.rs`)

This also eliminates all uses of the unsafe `env::set_var`/`env::remove_var` from domain tests.

### Changes
* Move `dotenv()` out of `Config::new()` into a new `service::load_env_file()` function
* Call `service::load_env_file()` explicitly in `main.rs` and `seed_db.rs` before `Config::new()`
* Add `Config::from_args()` public method for constructing configs from explicit CLI arg lists
* Redefine `Config::default()` to use `from_args()` — safe, predictable, no side effects
* Replace all `env::set_var` / `env::remove_var` / `EnvGuard` / `Config::default()` in domain email tests with `Config::from_args([...])`
* Remove the `EnvGuard` helper struct from `domain/src/emails.rs`
* Remove all `#[serial]` annotations and the `serial_test` dev-dependency — no longer needed since tests don't share mutable state

### Testing Strategy
* `cargo test -p domain --lib` — all 31 tests pass
* `cargo test -p service --lib` — all 10 tests pass
* `cargo clippy --all-targets -- -D warnings` — clean across entire workspace
* Tests are now deterministic regardless of local `.env` content or shell environment