### PR TITLE
Handle no OAuth credentials

### DIFF
--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -62,7 +62,13 @@ pub async fn create(
     info!("Attempting to create Tiptap document with name: {document_name}");
     coaching_session_model.collab_document_name = Some(document_name.clone());
 
-    maybe_attach_meeting_url(db, config, &mut coaching_session_model, coaching_relationship.coach_id).await?;
+    maybe_attach_meeting_url(
+        db,
+        config,
+        &mut coaching_session_model,
+        coaching_relationship.coach_id,
+    )
+    .await?;
 
     let tiptap = TiptapDocument::new(config).await?;
     tiptap.create(&document_name).await?;
@@ -125,13 +131,10 @@ async fn maybe_attach_meeting_url(
     coach_id: Id,
 ) -> Result<(), Error> {
     if let Some(provider) = &coaching_session_model.provider {
-        let has_credentials = crate::oauth_connection::find_by_user_and_provider(
-            db,
-            coach_id,
-            *provider,
-        )
-        .await?
-        .is_some();
+        let has_credentials =
+            crate::oauth_connection::find_by_user_and_provider(db, coach_id, *provider)
+                .await?
+                .is_some();
 
         if has_credentials {
             let meeting_url = create_meeting_url(db, config, coach_id, provider).await?;


### PR DESCRIPTION
## Description                                                                                                                                         
  Gracefully handle the case where a coaching session is created with a meeting provider specified, but the coach has not yet connected their OAuth credentials. Previously this would result in an error; now the session is created successfully without a meeting URL when no OAuth credentials exist.  
                  
  #### GitHub Issue: Closes #_your GitHub issue number here_

  ### Changes
  * Updated `domain/src/coaching_session.rs` to check for existing OAuth credentials before attempting to create a meeting URL
  * When a provider is specified but no OAuth connection exists for the coach, meeting creation is skipped and the session proceeds without a
  `meeting_url`
  * Added `mock`-gated unit tests covering two scenarios: no provider set (skips OAuth lookup entirely), and provider set with no credentials (skips
  meeting creation)

  ### Testing Strategy
  - Run `cargo test --features mock` to execute the new unit tests in `domain/src/coaching_session.rs`
  - Manually create a coaching session with a provider (e.g. Google) for a coach who has not connected OAuth — verify the session is created successfully
   with `meeting_url: null` instead of returning an error
  - Verify that a coach who *has* connected OAuth still gets a `meeting_url` populated as expected

