### PR TITLE
Fix status enum ownership for on_hold migration

### DIFF
--- a/migration/src/m20260317_000000_add_on_hold_to_status_enum.rs
+++ b/migration/src/m20260317_000000_add_on_hold_to_status_enum.rs
@@ -8,7 +8,14 @@ impl MigrationTrait for Migration {
     async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
         manager
             .get_connection()
-            .execute_unprepared("ALTER TYPE refactor_platform.status ADD VALUE 'on_hold'")
+            .execute_unprepared(
+                "ALTER TYPE refactor_platform.status ADD VALUE IF NOT EXISTS 'on_hold'",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("ALTER TYPE refactor_platform.status OWNER TO refactor")
             .await?;
 
         Ok(())


### PR DESCRIPTION
## Description
Fix the `on_hold` status enum migration to set proper ownership on the `status` PostgreSQL type, preventing "must be owner of type status" errors when the migration runs as the `refactor` user.

### Changes
* Add `ALTER TYPE refactor_platform.status OWNER TO refactor` after adding the `on_hold` value in the `up` migration
* Use `IF NOT EXISTS` for idempotency since the `on_hold` value was already manually applied to production

### Testing Strategy
* Run `sea-orm-cli migrate status -s refactor_platform -d migration` against a fresh database to confirm the migration applies cleanly
* Verify the migration is idempotent on the production database where `on_hold` was already manually added

### Concerns
* The `down` migration already had the `OWNER TO refactor` step — this brings `up` into parity
* **Production was unblocked by manually running** `ALTER TYPE refactor_platform.status OWNER TO refactor` followed by the migration