### PR TITLE
Tolerate empty DB pool env vars on container startup

### DIFF
--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -385,9 +385,8 @@ impl Config {
     /// load `.env` itself so that test code can use [`Config::default`] or
     /// [`Config::from_args`] without side effects.
     pub fn new() -> Self {
-        let cmd = Config::command();
-        Self::sanitize_empty_env(&cmd);
-        let matches = cmd.get_matches();
+        Self::sanitize_empty_env(&Config::command());
+        let matches = Config::command().get_matches();
         let mut config =
             Config::from_arg_matches(&matches).expect("Failed to build Config from arg matches");
 
@@ -407,9 +406,8 @@ impl Config {
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        let cmd = Config::command();
-        Self::sanitize_empty_env(&cmd);
-        let matches = cmd
+        Self::sanitize_empty_env(&Config::command());
+        let matches = Config::command()
             .try_get_matches_from(args)
             .expect("Failed to parse args");
         let mut config =
@@ -429,6 +427,12 @@ impl Config {
     /// empty env as unset here lets clap fall back to `default_value_t`
     /// uniformly for every field, without hardcoding which ones need it.
     /// Self-maintaining: new `#[arg(env)]` fields get this behavior for free.
+    ///
+    /// The caller must pass a *throwaway* `Command` and build a fresh one for
+    /// actual parsing — clap 4 snapshots env values when each `Arg` is
+    /// constructed during `augment_args`, not when `get_matches()` is called,
+    /// so the `Command` used for parsing must be built *after* this sanitize
+    /// runs for the cleanup to take effect.
     fn sanitize_empty_env(cmd: &clap::Command) {
         for arg in cmd.get_arguments() {
             let Some(env_name) = arg.get_env() else {

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -27,6 +27,27 @@ const DEFAULT_SESSION_SCHEDULED_EMAIL_URL_PATH: &str = "/coaching-sessions/{sess
 /// Default URL path for action-assigned email links.
 const DEFAULT_ACTION_ASSIGNED_EMAIL_URL_PATH: &str = "/coaching-sessions/{session_id}?tab=actions";
 
+/// Parse an env var as `Self`, falling back to `default` when the var is unset,
+/// empty, whitespace-only, or unparseable.
+///
+/// Why: Docker Compose expands `KEY: ${KEY}` to an empty string when the host
+/// env var is unset, and clap's `#[arg(env)]` treats an empty value as a parse
+/// error for primitives (crashing the app on startup). Used by the DB pool
+/// tuning fields via `default_value_t` so missing/empty env vars degrade to
+/// the compiled-in default instead of failing to boot.
+trait FromEnvOrDefault: Sized {
+    fn from_env_or(key: &str, default: Self) -> Self;
+}
+
+impl<T: FromStr> FromEnvOrDefault for T {
+    fn from_env_or(key: &str, default: Self) -> Self {
+        std::env::var(key)
+            .ok()
+            .and_then(|v| v.trim().parse().ok())
+            .unwrap_or(default)
+    }
+}
+
 /// All config field names registered with Clap, used for value source tracking.
 /// This is the single source of truth for field key names across the Config type.
 const CONFIG_FIELD_KEYS: &[&str] = &[
@@ -192,27 +213,27 @@ pub struct Config {
     database_url: Option<String>,
 
     /// Maximum number of database connections in the pool
-    #[arg(long, env, default_value_t = 100)]
+    #[arg(long, default_value_t = u32::from_env_or("DB_MAX_CONNECTIONS", 100))]
     pub db_max_connections: u32,
 
     /// Minimum number of idle database connections to maintain
-    #[arg(long, env, default_value_t = 5)]
+    #[arg(long, default_value_t = u32::from_env_or("DB_MIN_CONNECTIONS", 5))]
     pub db_min_connections: u32,
 
     /// Timeout in seconds for establishing a new database connection
-    #[arg(long, env, default_value_t = 8)]
+    #[arg(long, default_value_t = u64::from_env_or("DB_CONNECT_TIMEOUT_SECS", 8))]
     pub db_connect_timeout_secs: u64,
 
     /// Timeout in seconds for acquiring a connection from the pool
-    #[arg(long, env, default_value_t = 8)]
+    #[arg(long, default_value_t = u64::from_env_or("DB_ACQUIRE_TIMEOUT_SECS", 8))]
     pub db_acquire_timeout_secs: u64,
 
     /// Seconds before an idle connection is closed
-    #[arg(long, env, default_value_t = 600)]
+    #[arg(long, default_value_t = u64::from_env_or("DB_IDLE_TIMEOUT_SECS", 600))]
     pub db_idle_timeout_secs: u64,
 
     /// Maximum lifetime in seconds for any connection in the pool
-    #[arg(long, env, default_value_t = 1800)]
+    #[arg(long, default_value_t = u64::from_env_or("DB_MAX_LIFETIME_SECS", 1800))]
     pub db_max_lifetime_secs: u64,
 
     /// The URL for the Tiptap Cloud API provider

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -27,27 +27,6 @@ const DEFAULT_SESSION_SCHEDULED_EMAIL_URL_PATH: &str = "/coaching-sessions/{sess
 /// Default URL path for action-assigned email links.
 const DEFAULT_ACTION_ASSIGNED_EMAIL_URL_PATH: &str = "/coaching-sessions/{session_id}?tab=actions";
 
-/// Parse an env var as `Self`, falling back to `default` when the var is unset,
-/// empty, whitespace-only, or unparseable.
-///
-/// Why: Docker Compose expands `KEY: ${KEY}` to an empty string when the host
-/// env var is unset, and clap's `#[arg(env)]` treats an empty value as a parse
-/// error for primitives (crashing the app on startup). Used by the DB pool
-/// tuning fields via `default_value_t` so missing/empty env vars degrade to
-/// the compiled-in default instead of failing to boot.
-trait FromEnvOrDefault: Sized {
-    fn from_env_or(key: &str, default: Self) -> Self;
-}
-
-impl<T: FromStr> FromEnvOrDefault for T {
-    fn from_env_or(key: &str, default: Self) -> Self {
-        std::env::var(key)
-            .ok()
-            .and_then(|v| v.trim().parse().ok())
-            .unwrap_or(default)
-    }
-}
-
 /// All config field names registered with Clap, used for value source tracking.
 /// This is the single source of truth for field key names across the Config type.
 const CONFIG_FIELD_KEYS: &[&str] = &[
@@ -213,27 +192,27 @@ pub struct Config {
     database_url: Option<String>,
 
     /// Maximum number of database connections in the pool
-    #[arg(long, default_value_t = u32::from_env_or("DB_MAX_CONNECTIONS", 100))]
+    #[arg(long, env, default_value_t = 100)]
     pub db_max_connections: u32,
 
     /// Minimum number of idle database connections to maintain
-    #[arg(long, default_value_t = u32::from_env_or("DB_MIN_CONNECTIONS", 5))]
+    #[arg(long, env, default_value_t = 5)]
     pub db_min_connections: u32,
 
     /// Timeout in seconds for establishing a new database connection
-    #[arg(long, default_value_t = u64::from_env_or("DB_CONNECT_TIMEOUT_SECS", 8))]
+    #[arg(long, env, default_value_t = 8)]
     pub db_connect_timeout_secs: u64,
 
     /// Timeout in seconds for acquiring a connection from the pool
-    #[arg(long, default_value_t = u64::from_env_or("DB_ACQUIRE_TIMEOUT_SECS", 8))]
+    #[arg(long, env, default_value_t = 8)]
     pub db_acquire_timeout_secs: u64,
 
     /// Seconds before an idle connection is closed
-    #[arg(long, default_value_t = u64::from_env_or("DB_IDLE_TIMEOUT_SECS", 600))]
+    #[arg(long, env, default_value_t = 600)]
     pub db_idle_timeout_secs: u64,
 
     /// Maximum lifetime in seconds for any connection in the pool
-    #[arg(long, default_value_t = u64::from_env_or("DB_MAX_LIFETIME_SECS", 1800))]
+    #[arg(long, env, default_value_t = 1800)]
     pub db_max_lifetime_secs: u64,
 
     /// The URL for the Tiptap Cloud API provider
@@ -406,7 +385,9 @@ impl Config {
     /// load `.env` itself so that test code can use [`Config::default`] or
     /// [`Config::from_args`] without side effects.
     pub fn new() -> Self {
-        let matches = Config::command().get_matches();
+        let cmd = Config::command();
+        Self::sanitize_empty_env(&cmd);
+        let matches = cmd.get_matches();
         let mut config =
             Config::from_arg_matches(&matches).expect("Failed to build Config from arg matches");
 
@@ -426,7 +407,9 @@ impl Config {
         I: IntoIterator<Item = T>,
         T: Into<std::ffi::OsString> + Clone,
     {
-        let matches = Config::command()
+        let cmd = Config::command();
+        Self::sanitize_empty_env(&cmd);
+        let matches = cmd
             .try_get_matches_from(args)
             .expect("Failed to parse args");
         let mut config =
@@ -435,6 +418,29 @@ impl Config {
         config.capture_value_sources(&matches);
 
         config
+    }
+
+    /// Unset any process env var that clap is configured to read (via
+    /// `#[arg(env)]`) whose value is empty or whitespace-only.
+    ///
+    /// Why: Docker Compose expands `KEY: ${KEY}` to an empty string when the
+    /// host var is unset, which clap treats as a set-but-unparseable value —
+    /// crashing primitive-typed fields like `u32`/`u64` on startup. Treating
+    /// empty env as unset here lets clap fall back to `default_value_t`
+    /// uniformly for every field, without hardcoding which ones need it.
+    /// Self-maintaining: new `#[arg(env)]` fields get this behavior for free.
+    fn sanitize_empty_env(cmd: &clap::Command) {
+        for arg in cmd.get_arguments() {
+            let Some(env_name) = arg.get_env() else {
+                continue;
+            };
+            let Ok(val) = std::env::var(env_name) else {
+                continue;
+            };
+            if val.trim().is_empty() {
+                std::env::remove_var(env_name);
+            }
+        }
     }
 
     /// Records the value source (Default, EnvVariable, CommandLine) for every


### PR DESCRIPTION
## Summary

Production boot is crashing on the rust-app container because Docker Compose expands `KEY: ${KEY}` to an empty string when the host var is unset, and clap's `#[arg(env)]` treats a set-but-empty env var as a parse error for `u32`/`u64` fields:

```
rust-app | error: invalid value '' for '--db-connect-timeout-secs <DB_CONNECT_TIMEOUT_SECS>':
rust-app |   cannot parse integer from empty string
```

This PR fixes that uniformly for every `#[arg(env)]` field in the Config, not just the six DB pool ones — by sanitizing empty env vars at a single chokepoint before clap builds its parsing Command.

## How

Adds `Config::sanitize_empty_env()` in `service/src/config.rs`, called from both `Config::new()` and `Config::from_args()`. It iterates `Command::get_arguments()`, reads `Arg::get_env()` to discover the env var name clap is configured to read for each argument, and unsets any whose current process-env value is empty or whitespace-only.

```rust
pub fn new() -> Self {
    Self::sanitize_empty_env(&Config::command());   // throwaway Command, purely for discovery
    let matches = Config::command().get_matches();  // fresh Command built after sanitize
    ...
}

fn sanitize_empty_env(cmd: &clap::Command) {
    for arg in cmd.get_arguments() {
        let Some(env_name) = arg.get_env() else { continue };
        let Ok(val) = std::env::var(env_name) else { continue };
        if val.trim().is_empty() {
            std::env::remove_var(env_name);
        }
    }
}
```

### The clap 4 env-snapshotting subtlety

**Clap 4 reads env values when each `Arg` is constructed during `augment_args` — not when `get_matches()` runs.** So if you build a `Command`, mutate the process env, and then call `get_matches()` on that same `Command`, the mutation has no effect — the `Arg`s are already frozen with the old env values.

The fix therefore builds the `Command` **twice**: once as a throwaway to discover which env var names clap cares about, and a second time (after the sanitize) to actually parse. The second `Command`'s `Arg`s are constructed against the cleaned-up env, so they see the empty vars as absent and fall back to `default_value_t` correctly.

Building the Command twice is cheap (metadata assembly, no I/O beyond env reads) and the alternative — hardcoding a per-field list of env var names in the sanitize — reintroduces the exact duplication this generic approach was designed to avoid.

## Why this shape

- **Generic, not per-field**: no hardcoded list of which fields need empty-string tolerance. Any future `#[arg(env)]` field gets the same behavior automatically.
- **Self-maintaining**: the env var names come from clap itself via `Arg::get_env()`. No duplication between attribute definitions and fix logic.
- **Preserves value-source tracking**: the six DB pool fields keep their original `#[arg(long, env, default_value_t = N)]` attributes, so clap's native `ValueSource::EnvVariable` vs `DefaultValue` tracking works correctly. Startup logs show `db_max_connections: 19` (no `(default)` suffix) when the env var is set, and `db_max_connections: 100 (default)` when it isn't.
- **Right altitude**: fixes the compose→clap impedance mismatch at the boundary between them rather than working around it inside individual field definitions.

## Commits

1. `fix: tolerate empty DB pool env vars on container startup` — initial narrow fix using a `FromEnvOrDefault` trait (superseded).
2. `refactor: sanitize empty env vars at chokepoint, not per field` — introduces the generic sanitize pass.
3. `fix: sanitize env vars before building the parsing Command` — corrects commit 2 to account for clap's eager env snapshotting; builds a throwaway Command for discovery, sanitizes, then builds the real Command for parsing.

Happy to squash-merge if you prefer a single logical commit in `main`.

## Test plan

- [x] `cargo check -p service` passes
- [x] `cargo clippy -p service --all-targets -- -D warnings` clean
- [x] `cargo fmt --check -p service` clean
- [x] `cargo test -p service --lib` — 10 tests pass
- [x] Local: `DB_MAX_CONNECTIONS=` (empty) in `.env` → container boots, log shows `max_connections=100` and `db_max_connections: 100 (default)`
- [x] Local: `DB_MAX_CONNECTIONS=19` exported → log shows `max_connections=19` and `db_max_connections: 19` (no `(default)` suffix)
- [x] Local: `DB_MIN_CONNECTIONS` unset → log shows `db_min_connections: 5 (default)`
- [ ] After merge + production deploy, confirm container boots and `Database pool config:` log line shows sensible values (either compiled default `100` or the configured value once `vars.DB_MAX_CONNECTIONS` is populated)
- [ ] Follow-up: set the six `vars.DB_*` values in the GitHub production environment so production runs with the intended `max_connections=19` cap