### PR TITLE
Remove in-progress status filter from batch_load_goals

### DIFF
--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -445,13 +445,10 @@ async fn batch_load_organizations(
         .collect())
 }
 
-/// Batch load in-progress goals by session IDs via the coaching_sessions_goals join table.
+/// Batch load goals by session IDs via the coaching_sessions_goals join table.
 ///
 /// Delegates to [`super::coaching_session_goal::find_goals_grouped_by_session_ids`] for
-/// the DB query and grouping, then filters to in-progress goals capped at
-/// [`super::goal::max_in_progress_goals`] per session.
-///
-/// For full per-session goal lists, use `GET /coaching_sessions/{id}/goals` instead.
+/// the DB query and grouping, then caps at [`super::goal::max_in_progress_goals`] per session.
 async fn batch_load_goals(
     db: &impl ConnectionTrait,
     session_ids: &[Id],
@@ -464,18 +461,13 @@ async fn batch_load_goals(
     let map: HashMap<Id, Vec<goals::Model>> = all_goals
         .into_iter()
         .map(|(session_id, goals)| {
-            let capped: Vec<_> = goals
-                .into_iter()
-                .filter(|g| g.in_progress())
-                .take(max_goals)
-                .collect();
+            let capped: Vec<_> = goals.into_iter().take(max_goals).collect();
             (session_id, capped)
         })
-        .filter(|(_, goals)| !goals.is_empty())
         .collect();
 
     debug!(
-        "batch_load_goals: loaded in-progress goals for {} of {} sessions",
+        "batch_load_goals: loaded goals for {} of {} sessions",
         map.len(),
         session_ids.len()
     );


### PR DESCRIPTION
## Description
The enriched sessions endpoint (`batch_load_goals`) filtered goals to only in-progress status, while the batch goals endpoint returned all goals regardless of status. This caused the join session popover to show "No goal set" for sessions that had linked goals with `not_started` or other non-in-progress statuses, even though the coaching session list displayed them correctly.

### Changes
* Remove `.filter(|g| g.in_progress())` from `batch_load_goals` in `entity_api/src/coaching_session.rs` so all linked goals are returned regardless of status
* Remove `.filter(|(_, goals)| !goals.is_empty())` which dropped sessions after the status filter emptied their goal list
* Keep the per-session cap at `max_in_progress_goals()` to bound payload size

### Testing Strategy
1. Open the coaching sessions page for a relationship that has sessions with non-in-progress goals (e.g. `not_started`)
2. Verify the join session popover (right side) now shows goal titles matching the coaching session list (left side)
3. Verify sessions that genuinely have no linked goals still show "No goal set"

### Concerns
None — the only frontend consumer of `batch_load_goals` (via the enriched endpoint) is the join session popover, which displays the first goal title regardless of status. The coaching session detail page does its own in-progress filtering on the frontend side.