### PR TITLE
Wait for Tailscale path before SSH ops in deploy_to_do workflow

### DIFF
--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -31,6 +31,26 @@ jobs:
           version: latest # Use the latest version of Tailscale
           use-cache: "true" # Cache Tailscale binary for faster startup
 
+      # Step 1.5: Wait for the Tailscale WireGuard path to the deploy host to be
+      # established before running any SSH operations. Without this gate, the
+      # deploy step can race Tailscale's MagicDNS / route propagation and
+      # `ssh-keyscan` will fail silently under `bash -e`, exiting the step
+      # before any echo runs. `tailscale ping` confirms the actual peer path,
+      # not just DNS resolution.
+      - name: Wait for Tailscale path to deploy host
+        run: |
+          echo "Waiting for Tailscale to establish path to ${{ secrets.DO_TAILSCALE_NAME }}..."
+          for i in {1..20}; do
+            if tailscale ping --c 1 --timeout 2s ${{ secrets.DO_TAILSCALE_NAME }} >/dev/null 2>&1; then
+              echo "Tailscale path ready (attempt $i)"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "ERROR: Tailscale never reached ${{ secrets.DO_TAILSCALE_NAME }} after 40s"
+          tailscale status || true
+          exit 1
+
       # Step 2: (Debug only) Verifies SSH ED25519 SSH key
       - name: Debug ED25519 Key # SSH key debugging step
         if: ${{ inputs.enable_ssh_debugging == true }} # Only run when debugging is enabled
@@ -189,8 +209,23 @@ jobs:
           # Set secure permissions on key
           echo "${{ secrets.DO_HOST_KEY }}" >> ~/.ssh/known_hosts
           # Add static host key
-          ssh-keyscan -H ${{ secrets.DO_TAILSCALE_NAME }} >> ~/.ssh/known_hosts
-          # Add dynamic host key
+          # Refresh dynamic host key with retry. Even after the Tailscale gate
+          # passes, ssh-keyscan can hit transient blips (relay reroute, brief
+          # packet loss, sshd taking an extra beat). Failure here is non-fatal
+          # because DO_HOST_KEY (above) is the authoritative static fallback.
+          echo "Refreshing host key for ${{ secrets.DO_TAILSCALE_NAME }}..."
+          for i in {1..5}; do
+            if ssh-keyscan -T 5 -H ${{ secrets.DO_TAILSCALE_NAME }} >> ~/.ssh/known_hosts 2>/dev/null; then
+              echo "ssh-keyscan succeeded (attempt $i)"
+              break
+            fi
+            if [ $i -eq 5 ]; then
+              echo "WARNING: ssh-keyscan failed 5x, falling back to static DO_HOST_KEY only"
+              break
+            fi
+            echo "ssh-keyscan attempt $i failed, retrying in 3s..."
+            sleep 3
+          done
 
           # Test SSH connection first
           echo "Testing SSH connection to ${{ secrets.DO_TAILSCALE_NAME }}..."


### PR DESCRIPTION
## Description
The manual `Deploy to DigitalOcean via Tailscale` workflow intermittently fails when the **Enable verbose SSH debugging** checkbox is left off. The deploy step exits in ~5s with no stdout, then succeeds reliably when debugging is enabled.

Root cause: `ssh-keyscan` races Tailscale's MagicDNS / route propagation. When the Tailscale path to the deploy host isn't ready yet, `ssh-keyscan` exits non-zero — and the runner's `bash -e` shell kills the step silently before any `echo` runs. Enabling SSH debugging masks the bug because the optional debug step performs its own `ssh -vvv` probe, which acts as an inadvertent warmup that gives Tailscale time to settle.

### Changes
* Add new **Wait for Tailscale path to deploy host** step after Tailscale setup. Uses `tailscale ping --c 1 --timeout 2s` in a 20-attempt loop (≤40s) to confirm the WireGuard peer path is established before any SSH operation runs.
* Wrap `ssh-keyscan` in a 5-attempt retry with 3s backoff. Failure is now non-fatal because `DO_HOST_KEY` (loaded from secrets on the line above) is the authoritative static fallback in `~/.ssh/known_hosts`.
* Add explanatory comments in the workflow describing the `bash -e` interaction and why both gates are needed.

### Testing Strategy
1. Manually dispatch **Deploy to DigitalOcean via Tailscale** from the Actions tab with the **Enable verbose SSH debugging** checkbox **OFF** — this is the failure path.
2. Confirm the new "Wait for Tailscale path to deploy host" step logs `Tailscale path ready (attempt N)` and the deploy step proceeds normally.
3. (Optional) Dispatch again with the debug checkbox ON and confirm both paths still succeed.
4. Watch a few subsequent dispatches over time to confirm the intermittent failure is gone.

### Concerns
* **`ssh-keyscan` failure is now non-fatal.** This relies on `DO_HOST_KEY` being correct in repo secrets. If the deploy host's SSH host key is ever rotated, that secret must be updated; otherwise SSH will fail at the connection attempt (with a clear `Host key verification failed` error, not a silent exit).
* **40s upper bound on the Tailscale gate.** In normal conditions the path is ready within 2–6s. If 40s is ever insufficient, the gate fails loudly with `tailscale status` dumped for diagnostics — increase the loop count if real-world Tailscale warmup proves slower.