### PR TITLE
Resolve assignee query param in single-relationship actions endpoint

### DIFF
--- a/web/src/controller/organization/coaching_relationship/actions_controller.rs
+++ b/web/src/controller/organization/coaching_relationship/actions_controller.rs
@@ -45,7 +45,15 @@ pub async fn read(
 ) -> Result<impl IntoResponse, Error> {
     debug!("GET actions for coaching relationship: {}", relationship.id);
 
-    let query_params = params.into_query_params();
+    let assignee_scope = params.assignee_scope();
+    let mut query_params = params.into_query_params();
+
+    // Resolve role-based assignee scope to a concrete user ID
+    query_params.assignee_user_id = assignee_scope.map(|scope| match scope {
+        ActionApi::AssigneeScope::Coach => relationship.coach_id,
+        ActionApi::AssigneeScope::Coachee => relationship.coachee_id,
+        ActionApi::AssigneeScope::User(id) => id,
+    });
 
     let actions = ActionApi::find_by_coaching_relationship(
         app_state.db_conn_ref(),


### PR DESCRIPTION
## Description

The single-relationship actions endpoint (`GET /coaching_relationships/{rel_id}/actions`) accepted the `assignee` query parameter but silently discarded it. The `into_query_params()` conversion hardcoded `assignee_user_id` to `None`, meaning `?assignee=coach` and `?assignee=coachee` had no effect — both returned all actions for the relationship.

### Changes

* Extract `assignee_scope` from query params before consuming them via `into_query_params()`
* Resolve the role-based scope (`coach`/`coachee`/UUID) to a concrete user ID using the relationship model's `coach_id`/`coachee_id`
* Set `assignee_user_id` on the query params so the existing post-query filter in `find_by_coaching_relationship()` applies correctly

This mirrors the pattern already used by the batch endpoint (`index()` handler), which correctly resolves the assignee scope per-relationship.

### Testing Strategy

1. Call `GET /organizations/{org_id}/coaching_relationships/{rel_id}/actions?assignee=coach` — should return only actions where the coach is an assignee
2. Call the same endpoint with `?assignee=coachee` — should return only actions where the coachee is an assignee
3. Call without `assignee` param — should return all actions (unchanged behavior)
4. Verify the batch endpoint (`GET .../coaching_relationships/actions?assignee=coach`) still works correctly (no changes to that code path)

### Concerns

* The batch endpoint is unaffected — it has separate scope resolution logic in `find_by_coach_relationships()`
* No migration or breaking API changes — the endpoint already advertised this param, it just wasn't wired up