### PR TITLE
Stop test runner from polluting child env via .env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,7 +114,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -125,7 +125,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -732,7 +732,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1141,7 +1141,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3413,7 +3413,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3464,6 +3464,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3477,6 +3486,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sea-bae"
@@ -3758,6 +3773,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot 0.12.5",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "service"
 version = "1.0.0-beta3"
 dependencies = [
@@ -3768,6 +3809,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
+ "serial_test",
  "simplelog",
  "sqlx",
  "tokio",
@@ -3905,7 +3947,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4271,10 +4313,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5144,7 +5186,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/meeting-auth/src/oauth/providers/google.rs
+++ b/meeting-auth/src/oauth/providers/google.rs
@@ -336,6 +336,7 @@ mod tests {
             SecretString::from("test_client_secret".to_string()),
             "https://example.com/callback".to_string(),
         )
+        .expect("test provider construction must succeed")
     }
 
     #[test]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -26,3 +26,6 @@ tokio = { version = "1.44", features = ["full"] }
 tower = "0.5.1"
 utoipa = { version = "4.2.0", features = ["axum_extras", "uuid"] }
 semver = { version = "1.0.23", features = ["serde"] }
+
+[dev-dependencies]
+serial_test = "3"

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -387,6 +387,10 @@ impl Default for Config {
     /// Returns a `Config` with clap's compiled-in defaults. Does not read
     /// real CLI args or `.env` files. Shell env vars are still read via
     /// clap's `#[arg(env)]` attributes.
+    ///
+    /// Side effect: may call `std::env::remove_var` on any `#[arg(env)]`
+    /// var whose current value is empty or whitespace-only (see
+    /// `sanitize_empty_env`).
     fn default() -> Self {
         Self::from_args(["refactor-platform-rs"])
     }
@@ -780,6 +784,7 @@ impl fmt::Display for ApiVersion {
 mod tests {
     use super::*;
     use serial_test::serial;
+    use std::fs;
 
     #[test]
     fn unset_field_shows_default_value_and_suffix() {
@@ -895,8 +900,6 @@ mod tests {
     #[test]
     #[serial]
     fn default_constructor_does_not_load_env_file() {
-        use std::fs;
-
         let _key_guard = EnvGuard::unset("MAILERSEND_API_KEY");
 
         let temp_dir = std::env::temp_dir().join(format!(

--- a/service/src/config.rs
+++ b/service/src/config.rs
@@ -779,6 +779,7 @@ impl fmt::Display for ApiVersion {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serial_test::serial;
 
     #[test]
     fn unset_field_shows_default_value_and_suffix() {
@@ -796,7 +797,12 @@ mod tests {
         assert_eq!(config.source_suffix("port"), "");
     }
 
+    // Marked `#[serial]` because iterating `matches.ids()` while another
+    // thread is mutating env vars or building its own augmented Command
+    // races on clap's internal state — the command name ("Config") leaks
+    // into the id iterator. Serializing avoids the race.
     #[test]
+    #[serial]
     fn all_config_fields_are_tracked() {
         let matches = Config::command()
             .try_get_matches_from(["test_binary"])
@@ -811,6 +817,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn untracked_field_is_detected() {
         let matches = Config::command()
             .arg(clap::Arg::new("extra_test_field").long("extra-test-field"))
@@ -819,5 +826,107 @@ mod tests {
 
         let untracked = Config::find_untracked_fields(&matches);
         assert_eq!(untracked, vec!["extra_test_field"]);
+    }
+
+    /// RAII guard that restores a process env var to its prior state on drop.
+    /// Use with `#[serial]` so concurrent tests do not race on the env table.
+    struct EnvGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, original }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let original = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            match &self.original {
+                Some(v) => std::env::set_var(self.key, v),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn env_var_populates_field_when_no_flag() {
+        let _guard = EnvGuard::set("MAILERSEND_API_KEY", "from_env");
+        let config = Config::from_args(["test_binary"]);
+        assert_eq!(config.mailersend_api_key(), Some("from_env".to_string()));
+    }
+
+    #[test]
+    #[serial]
+    fn cli_flag_overrides_env_var() {
+        let _guard = EnvGuard::set("MAILERSEND_API_KEY", "from_env");
+        let config = Config::from_args(["test_binary", "--mailersend-api-key", "from_cli"]);
+        assert_eq!(config.mailersend_api_key(), Some("from_cli".to_string()));
+    }
+
+    #[test]
+    #[serial]
+    fn value_source_records_env_for_env_sourced_field() {
+        let _guard = EnvGuard::set("MAILERSEND_API_KEY", "from_env");
+        let config = Config::from_args(["test_binary"]);
+        assert_eq!(
+            config.value_sources.get("mailersend_api_key"),
+            Some(&ValueSource::EnvVariable),
+        );
+    }
+
+    /// Regression guard for the parent test runner in `src/main.rs`. The
+    /// runner calls `Config::default()` and then spawns child cargo
+    /// processes that inherit its env. If `Config::default()` ever started
+    /// loading `.env` (e.g. via a misplaced `dotenvy::dotenv()`), child
+    /// processes would inherit those values and tests like
+    /// `domain::emails::tests::test_send_*_missing_template_id` would
+    /// silently start failing again.
+    #[test]
+    #[serial]
+    fn default_constructor_does_not_load_env_file() {
+        use std::fs;
+
+        let _key_guard = EnvGuard::unset("MAILERSEND_API_KEY");
+
+        let temp_dir = std::env::temp_dir().join(format!(
+            "refactor-config-default-test-{}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&temp_dir).unwrap();
+        fs::write(
+            temp_dir.join(".env"),
+            "MAILERSEND_API_KEY=should_not_be_loaded\n",
+        )
+        .unwrap();
+
+        let original_cwd = std::env::current_dir().unwrap();
+        std::env::set_current_dir(&temp_dir).unwrap();
+
+        let config = Config::default();
+
+        // Restore cwd and clean up before any assertion that might panic.
+        std::env::set_current_dir(&original_cwd).unwrap();
+        fs::remove_dir_all(&temp_dir).ok();
+
+        assert!(
+            config.mailersend_api_key().is_none(),
+            "Config::default() must not load .env (got {:?})",
+            config.mailersend_api_key()
+        );
+        assert!(
+            std::env::var("MAILERSEND_API_KEY").is_err(),
+            "Config::default() must not write .env values into the process env",
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,8 @@ use std::sync::Arc;
 
 #[tokio::main]
 async fn main() {
-    let config = get_config();
+    service::load_env_file();
+    let config = Config::new();
     Logger::init_logger(&config);
 
     info!("Starting up...");
@@ -65,23 +66,23 @@ async fn main() {
     web::init_server(web_state).await.unwrap();
 }
 
-fn get_config() -> Config {
-    service::load_env_file();
-    Config::new()
-}
-
 // This is the parent test "runner" that initiates all other crate
 // unit/integration tests.
 #[cfg(test)]
 mod all_tests {
     use log::LevelFilter;
+    use service::config::Config;
     use service::logging::Logger;
     use simplelog::{error, info};
     use std::process::Command;
 
     #[tokio::test]
     async fn main() {
-        let mut config = crate::get_config();
+        // Use Config::default() (no .env load, no real CLI args) so that the
+        // child cargo processes spawned below inherit a clean env. Loading
+        // .env here would pollute the parent process and break tests like
+        // domain::emails::tests::test_send_*_missing_template_id.
+        let mut config = Config::default();
         config.log_level_filter = LevelFilter::Trace;
         Logger::init_logger(&config);
 


### PR DESCRIPTION
## Summary

Fixes the long-standing local-only `cargo test` flake in `domain::emails::tests::test_send_*_missing_template_id`. The root cause was the parent test runner in [src/main.rs](src/main.rs) loading `.env` into its own process and leaking those values into the `cargo test` subprocesses it spawns. Also fixes a pre-existing `meeting-auth` test compile error that was blocking `cargo test --workspace --all-targets` and `cargo clippy --workspace --all-targets -- -D warnings`.

## The bug

[src/main.rs](src/main.rs#L75-L148) defines a `#[cfg(test)] mod all_tests` containing a `#[tokio::test] async fn main()` that orchestrates child `cargo test` invocations for `domain`, `entity_api` (`--features mock`), and `web` (`--features mock`). It was using a `get_config()` helper that bundled two unrelated operations:

```rust
fn get_config() -> Config {
    service::load_env_file();   // <-- writes .env values into process env
    Config::new()
}
```

When the parent test runner called this, `.env` values (e.g. `WELCOME_EMAIL_TEMPLATE_ID=...`) were written to the parent process's env table. The child `cargo test` subprocesses spawned by `Command::new("cargo")` inherited that env. Tests like `test_send_welcome_email_missing_template_id` — which assert `config.welcome_email_template_id().is_none()` after constructing a `Config` with no flag — saw clap pick up the env-inherited value and fail.

| Scenario | Has `.env`? | `dotenvy::dotenv()` runs? | Subprocess inherits? | Result |
|---|---|---|---|---|
| GitHub CI | ❌ (gitignored) | yes but loads nothing | clean env | ✅ pass |
| Local dev | ✅ | yes, loads template ids | polluted env | ❌ fail |
| Local with `.env` removed | ❌ | yes but loads nothing | clean env | ✅ pass |

## The fix

[src/main.rs](src/main.rs):

1. **Inline `service::load_env_file()` directly into `async fn main()`** as its first line — production behavior unchanged.
2. **Delete the `get_config()` helper** so no one can accidentally trigger the conflated load+construct again.
3. **Have the parent test runner use `Config::default()`**, which is documented at [service/src/config.rs:386-393](service/src/config.rs#L386-L393) as not reading `.env` or real CLI args.

[meeting-auth/src/oauth/providers/google.rs](meeting-auth/src/oauth/providers/google.rs#L333-L340):

4. **Unwrap `Provider::new()` in `create_test_provider`** with `.expect(...)`. The constructor was changed in f0bc154 to return `Result<Self, reqwest::Error>`, but the test helper still treated it as a direct `Provider`. This was breaking `--all-targets` builds.

## Regression tests

Added 4 tests to `service::config::tests` covering the env dimension that wasn't tested before:

| Test | Guards against |
|---|---|
| `env_var_populates_field_when_no_flag` | `#[arg(env)]` silently breaking |
| `cli_flag_overrides_env_var` | Precedence inversion (env winning over CLI) |
| `value_source_records_env_for_env_sourced_field` | `value_sources` losing the ability to distinguish `EnvVariable` vs `CommandLine` |
| `default_constructor_does_not_load_env_file` | A future change re-introducing `dotenvy::dotenv()` into the `Config::default()` path — directly guards the invariant the parent test runner relies on |

Env-mutating tests use a small RAII `EnvGuard` and `#[serial_test::serial]` to avoid races. The two existing meta-tests that iterate `matches.ids()` are also marked `#[serial]` because they race with concurrent `Config::command()` calls under contention (a clap-internal quirk where the command name "Config" leaks into the id iterator).

Adds `serial_test = "3"` as a `[dev-dependencies]` entry on `service`.

## Test plan

- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --lib -- -D warnings` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean (this was failing on `main` before the meeting-auth fix)
- [x] `cargo test --workspace` passes on local with `.env` present — all binaries `0 failed`
- [x] `cargo test -p service` runs the 4 new regression tests (all pass)
- [ ] CI lint + test green

## Notes

The `sanitize_empty_env` function in [service/src/config.rs:451-463](service/src/config.rs#L451-L463) still calls `std::env::remove_var` (deprecated as `unsafe` in Rust 1.84+ for thread-safety reasons). With `.env` no longer leaking into test envs, this race is unlikely to manifest, but it remains a latent issue — tracked as a separate follow-up if we still see flakes.