### PR TITLE
Patch rustls-webpki CVE GHSA-82j2-j2ch-gfr8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,7 +390,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -413,7 +413,7 @@ dependencies = [
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -438,12 +438,6 @@ dependencies = [
  "tracing",
  "urlencoding",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -1001,7 +995,7 @@ dependencies = [
  "meeting-auth",
  "mockito",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest",
  "sea-orm",
  "secrecy",
  "serde",
@@ -1790,7 +1784,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.3",
- "system-configuration 0.7.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -2219,9 +2213,8 @@ dependencies = [
  "hex",
  "hmac",
  "mockito",
- "oauth2",
  "rand 0.8.5",
- "reqwest 0.12.28",
+ "reqwest",
  "reqwest-middleware",
  "reqwest-retry",
  "secrecy",
@@ -2420,26 +2413,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "oauth2"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c38841cdd844847e3e7c8d29cef9dcfed8877f8f56f9071f77843ecf3baf937f"
-dependencies = [
- "base64 0.13.1",
- "chrono",
- "getrandom 0.2.17",
- "http 0.2.12",
- "rand 0.8.5",
- "reqwest 0.11.27",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "sha2",
- "thiserror 1.0.69",
- "url",
 ]
 
 [[package]]
@@ -3202,47 +3175,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-rustls 0.24.2",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls 0.21.12",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-rustls 0.24.1",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots 0.25.4",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
@@ -3273,7 +3205,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.26.4",
@@ -3296,7 +3228,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "http 1.4.0",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "thiserror 1.0.69",
  "tower-service",
@@ -3315,7 +3247,7 @@ dependencies = [
  "http 1.4.0",
  "hyper 1.8.1",
  "parking_lot 0.11.2",
- "reqwest 0.12.28",
+ "reqwest",
  "reqwest-middleware",
  "retry-policies",
  "tokio",
@@ -3479,7 +3411,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.9",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -3527,9 +3459,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4337,12 +4269,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -4363,34 +4289,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.11.0",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -4448,7 +4353,7 @@ dependencies = [
  "eventsource-client",
  "futures-util",
  "log",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -4693,7 +4598,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -4959,7 +4864,6 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
- "serde_derive",
 ]
 
 [[package]]
@@ -5210,7 +5114,7 @@ dependencies = [
  "log",
  "meeting-auth",
  "password-auth",
- "reqwest 0.12.28",
+ "reqwest",
  "sea-orm",
  "secrecy",
  "serde",
@@ -5247,12 +5151,6 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
-
-[[package]]
-name = "webpki-roots"
-version = "0.25.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
 
 [[package]]
 name = "webpki-roots"
@@ -5621,16 +5519,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/meeting-auth/Cargo.toml
+++ b/meeting-auth/Cargo.toml
@@ -4,9 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-# OAuth 2.0 flows with PKCE support
-oauth2 = "4.4"
-
 # HTTP client with middleware
 reqwest = { version = "0.12.12", features = ["json", "rustls-tls"] }
 reqwest-middleware = "0.3"


### PR DESCRIPTION
## Description

Patches Dependabot alert [#53](https://github.com/refactor-group/refactor-platform-rs/security/dependabot/53) — [GHSA-82j2-j2ch-gfr8](https://github.com/advisories/GHSA-82j2-j2ch-gfr8): a high-severity DoS-via-panic in `rustls-webpki` (CVSS 7.5). The vulnerable code panics with an out-of-bounds index when parsing a malformed CRL `BIT STRING` whose content is exactly `[0x00]` (zero padding bits, zero data bytes). Exploitable by any attacker who can feed us a crafted CRL during TLS handshake — requires opt-in CRL revocation checking, which we do not currently enable, but the flagged crate is still present in the runtime graph.

#### GitHub Issue: Closes Dependabot alert #53

### Changes
* Bump `rustls-webpki` 0.103.9 → 0.103.13 in `Cargo.lock` via `cargo update -p rustls-webpki@0.103.9 --precise 0.103.13`. Patches the production TLS path (reqwest 0.12 → rustls 0.23 → sqlx → sea-orm).
* Remove the unused `oauth2 = "4.4"` dependency from `meeting-auth/Cargo.toml`. It was declared but never imported or referenced in any `.rs` file. Removing it drops the entire old rustls 0.21 / reqwest 0.11 stack from the production dependency graph.

### Testing Strategy
* `cargo check --workspace --lib` — clean
* `cargo clippy --workspace --lib -- -D warnings` — clean
* `cargo fmt --check` — clean
* `cargo tree -i rustls-webpki@0.103.9` — no longer present
* `cargo tree -i rustls-webpki@0.103.13` — is the only production path
* `grep -rn 'oauth2::\|use oauth2' --include='*.rs'` — zero hits, confirming the crate was dead code

### Concerns
A residual copy of `rustls-webpki 0.101.7` remains in `Cargo.lock`, reachable only via `testing-tools` → `eventsource-client 0.12` → `rustls 0.21`. `testing-tools` is explicitly excluded from `default-members` in [Cargo.toml](../blob/main/Cargo.toml#L10-L12) and never ships to production, so the vulnerable code is not in any deployed artifact. If Dependabot keeps the alert open after merge (because it scans the full lockfile), the follow-up is either (a) upgrade `eventsource-client` to 0.17.x (requires API/feature porting in `testing-tools/src/sse_client.rs`) or (b) dismiss the alert with reason "vulnerable code not reachable — dev-only workspace member".

A pre-existing unrelated test-compile error in `meeting-auth/src/oauth/providers/google.rs:334` also exists on `main`; it is out of scope for this PR.