### PR TITLE
Relay correct status code for DB errors in `OrganizationMemberAccess` extractor

### DIFF
--- a/web/src/extractors/organization_member_access.rs
+++ b/web/src/extractors/organization_member_access.rs
@@ -64,17 +64,23 @@ where
             return Ok(OrganizationMemberAccess(organization_id));
         }
 
-        let user_organization_role_exists =
-            match UserApi::find_by_organization(state.db_conn_ref(), organization_id).await {
-                Ok(users) => users.iter().any(|user| user.id == authenticated_user.id),
-                Err(_) => {
-                    error!("Organization not found with ID {organization_id:?}");
-                    return Err((
-                        StatusCode::BAD_REQUEST,
-                        "Invalid organization ID".to_string(),
-                    ));
-                }
-            };
+        let user_organization_role_exists = match UserApi::find_by_organization(
+            state.db_conn_ref(),
+            organization_id,
+        )
+        .await
+        {
+            Ok(users) => users.iter().any(|user| user.id == authenticated_user.id),
+            Err(err) => {
+                error!(
+                        "find_by_organization({organization_id:?}) failed while verifying membership: {err:?}"
+                    );
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to verify organization membership".to_string(),
+                ));
+            }
+        };
 
         if !user_organization_role_exists {
             return Err((


### PR DESCRIPTION
## Description
The `OrganizationMemberAccess` extractor was mapping any failure from `UserApi::find_by_organization` to `400 Bad Request "Invalid organization ID"`.

That response is misleading: the organization ID is already parsed and validated as a UUID earlier in the extractor, and `find_by_organization` returns `Ok(vec![])` (not an error) when no users match — so the `Err(_)` arm can only be reached via a genuine database failure. Infrastructure errors should surface as `500 Internal Server Error`, not as a client-side validation failure, and the log line should reflect the actual cause rather than a fabricated "Organization not found" message.


#### GitHub Issue: [Fixes] #284 

### Changes
* In `web/src/extractors/organization_member_access.rs`, replace the `400 Bad Request "Invalid organization ID"` response in the DB-error arm with `500 Internal Server Error "Failed to verify organization membership"`.
* Log the underlying `sea_orm` error (`find_by_organization({organization_id:?}) failed while verifying membership: {err:?}`) instead of the misleading "Organization not found with ID ..." message.

### Testing Strategy
* `cargo check -p web` and `cargo clippy` both pass.
* Existing extractor tests (`test_extractor_returns_200_for_users_with_organizational_roles`, `test_extractor_returns_200_for_super_admin_users_without_organizational_roles`, `test_extractor_returns_401_organization_for_regular_users_without_organization_roles`) continue to exercise the success and unauthorized branches; no behavior change for those cases.
* To manually verify the new 500 path, point the backend at an unreachable database (e.g. stop Postgres or set a bad `DATABASE_URL`) and hit a route guarded by this extractor as a non-SuperAdmin user — the response should now be `500 Internal Server Error` with the real `sea_orm` error captured in the logs, rather than a confusing `400`.


### Concerns
* Behavior for a *valid UUID that does not exist in the database* is unchanged: non-admins still receive `401 Unauthorized` (since the member lookup returns an empty set), and SuperAdmins still pass the extractor and fail later in the handler. If we want missing-org requests to return `404` explicitly, that would be a separate change that adds an `organizations::find_by_id` check before the membership lookup.
