### PR TITLE
Adjust API version comparison log levels

### DIFF
--- a/web/src/extractors/compare_api_version.rs
+++ b/web/src/extractors/compare_api_version.rs
@@ -58,7 +58,7 @@ fn is_current_api_version(
 ) -> Result<CompareApiVersion, RejectionType> {
     let version_str = normalize_version(&version);
     let api_version_str = normalize_version(&api_version);
-    warn!(
+    trace!(
         "API version comparison {:?} == {:?}: {}",
         version_str,
         api_version_str,
@@ -67,6 +67,10 @@ fn is_current_api_version(
     if version_str == api_version_str {
         Ok(CompareApiVersion(version))
     } else {
+        warn!(
+            "API version mismatch: client sent {:?}, server expects {:?}",
+            version_str, api_version_str
+        );
         Err((
             StatusCode::BAD_REQUEST,
             format!(


### PR DESCRIPTION
## Description
Demote the API version comparison log from `warn` to `trace` for the happy path (versions match) and add a `warn`-level log for the mismatch case.

### Changes
* Changed `warn!` to `trace!` for the routine version comparison message that fires on every request
* Added a `warn!` log when the client-provided API version does not match the server's expected version

### Testing Strategy
- Run the server locally and confirm that matching version requests no longer produce warn-level output
- Send a request with a mismatched `X-Version` header and verify the warn log appears

### Concerns
None