### PR TITLE
MCP proof of concept

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ nginx/logs/
 
 # Snyk Security Extension - AI Rules (auto-generated)
 .github/instructions/snyk_rules.instructions.md
+WARP.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,8 +879,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
@@ -897,12 +907,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.117",
 ]
@@ -1044,6 +1078,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -2619,6 +2659,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3146,6 +3192,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "refactor_platform_rs"
 version = "1.0.0-beta3"
 dependencies = [
@@ -3334,6 +3400,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+dependencies = [
+ "async-trait",
+ "base64",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pastey",
+ "pin-project-lite",
+ "rand 0.10.1",
+ "rmcp-macros",
+ "schemars",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rmp"
 version = "0.8.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3482,6 +3592,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3624,7 +3760,7 @@ version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bae0cbad6ab996955664982739354128c58d16e126114fe88c2a493642502aab"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "heck 0.4.1",
  "proc-macro2",
  "quote",
@@ -3730,6 +3866,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4194,6 +4341,19 @@ dependencies = [
  "serde_json",
  "tokio",
  "uuid",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3962b63f038885f15bce2c6e02c0e7925c072f1ac86bb60fd44c5c6b762fb72"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -5099,6 +5259,7 @@ dependencies = [
  "meeting-auth",
  "password-auth",
  "reqwest",
+ "rmcp",
  "sea-orm",
  "secrecy",
  "serde",

--- a/README.md
+++ b/README.md
@@ -234,6 +234,7 @@ curl -X POST http://localhost:4000/mcp \
 | `list_actions` | List actions with session, status, and keyword filters |
 | `get_session` | Get a session with all related data (notes, actions, agreements, goals) |
 
+For client setup instructions, see the [MCP Server Setup Guide](docs/mcp_server/README.md).
 For architecture details, see [docs/architecture/mcp_server.md](docs/architecture/mcp_server.md).
 
 ---

--- a/README.md
+++ b/README.md
@@ -200,6 +200,44 @@ _For additional commands, database utilities, and debugging tips, check the [Con
 
 ---
 
+## MCP Server
+
+The platform includes an MCP (Model Context Protocol) server that lets AI clients (Warp, Claude, etc.) interact with coaching data through structured tools.
+
+### Endpoint
+
+`POST /mcp` — Streamable HTTP transport. All requests require a Personal Access Token (PAT) as a Bearer token.
+
+### Authentication
+
+Create a PAT via the REST API (authenticated with your session cookie):
+
+```bash
+# Create a token (shown once, never stored)
+curl -X POST http://localhost:4000/users/<your-user-id>/tokens \
+  -H "Cookie: <session-cookie>"
+
+# Use the token for MCP requests
+curl -X POST http://localhost:4000/mcp \
+  -H "Authorization: Bearer <your-pat>" \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","method":"initialize","params":{},"id":1}'
+```
+
+### Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_coachees` | List all coachees for the authenticated coach |
+| `get_coachee` | Get a coachee profile with optional goals, actions, notes |
+| `list_sessions` | List coaching sessions with optional date range filter |
+| `list_actions` | List actions with session, status, and keyword filters |
+| `get_session` | Get a session with all related data (notes, actions, agreements, goals) |
+
+For architecture details, see [docs/architecture/mcp_server.md](docs/architecture/mcp_server.md).
+
+---
+
 ## CI/CD & Deployment
 
 This project uses GitHub Actions for continuous integration, release builds, and deployment.

--- a/docs/architecture/mcp_server.md
+++ b/docs/architecture/mcp_server.md
@@ -1,4 +1,7 @@
 # MCP Server
+
+**Status: Implemented** (MVP)
+
 Add an MCP server to the rust backend so that AI clients can interact with the coaching platform through structured tools.
 
 ## Context

--- a/docs/architecture/mcp_server.md
+++ b/docs/architecture/mcp_server.md
@@ -1,0 +1,169 @@
+# MCP Server
+Add an MCP server to the rust backend so that AI clients can interact with the coaching platform through structured tools.
+
+## Context
+Enable users to interact with the platform without leaving their AI workflow.
+Opens the door to AI automation and generative features like session summarization that the REST API alone cannot provide.
+
+The MCP server will exist inside the existing rust crate as a separate endpoint.
+
+## Data Model
+One new table: `personal_access_tokens`. All MCP tools read from existing tables.
+
+Value is never stored, only the token hash. This means users must be allowed to regenerate their token and deactivate the old one.
+
+Operations: create, show (metadata only, not the raw token), deactivate. No delete — inactive tokens are kept for audit history.
+
+Limit one active PAT per user, enforced by a partial unique index: `UNIQUE (user_id) WHERE status = 'active'`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | uuid PK | |
+| user_id | uuid FK → users | Owner of the token |
+| token_hash | varchar | SHA-256 of the raw token (raw token is never stored) |
+| status | enum `pat_status` (active, inactive) | New Postgres enum, separate from existing `refactor_platform.status`. Only active tokens are accepted. Users can deactivate a lost token and generate a new one. |
+| last_used_at | timestamptz | Optional, for observability |
+| created_at | timestamptz | |
+| updated_at | timestamptz | |
+
+## Layer Responsibilities
+
+| Layer | Module | Responsibility |
+|-------|--------|----------------|
+| `entity` | `personal_access_tokens` | SeaORM entity for PAT table |
+| `entity_api` | `personal_access_token` | PAT operations: create, find by token hash, deactivate |
+| `domain` | `personal_access_token` | Business logic: hash on create, validate status |
+| `web` | `mcp/mod` | Module root |
+| `web` | `mcp/auth` | PAT bearer middleware: extract header → hash → lookup user + roles |
+| `web` | `mcp/tools/mod` | `McpToolHandler` struct + `#[tool_router]`/`#[tool_handler]` wiring. Holds `AppState`. |
+| `web` | `mcp/tools/*` | Individual tool methods using `#[tool]` macro |
+| `web` | `router` | MCP service nested via `nest_service("/mcp", service)` in existing `define_routes()` |
+| `web` | `controller/pat_controller` | REST endpoints for PAT management (create, show, deactivate) used by the UI |
+| `web` | `protect/users/tokens` | Authorization middleware for PAT routes: user can only manage own tokens |
+| `migration` | new migration | `personal_access_tokens` table + partial unique index |
+
+## Dependencies
+
+`sha2` + `rand` — added to the `domain` crate for PAT token generation. `rand` (with `OsRng`) generates cryptographically secure random bytes for the raw token value. `sha2` hashes the raw token to produce the `token_hash` stored in the database and also identify and validate PATs. Both are already in the workspace via `meeting-auth`.
+
+`rmcp` — the official Rust MCP SDK (`modelcontextprotocol/rust-sdk`). Added to the `web` crate with the `transport-streamable-http-server` feature. Provides:
+- `StreamableHttpService` — integrates with Axum via `nest_service("/mcp", service)`, handling JSON-RPC parsing, `initialize`/`tools/list`/`tools/call` dispatch, session management, and SSE. `StreamableHttpService::new` accepts a factory closure (`Fn() -> Result<H>`) — after initializing, every session gets its own `McpToolHandler` instance to manage requests and hold app state. The authenticated user is not stored on the handler — it flows through `RequestContext.extensions` on each tool call (see [rmcp integration](./mcp_server/rmcp_integration.md#user-context-propagation)).
+- `#[tool]`, `#[tool_router]`, `#[tool_handler]` macros — generate tool schemas and dispatch from annotated functions.
+- Does not own auth — PAT middleware is applied as a `.layer()` on the Router containing the nested MCP service, matching rmcp's official auth examples. `route_layer` is not used because it only applies to `.route()` registrations, not `nest_service`.
+
+## Authentication
+Personal Access Token (PAT) as bearer token. PATs will be issued through the UI in the personal settings page.
+- New UI to create/view PAT.
+- New endpionts to create and get a PAT, scoped to current user.
+
+## Authorization
+Authorization is built off of the existing authorization model.
+
+- New `mcp` module and submodules for authorization
+- auth submodule for PAT auth middleware. Extract authorization header and authorizes.
+- Utilize existing authorization patterns, like those in `coaching_relationships::is_coach_of`. There is some maintenance burden here if the authorization logic of the API were to change, it would need to be updated for the MCP server too.
+- The PAT middleware inserts the authenticated `users::Model` into HTTP request extensions. `rmcp` propagates these into `RequestContext.extensions`, making the user available inside tool handlers without storing it on the handler struct. See [rmcp integration — user context propagation](./mcp_server/rmcp_integration.md#user-context-propagation) for details.
+
+## Connection Protocols
+- MVP — Stateless Streamable HTTP: `stateful_mode: false` in `StreamableHttpServerConfig`. Every POST is self-contained — no session ID, no persistent handler state. The factory creates a fresh `McpToolHandler` per request. Simpler auth bridging, no stale session cleanup.
+- Later — Stateful mode (`stateful_mode: true`) for SSE streaming and server-initiated events. Handler persists across requests in a session. Same tools and auth, only the config changes.
+- No stdio — the MCP server runs inside the existing backend process.
+
+## Tool List (MVP)
+- [Exhaustive tool list](./mcp_server/exhaustive_list.md)
+- [MVP tool list](./mcp_server/mvp_tools.md)
+
+## Tool Design
+Tools that require a specific resource (session, coachee) expect an exact ID. Discovery tools (`list_coachees`, `list_sessions`) return enough data for the LLM to identify and select the right record. No fuzzy matching or inline disambiguation — the LLM chains a list call before a get call.
+
+### Inputs
+- Input schemas are auto-generated by `rmcp` via `schemars`. Each tool defines a `Parameters<T>` struct deriving `Deserialize` + `schemars::JsonSchema`. The `#[tool]` macro produces the JSON Schema from that struct and returns it in `tools/list`. No manual schema definition needed — field types, optionality, and `#[schemars(description = "...")]` annotations are the single source of truth for what the tool accepts.
+- Tools identify the caller via PAT — no user ID parameter needed.
+- Coach tools that operate on a coachee accept an optional `coachee_id`. Defaults to self when omitted (coachee calling for themselves).
+- `get_coachee` supports an optional `include` array (`["goals", "actions", "notes"]`) to inline related records filtered to active status. Without `include`, returns profile + aggregated stats only.
+- `list_sessions` accepts optional `date_from`, `date_to` for date range filtering.
+- `list_actions` accepts optional `coaching_session_id`, `keyword` (searches body text), `date_from`/`date_to`, `status`. Coaches optionally provide `coachee_id` (defaults to self for coachees). Returns `ActionResponse` arrays (flattened `actions::Model` + `SessionRef` with frontend URL). See [response structs](./mcp_server/mcp_response_structs.md).
+- `get_session` accepts an optional `session_id`. Defaults to the latest session for the coaching relationship.
+
+### Outputs
+- All tools return structured JSON.
+- Existing entity models (e.g. `actions::Model`, `goals::Model`, `users::Model`) already derive `Serialize` with `#[serde(skip_serializing)]` on sensitive fields (passwords, OAuth tokens). Tool handlers serialize these models directly rather than redefining every field. Where a tool needs computed or nested fields not on the entity (e.g. `session_url`, inline `assignees`), a thin response wrapper uses `#[serde(flatten)]` to inline the entity and adds only the extra fields. This avoids duplicating field definitions and keeps the entity model as the source of truth. See [response struct definitions](./mcp_server/mcp_response_structs.md) for the full output shapes.
+- `get_coachee` without `include`: profile fields + stat counts (active goals, open actions, overdue actions, last/next session date).
+- `get_coachee` with `include`: same as above, plus arrays of raw entity models (`goals::Model`, `actions::Model`, `notes::Model`) filtered to active statuses. No nested refs or computed fields — keeps the tool lightweight. Rich action responses (with session URLs, nested goals, assignees) are deferred to a future dedicated action search tool.
+- `list_sessions`: array of session summaries (id, date, meeting_url).
+- `get_session`: structured data bundle of the session record + associated notes, actions, agreements, and linked goals. The client LLM generates the prose summary from this data — no server-side LLM needed.
+
+### Error Handling
+On error, response will have:
+- isError: true
+- ErrorMessage: "Descriptive error including error type and actionable steps"
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    participant Client as AI Client (Warp, Claude, etc.)
+    participant MCP as MCP Endpoint
+    participant Auth as PAT Auth Middleware
+    participant Tool as Tool Handler
+    participant Domain as Domain Layer
+    participant DB as Database
+
+    Client->>MCP: POST /mcp (Bearer PAT, tool call)
+    MCP->>Auth: Validate PAT
+    Auth->>DB: Lookup user + roles by PAT
+    alt Invalid/expired PAT
+        Auth-->>Client: isError: "Unauthorized"
+    end
+    Auth->>MCP: Authenticated user with roles
+    MCP->>Tool: Dispatch to tool handler
+    Tool->>Tool: Authorize (role check, ownership check)
+    alt Forbidden
+        Tool-->>Client: isError: "Forbidden"
+    end
+    Tool->>Domain: Call domain function
+    Domain->>DB: Query/mutate
+    DB-->>Domain: Result
+    Domain-->>Tool: Data or error
+    alt Domain error
+        Tool-->>Client: isError: actionable message
+    end
+    Tool-->>Client: Structured JSON result
+```
+
+## Security Considerations
+- **Data ownership via PAT**: Data is scoped by the authorized PAT. Coaches cannot manage other coaches data, only their own and their associated coachees. Coachees can only manage their own data. This pattern is extensible to organizations, if we wanted to add multi tenancy. Associating tools with a PAT also supports auditing and observability of MCP usage, if we wanted it.
+- **No deletes**: MVP excludes all delete operations. Writes are limited to append-only creates and status updates.
+- **Prompt injection via stored data**: Note bodies, goal titles, and action text are user-generated and returned in tool responses. A malicious string in a note could instruct the client LLM to take unintended actions. The MCP server does not sanitize output — this is the client's responsibility.
+- **Data exfiltration**: Tool responses contain names, emails, and session content. This data flows through whatever LLM provider the client uses. Users should be aware their coaching data is sent to third-party models.
+- **Rate limiting**: PAT-scoped rate limits prevent a misbehaving client from enumerating data or overwhelming the backend. Exact limits TBD.
+- **No secrets in responses**: Passwords and PAT values are never included in tool output.
+
+## Future Considerations
+- **OAuth**: PAT is MVP. OAuth enables MCP clients (Claude Desktop, Warp, etc.) to authenticate via browser redirect without manual token generation. The auth middleware will be designed to support a second credential type — OAuth would resolve to the same user + roles as a PAT, reusing the existing authorization layer.
+
+Oauth would require lifecycle management, the mcp server will need to be able to issue access and refresh tokens. Fortunately Axum allows Oauth support through hooks, making it easier to add on later without breaking auth.
+
+- **Admin-only tools**: Post-MVP. Cross-organization data views, user management, platform-wide analytics. Scoped to SuperAdmin role.
+- **Write tools**: MVP is read-only plus status updates. Next tier adds `create_action`, `create_note`, `create_goal`, `create_agreement`, `create_session` — all append-only, no edits or deletes. See [exhaustive tool list](./mcp_server/exhaustive_list.md) for the full set.
+
+## Decisions
+
+- **`rmcp` over hand-rolling the MCP protocol.** The official Rust MCP SDK handles JSON-RPC parsing, session management, and tool dispatch. It integrates with Axum via `nest_service` and doesn't own auth. Saves 1-2 days of protocol boilerplate with no loss of control. This should be the first target for proof of concept to ensure the sdk works with the codebase.
+- **Streamable HTTP only.** No stdio — the MCP server is an endpoint inside the existing backend, not a standalone binary. Streamable HTTP is the current MCP spec transport for remote servers.
+- **Reuse existing authorization patterns.** Try to limit maintenance burden by reusing domain-level ownership functions like `coaching_relationship::is_coach_of`.
+- **No deletes for MVP.** Too destructive for LLM-initiated calls.
+- **PAT-direct as bearer token over access/refresh tokens.** The PAT is sent as `Authorization: Bearer <token>` on every request. No token expiration, no refresh flow, no token endpoint. Simpler for MVP. OAuth will require access/refresh tokens later.
+- **Store only the token hash; support deactivation instead of expiration.** The raw PAT is shown once at creation and never stored. Only the SHA-256 hash is persisted. If a user loses their token, they deactivate the old one and generate a new one. One active PAT per user, enforced by a partial unique index.
+- **`get_coachee` with `include` replaces individual list tools.** Instead of separate `list_goals`, `list_actions`, `list_notes` tools, `get_coachee` accepts an optional `include` array to inline related records filtered to active status. Fewer tools, fewer round-trips, one call answers "how is this coachee doing?"
+- **Disambiguation via separate list/get tools.** Tools that operate on a specific resource require an exact ID. Discovery tools (`list_coachees`, `list_sessions`) return enough identifying data (name, email, date) for the LLM to select the right record. No fuzzy matching or server-side disambiguation — the LLM chains a list call before a get call, matching the pattern used by GitHub and other major MCP servers.
+- **`.layer()` over `route_layer` for MCP auth.** `route_layer` only applies to routes added via `.route()`, not `nest_service`. The auth middleware is applied as a `.layer()` on the Router wrapping the nested `StreamableHttpService`, matching rmcp's official examples.
+- **Factory closure per session, not singleton clone.** `StreamableHttpService::new` takes `Fn() -> Result<H>`, creating a fresh handler per MCP session (per request in stateless mode). The `McpToolHandler` struct owns app state; the authenticated user flows through `RequestContext.extensions` on each tool call.
+- **Stateless mode for MVP.** No session management, no in-memory session map, no stale session cleanup. Every request carries a PAT and is validated independently. SSE streaming deferred to stateful mode later.
+- **No server-side LLM for MVP.** Tools return structured data, not generated prose. The client LLM (Warp, Claude, etc.) handles summarization and natural language from the data. This avoids adding an LLM provider dependency, API keys, token costs, and prompt management to the backend.
+
+## Implementation
+The MCP server is delivered through three PRs:
+- **PR 1 — PAT infrastructure + REST endpoints.** Migration, entity, entity_api, domain, controller, and routes for personal access tokens. Independent of MCP.
+- **PR 2 — MCP skeleton with auth.** `rmcp` dependency, module structure, `ServerHandler` implementation, PAT auth middleware, router integration. Zero tools, but `initialize` and `tools/list` work end-to-end.
+- **PR 3 — MVP tools.** `list_coachees`, `get_coachee` (with `include`), `list_sessions`, `list_actions`, `get_session`. Documentation updates.

--- a/docs/architecture/mcp_server/exhaustive_list.md
+++ b/docs/architecture/mcp_server/exhaustive_list.md
@@ -1,0 +1,39 @@
+# MCP Tools — Exhaustive Tool List
+Prefer not deleting through mcp for now, destructively risky.
+
+## Coach-Only
+1. `list_coachees` — all coachees for this coach
+2. `get_coachee` — profile + aggregated stats for one coachee
+3. `list_overdue_actions` — overdue actions across all coachees
+4. `create_session` — schedule a session
+5. ~~`update_session` — change date, meeting URL~~ - rescheduling is better done in the UI where you see a calendar
+6. ~~`delete_session` — cancel a session~~ - too destructive for LLM-initiated calls, do this in the UI
+7. `create_goal` — create goal for a coachee
+8. ~~`update_goal` — edit goal title/body~~ - editing body text via MCP is awkward; status changes are the high-value operation
+9. ~~`delete_goal` — remove a goal~~ - too destructive for LLM-initiated calls, do this in the UI
+10. `create_action` — create action item with optional assignees and goal link
+11. ~~`update_action` — edit action body/due date~~ - editing body text via MCP is awkward; status changes are the high-value operation
+12. ~~`delete_action` — remove action~~ - too destructive for LLM-initiated calls, do this in the UI
+13. `create_note` — add note to a session
+14. ~~`update_note` — edit a note~~ - low value via MCP, notes are typically written once
+15. `create_agreement` — add agreement to a session
+16. ~~`update_agreement` — edit agreement~~ - low value via MCP, agreements are typically written once
+17. ~~`delete_agreement` — remove agreement~~ - too destructive for LLM-initiated calls, do this in the UI
+18. `weekly_digest` — summary across all coachees (generative)
+19. `prepare_for_session` — pre-session brief (generative)
+20. ~~`suggest_goals` — suggest goals based on session history (generative)~~ - requires LLM on the server, post-MVP
+
+## Coachee-Only
+21. ~~`get_my_coach` — coach profile for a relationship~~ - the coachee already knows their coach; low utility
+22. ~~`create_goal` — coachee creates own goal~~ - coachees can use the UI for this; the value of MCP for coachees is reading, not writing
+
+## Shared (both roles, coach specifies coachee, coachee auto-scoped)
+23. `list_sessions` — sessions by date range, sort
+24. `get_session` — full session detail with notes, actions, agreements, goals via `include` param
+25. `list_goals` — goals filterable by status
+26. `list_actions` — actions filterable by session, goal, status, due date
+27. ~~`list_notes` — notes for a session~~ - folds into `get_session` via `include` parameter
+28. ~~`list_agreements` — agreements for a session~~ - folds into `get_session` via `include` parameter
+29. `update_goal_status` — change goal status
+30. `update_action_status` — change action status
+31. `get_session` — session recap (generative)

--- a/docs/architecture/mcp_server/implementation-plan.md
+++ b/docs/architecture/mcp_server/implementation-plan.md
@@ -1,0 +1,60 @@
+# MCP Server Implementation Plan
+Atomic commits organized inside-out: deepest dependencies first, consumers last.
+Each numbered step is a separate commit. Commit before starting the next step. See `commit-strategy.md` for the full commit workflow including validation and message conventions.
+## Section 1: Database & Entity Layer (PAT)
+Foundation — the PAT table and its SeaORM entity. No consumers yet.
+1. **Migration: create `personal_access_tokens` table** — new migration with table definition (id, user_id FK, token_hash, status enum, last_used_at, created_at, updated_at) + partial unique index `UNIQUE (user_id) WHERE status = 'active'`. Run migration to verify.
+2. **Entity: `personal_access_tokens` SeaORM entity** — new file `entity/src/personal_access_tokens.rs`. Define `Model`, `Relation` (belongs_to users), `ActiveModelBehavior`. Register in `entity/src/lib.rs`. Verify it compiles.
+3. **Update DBML** — add `personal_access_tokens` table and relationship to `docs/db/refactor_platform_rs.dbml`.
+## Section 2: Entity API Layer (PAT CRUD)
+Data operations on PATs. No callers yet.
+4. **Entity API: `personal_access_token` module** — new file `entity_api/src/personal_access_token.rs`. Implement `create(db, user_id, token_hash)`, `find_by_token_hash(db, hash)`, `find_active_by_user(db, user_id)`, `deactivate(db, pat_id)`. Register in `entity_api/src/lib.rs`. Unit tests with mock DB. Note: `find_by_token_hash` is a direct indexed lookup, not a scan — SHA-256 is deterministic, so the middleware hashes the incoming raw token and queries by the hash directly.
+## Section 3: Domain Layer (PAT Business Logic)
+Hashing, validation, token generation. No web layer yet.
+5. **Domain: `personal_access_token` module** — add `sha2` and `rand` to `domain/Cargo.toml` (both already in workspace via `meeting-auth`). New file `domain/src/personal_access_token.rs`. Implement `create_token(db, user_id) -> (raw_token, Model)` (generates random token via `rand::rngs::OsRng`, hashes with `sha2::Sha256`, calls entity_api create, returns raw token + model), `validate_token(db, raw_token) -> Result<users::Model>` (hashes input, looks up by hash, checks status is active, loads user + roles), `deactivate_token(db, pat_id)`. Register in `domain/src/lib.rs`. Unit tests.
+## Section 4: PAT REST Endpoints (for UI)
+The UI needs to create/show/deactivate tokens. Independent of MCP.
+6. **Controller: `pat_controller`** — new file `web/src/controller/pat_controller.rs`. Three endpoints: `POST /users/:id/tokens` (create, returns raw token once), `GET /users/:id/tokens` (show active token metadata, no raw value), `PUT /users/:id/tokens/:token_id/deactivate`. Register in controller mod.rs.
+6b. **Protect: `users/tokens`** — new file `web/src/protect/users/tokens.rs`. Authorization middleware for PAT routes: authenticated user can only manage their own tokens (`:id` must match the session user). Uses the existing `Check` trait and `Predicate` pattern from `protect/mod.rs`. Register in `protect/users/mod.rs`.
+7. **Router: PAT routes** — add `pat_routes(app_state)` function in `web/src/router.rs`, merge into `define_routes()`. Protected by `require_auth` + `protect::users::tokens` ownership check via `route_layer`.
+## Section 5: Add `rmcp` Dependency
+Prove the SDK works with the codebase before building on it.
+8. **Add `rmcp` to `web/Cargo.toml`** — add `rmcp = { version = "...", features = ["server", "macros", "transport-streamable-http-server"] }`. Verify the workspace compiles with the new dependency.
+## Section 6: MCP Module Skeleton
+Empty MCP module structure. No tools, no auth, no routes yet.
+9. **Create `web/src/mcp/mod.rs`** — declare submodules: `pub(crate) mod auth;`, `pub(crate) mod tools;`. Create empty files for `web/src/mcp/auth.rs` and `web/src/mcp/tools/mod.rs`. Register `pub(crate) mod mcp;` in `web/src/lib.rs`. Verify compiles.
+## Section 7: MCP Server Handler (rmcp)
+Minimal MCP server that responds to `initialize` and `tools/list` with zero tools. Proves rmcp integration works.
+10. **Implement `ServerHandler` for a minimal MCP handler** — in `web/src/mcp/tools/mod.rs`, define `McpToolHandler` struct holding `app_state: AppState` (no user field). Implement rmcp's `ServerHandler` trait via `#[tool_router]` + `#[tool_handler]`. Return server info (name, version, capabilities: tools enabled). No tools registered yet. `tools/list` returns empty. Add a test that constructs the handler and verifies `get_info()` returns expected values.
+
+**User context:** The authenticated user is NOT stored on the handler struct. `rmcp` propagates HTTP request `Parts` into `RequestContext.extensions`, so tool handlers extract the user via `context.extensions.get::<axum::http::request::Parts>()` → `parts.extensions.get::<users::Model>()`. This pattern is used by [`apollo-mcp-server`](https://github.com/apollographql/apollo-mcp-server/blob/ff28390b/crates/apollo-mcp-server/src/server/states/running.rs). No `Arc<RwLock<...>>` bridging needed. Validate that `Parts` propagation works during this step.
+## Section 8: MCP Auth Middleware
+PAT bearer extraction and validation. Independent of tools.
+11. **Implement PAT auth middleware** — in `web/src/mcp/auth.rs`:
+    - `validate_pat_from_header(db, headers) -> Result<users::Model>`: extracts `Authorization: Bearer <token>`, calls `domain::personal_access_token::validate_token`, returns the authenticated user with roles.
+    - `require_pat_auth`: an Axum middleware function (used via `middleware::from_fn_with_state`). Calls `validate_pat_from_header` and either inserts `users::Model` into request extensions and continues, or short-circuits with 401. Same pattern as existing `require_auth` middleware. The user inserted here is later accessible in tool handlers via `context.extensions.get::<axum::http::request::Parts>()` → `parts.extensions.get::<users::Model>()`.
+    - Test with mock DB: valid token proceeds, missing/invalid token returns 401.
+## Section 9: MCP Route + Integration
+Wire everything together: auth middleware wraps the router containing the nested MCP service.
+12. **Create `StreamableHttpService`, wrap with auth, nest into router** — in `web/src/router.rs`, add `mcp_routes(app_state)` function that:
+    1. Creates a `StreamableHttpService::new(factory, session_manager, config)` where `factory` is a closure that builds a `McpToolHandler` with `app_state` only (no user — user comes from request context).
+    2. Nests the service into a Router via `nest_service("/mcp", mcp_service)`.
+    3. Applies the PAT auth middleware as a `.layer(middleware::from_fn_with_state(app_state, require_pat_auth))` on the Router — NOT `route_layer` (which only applies to `.route()` registrations).
+    - This matches rmcp's official `simple_auth_streamhttp` example.
+    - Integration test: POST to `/mcp` without auth returns 401. POST with valid PAT and `initialize` method returns server info.
+## Section 10: Tool — `list_coachees`
+First real tool. Coach-only, read-only.
+13. **Implement `list_coachees` tool** — add to `McpToolHandler` using `#[tool]` macro. Extracts the authenticated user from `context.extensions.get::<axum::http::request::Parts>()` and accesses `self.app_state` for DB. Calls `domain::coaching_relationship::find_by_user` to get relationships where user is coach. Returns coachee profiles (id, name, email). Test: mock a coach user with two coachees, verify tool returns both.
+## Section 11: Tool — `get_coachee`
+Rich coachee profile with optional `include`.
+14. **Implement `get_coachee` tool** — accepts `coachee_id` (required for coaches, defaults to self for coachees). Authz via `coaching_relationship::is_coach_of`. Returns profile + stat counts. Test: coach can get own coachee, coach cannot get someone else's coachee.
+15. **Add `include` support to `get_coachee`** — optional `include` array param (`goals`, `actions`, `notes`). When present, fetches related records filtered to active statuses and appends to response. Test: with `include: ["goals"]`, response contains active goals array.
+## Section 12: Tool — `list_sessions`
+16. **Implement `list_sessions` tool** — accepts `coachee_id` (required for coaches), optional `date_from`/`date_to`. Authz via coaching relationship membership. Returns session summaries (id, date, meeting_url). Test: returns sessions within date range for authorized user.
+## Section 13: Tool — `list_actions`
+17. **Implement `list_actions` tool** — accepts optional `coachee_id` (required for coaches, defaults to self for coachees), `coaching_session_id`, `keyword` (searches body), `date_from`/`date_to`, `status`. Authz via `coaching_relationship::is_coach_of`. Returns `ActionResponse` arrays (flattened `actions::Model` + computed `session_url`). Test: keyword filter returns matching actions, session_id filter works, coach without coachee_id returns error, coachee defaults to self.
+## Section 14: Tool — `get_session`
+18. **Implement `get_session` tool** — accepts optional `session_id`, defaults to latest for the relationship. Authz via session ownership (`find_by_id_with_coaching_relationship` + `includes_user`) or `is_coach_of` when `coachee_id` provided. Returns structured JSON bundle: `SessionResponse` + raw entity arrays for notes, actions, agreements, and linked goals. No server-side LLM — the client LLM summarizes from this data. Test: returns complete session bundle with all related records for an authorized user.
+## Section 15: Cleanup & Documentation
+19. **Update ADR** — mark Decision section as final, remove any remaining placeholder text.
+20. **Update README** — add MCP server section documenting the `/mcp` endpoint, PAT setup, and available tools.

--- a/docs/architecture/mcp_server/mcp_response_schemas.md
+++ b/docs/architecture/mcp_server/mcp_response_schemas.md
@@ -1,0 +1,101 @@
+# MCP Request/Response Schemas
+Request and Response types for MCP tool handlers. Entity models already derive `Serialize` with `#[serde(skip_serializing)]` on sensitive fields. Where a tool returns an entity model directly, no wrapper is needed. Where a tool adds computed or nested fields, a thin wrapper uses `#[serde(flatten)]` to inline the entity and only defines the extra fields.
+
+## `get_coachee`
+
+### Input
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| coachee_id | uuid? | Coaches: yes. Coachees: no (defaults to self). | The coachee to look up. |
+| include | string[]? | No | Array of related data to inline. Valid values: `"goals"`, `"actions"`, `"notes"`. |
+
+### `CoacheeResponse`
+Flattens `users::Model` (or `coachees::Model`) and adds computed stats. No entity fields are redefined.
+
+| Extra field | Type | Source |
+|-------------|------|--------|
+| active_goals_count ** | u32 | count of goals where status in (`not_started`, `in_progress`, `on_hold`) |
+| open_actions_count | u32 | count of actions where status in (`not_started`, `in_progress`, `on_hold`) |
+| overdue_actions_count | u32 | count of actions where status in (`not_started`, `in_progress`, `on_hold`) AND `due_by < now` |
+| last_session_date | timestamptz? | most recent `coaching_sessions.date` |
+| next_session_date | timestamptz? | earliest future `coaching_sessions.date` |
+| goals | `goals::Model[]?` | populated when `include` contains `"goals"`, filtered to active statuses |
+| actions | `actions::Model[]?` | populated when `include` contains `"actions"`, filtered to active statuses |
+| notes | `notes::Model[]?` | populated when `include` contains `"notes"` |
+
+**"Active" means status is one of: `not_started`, `in_progress`, `on_hold`. This excludes `completed` and `wont_do`. Applies to `get_coachee` stat counts and `include` arrays.
+
+When `include` is absent or empty, `goals`, `actions`, and `notes` are omitted (not returned as empty arrays).
+
+The `include` arrays return raw entity models directly — no wrappers, no nested refs. This keeps `get_coachee` lightweight.
+
+## `list_actions`
+
+Filters (all optional):
+
+| Filter | Type | Description |
+|--------|------|-------------|
+| coachee_id | uuid? | Required for coaches to scope to a coachee. Defaults to self for coachees. |
+| coaching_session_id | uuid? | Filter to actions from a specific session |
+| keyword | string? | Searches `actions.body` text |
+| date_from | date? | Actions created on or after this date |
+| date_to | date? | Actions created on or before this date |
+| status | string? | Filter by status (`not_started`, `in_progress`, `completed`, `on_hold`, `wont_do`) |
+
+### `ActionResponse`
+Flattens `actions::Model` and adds a session reference with frontend URL.
+
+| Extra field | Type | Source |
+|-------------|------|--------|
+| session | `SessionResponse` | from `coaching_sessions` via `coaching_session_id` |
+
+## Shared response types
+
+### `SessionResponse`
+Flattens `coaching_sessions::Model` and adds a computed frontend URL. Reused by `list_sessions` and nested inside `ActionResponse`.
+
+| Extra field | Type | Source |
+|-------------|------|--------|
+| session_url | string | `{FRONTEND_BASE_URL}/coaching-sessions/{id}` (computed) |
+
+## `list_coachees`
+
+### Input
+No parameters — the coach is identified via PAT.
+
+### Output
+Returns raw `users::Model[]` for each coachee in the coach's coaching relationships.
+
+## `list_sessions`
+
+### Input
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| coachee_id | uuid? | Coaches: yes. Coachees: no (defaults to self). | Scope sessions to this coachee's coaching relationship. |
+| date_from | date? | No | Sessions on or after this date. |
+| date_to | date? | No | Sessions on or before this date. |
+
+### Output
+Returns `SessionResponse[]` — each session with a computed `session_url`.
+
+## `get_session`
+
+### Input
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| coachee_id | uuid? | Coaches: yes. Coachees: no (defaults to self). | Identifies the coaching relationship. |
+| session_id | uuid? | No | The session to summarize. Defaults to the most recent session for the coaching relationship. |
+
+### Output
+Returns a structured data bundle for the client LLM to summarize. No server-side LLM needed. All fields are raw entity models.
+
+| Field | Type | Source |
+|-------|------|--------|
+| session | `SessionResponse` | the session with `session_url` |
+| notes | `notes::Model[]` | all notes for the session |
+| actions | `actions::Model[]` | all actions for the session |
+| agreements | `agreements::Model[]` | all agreements for the session |
+| goals | `goals::Model[]` | goals linked to the session via `coaching_sessions_goals` |

--- a/docs/architecture/mcp_server/mvp_tools.md
+++ b/docs/architecture/mcp_server/mvp_tools.md
@@ -1,0 +1,20 @@
+# MCP Tools — MVP
+The MVP set of tools are all needed to summarize a session for a coach/ee. A typical flow for a coach would be
+
+Ask AI to "What have I been working on with Jane?" ->
+`list_coachees` to search for Jane ->
+`get_coachee` to learn about Jane ->
+`list_sessions` to learn about recent sessions
+`get_session` to generate a summary of the most recent session, pulling in other resources like goals, notes, and/or agreements as necessary.
+
+## Coach tools
+- `list_coachees` - list coachees associated with a coach.
+
+## Shared tools for Coach & Coachee
+A Coach can provide a coachee id for shared tools to filter on that coachee.
+
+- `get_coachee` — profile + aggregated stats for a coachee. Optional `include` to get current goals, actions, and notes. defaults to self when no id.
+  - flexibly replaces a lot of index tools like "list_actions" or "list_goals". Filtering was added to support the use case of getting more data about a coachee.
+- `list_sessions` - list sessions. optional date range filter.
+- `list_actions` — list actions. Filters: session id, keyword (searches body), date range, status. Coaches optionally provide a coachee id (defaults to self for coachees).
+- `get_session` — returns structured session data (session + notes + actions + agreements + linked goals) for the client LLM to summarize. No server-side LLM needed. Requires coachee_id for coach users. Optionally accepts session id, defaults to latest.

--- a/docs/architecture/mcp_server/rmcp_integration.md
+++ b/docs/architecture/mcp_server/rmcp_integration.md
@@ -5,7 +5,7 @@ How the [`rmcp`](https://docs.rs/rmcp/latest/rmcp/) SDK ([`modelcontextprotocol/
 ## Dependency
 
 ```toml
-rmcp = { version = "0.8", features = ["server", "macros", "transport-streamable-http-server"] }
+rmcp = { version = "1.5", features = ["server", "macros", "transport-streamable-http-server"] }
 ```
 
 `rmcp` re-exports [`schemars`](https://docs.rs/schemars/latest/schemars/) and [`serde`](https://docs.rs/serde/latest/serde/) — no separate `schemars` dependency needed in `web/Cargo.toml`.

--- a/docs/architecture/mcp_server/rmcp_integration.md
+++ b/docs/architecture/mcp_server/rmcp_integration.md
@@ -1,0 +1,144 @@
+# rmcp Integration
+
+How the [`rmcp`](https://docs.rs/rmcp/latest/rmcp/) SDK ([`modelcontextprotocol/rust-sdk`](https://github.com/modelcontextprotocol/rust-sdk)) integrates with the Axum backend.
+
+## Dependency
+
+```toml
+rmcp = { version = "0.8", features = ["server", "macros", "transport-streamable-http-server"] }
+```
+
+`rmcp` re-exports [`schemars`](https://docs.rs/schemars/latest/schemars/) and [`serde`](https://docs.rs/serde/latest/serde/) — no separate `schemars` dependency needed in `web/Cargo.toml`.
+
+## Architecture
+
+### Request flow through layers
+
+```
+HTTP Request (Authorization: Bearer <PAT>)
+  │
+  ▼
+Axum Router (.layer → require_pat_auth middleware)
+  │  ✅ Has HTTP request, headers, extensions
+  │  Validates PAT → resolves users::Model
+  │  Inserts users::Model into request extensions
+  │  401 if invalid
+  │
+  ▼
+StreamableHttpService (Tower Service)
+  │  Receives HTTP request, parses JSON-RPC
+  │  Propagates HTTP request Parts into RequestContext.extensions
+  │
+  ▼
+McpToolHandler (ServerHandler trait)
+  │  Owns: app_state (DB connection, config)
+  │  Dispatches to #[tool] methods via self
+  │
+  ▼
+Tool method (e.g. list_coachees)
+   Extracts user from context.extensions.get::<axum::http::request::Parts>()
+   Accesses self.app_state for DB
+```
+
+### User context propagation
+
+`rmcp` propagates the HTTP request [`Parts`](https://docs.rs/http/latest/http/request/struct.Parts.html) into [`RequestContext.extensions`](https://docs.rs/rmcp/latest/rmcp/service/struct.RequestContext.html). This means data inserted into HTTP request extensions by Axum middleware is accessible inside tool handlers.
+
+The auth middleware inserts `users::Model` into request extensions. Tool handlers extract it:
+
+```rust
+// In the tool handler:
+if let Some(axum_parts) = context.extensions.get::<axum::http::request::Parts>() {
+    if let Some(user) = axum_parts.extensions.get::<users::Model>() {
+        // user is the authenticated caller
+    }
+}
+```
+
+This pattern was discovered in [`apollo-mcp-server`](https://github.com/apollographql/apollo-mcp-server/blob/ff28390b/crates/apollo-mcp-server/src/server/states/running.rs), which uses the same approach to propagate validated OAuth tokens from Axum middleware into `rmcp` tool handlers. It is not documented in `rmcp`'s own docs or examples — their [`simple_auth_streamhttp`](https://github.com/modelcontextprotocol/rust-sdk/blob/main/examples/servers/src/simple_auth_streamhttp.rs) example only gates access without passing user identity into tools.
+
+This eliminates the need for `Arc<RwLock<...>>` bridging or storing the user on the handler struct. The `McpToolHandler` only needs `app_state` — the user flows through the request context on every call.
+
+## Stateless mode (MVP)
+
+[`StreamableHttpServerConfig`](https://docs.rs/rmcp/latest/rmcp/transport/streamable_http_server/tower/struct.StreamableHttpServerConfig.html) `{ stateful_mode: false, .. }` — every POST is self-contained. No session ID, no persistent handler. The factory creates a fresh `McpToolHandler` per request.
+
+Stateful mode (`stateful_mode: true`, the default) creates persistent sessions where the handler lives across multiple requests. Deferred to post-MVP for SSE streaming.
+
+## Auth integration
+
+PAT middleware wraps the [`Router`](https://docs.rs/axum/latest/axum/struct.Router.html) containing [`nest_service`](https://docs.rs/axum/latest/axum/struct.Router.html#method.nest_service), not the Tower service directly:
+
+```rust
+let mcp_service = StreamableHttpService::new(factory, session_manager, config);
+
+Router::new()
+    .nest_service("/mcp", mcp_service)
+    .layer(middleware::from_fn_with_state(app_state, require_pat_auth))
+```
+
+- [`.layer()`](https://docs.rs/axum/latest/axum/struct.Router.html#method.layer) applies to all routes and nested services in the Router.
+- [`route_layer`](https://docs.rs/axum/latest/axum/struct.Router.html#method.route_layer) does NOT work here — it only applies to `.route()` registrations.
+- This matches rmcp's official [`simple_auth_streamhttp`](https://github.com/modelcontextprotocol/rust-sdk/blob/main/examples/servers/src/simple_auth_streamhttp.rs) example.
+
+## Tool definition pattern
+
+Tools use three macros together:
+
+```rust
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ListCoacheesParams {
+    // empty — caller identified via PAT in request context
+}
+
+#[tool_router]
+impl McpToolHandler {
+    #[tool(description = "List coachees for the authenticated coach")]
+    async fn list_coachees(
+        &self,
+        Parameters(params): Parameters<ListCoacheesParams>,
+        context: RequestContext<RoleServer>,
+    ) -> String {
+        // Extract user from HTTP request parts propagated by rmcp
+        let parts = context.extensions.get::<axum::http::request::Parts>().unwrap();
+        let user = parts.extensions.get::<users::Model>().unwrap();
+        // self.app_state — DB access
+    }
+}
+
+#[tool_handler(name = "refactor-platform", version = "1.0.0")]
+impl ServerHandler for McpToolHandler {}
+```
+
+- [`#[tool_router]`](https://docs.rs/rmcp/latest/rmcp/attr.tool_router.html) — generates tool dispatch and `list_tools` from annotated methods.
+- [`#[tool]`](https://docs.rs/rmcp/latest/rmcp/attr.tool.html) — marks a method as an MCP tool, generates JSON Schema from the `Parameters<T>` type.
+- [`#[tool_handler]`](https://docs.rs/rmcp/latest/rmcp/attr.tool_handler.html) — auto-generates the [`ServerHandler`](https://docs.rs/rmcp/latest/rmcp/handler/server/trait.ServerHandler.html) impl with server info and tool capabilities. Use this when you need custom name/version.
+- [`Parameters<T>`](https://github.com/modelcontextprotocol/rust-sdk/blob/main/crates/rmcp/src/handler/server/wrapper.rs) — wrapper extractor. `T` must derive `schemars::JsonSchema` + `Deserialize`.
+
+## Handler struct
+
+```rust
+struct McpToolHandler {
+    app_state: AppState,     // DB connection, config
+}
+```
+
+The handler struct does not hold the user. The authenticated user is extracted from [`RequestContext.extensions`](https://docs.rs/rmcp/latest/rmcp/service/struct.RequestContext.html) on each tool call (see [User context propagation](#user-context-propagation) above). The factory closure only needs `app_state`:
+
+```rust
+let app_state = app_state.clone();
+StreamableHttpService::new(
+    move || Ok(McpToolHandler { app_state: app_state.clone() }),
+    session_manager,
+    config,
+)
+```
+
+## OAuth (future)
+
+`rmcp` has built-in [OAuth 2.1 support](https://github.com/modelcontextprotocol/rust-sdk/blob/main/docs/OAUTH_SUPPORT.md) via the `auth` feature flag:
+- PKCE (S256), dynamic client registration, token refresh, scope upgrade
+- Protected Resource Metadata discovery ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728))
+- [`AuthClient`](https://docs.rs/rmcp/latest/rmcp/transport/auth/struct.AuthClient.html) wraps `reqwest` with automatic token management
+
+This is client-side support. For the server side, we would implement authorization endpoints (authorize, token, metadata) in Axum, following the pattern in [`complex_auth_streamhttp`](https://github.com/modelcontextprotocol/rust-sdk/blob/main/examples/servers/src/complex_auth_streamhttp.rs). The PAT auth middleware is designed to support a second credential type — OAuth would resolve to the same `users::Model`, reusing the existing authorization layer.

--- a/docs/db/refactor_platform_rs.dbml
+++ b/docs/db/refactor_platform_rs.dbml
@@ -178,6 +178,26 @@ Table refactor_platform.magic_link_tokens {
   }
 }
 
+Table refactor_platform.personal_access_tokens {
+  id uuid [primary key, default: `gen_random_uuid()`]
+  user_id uuid [not null, note: 'The user who owns this token']
+  token_hash varchar(64) [unique, not null, note: 'SHA-256 hash of the raw token; raw value shown once at creation']
+  status refactor_platform.pat_status [not null, default: 'active', note: 'Only active tokens are accepted for authentication']
+  last_used_at timestamptz [note: 'For observability — updated on each authenticated request']
+  created_at timestamptz [not null, default: `now()`]
+  updated_at timestamptz [not null, default: `now()`]
+
+  Indexes {
+    (user_id) [unique, name: "idx_personal_access_tokens_one_active_per_user", note: "Partial unique index: WHERE status = 'active'"]
+    token_hash [name: "idx_personal_access_tokens_token_hash"]
+  }
+}
+
+enum refactor_platform.pat_status {
+  active
+  inactive
+}
+
 enum refactor_platform.status {
   not_started
   in_progress
@@ -232,6 +252,9 @@ Ref: refactor_platform.actions_users.user_id > refactor_platform.users.id
 
 // magic_link_tokens relationships
 Ref: refactor_platform.magic_link_tokens.user_id > refactor_platform.users.id [delete: cascade]
+
+// personal_access_tokens relationships
+Ref: refactor_platform.personal_access_tokens.user_id > refactor_platform.users.id [delete: cascade]
 
 //user_roles relationships
 Ref: refactor_platform.user_roles.organization_id > refactor_platform.organizations.id

--- a/docs/mcp_server/README.md
+++ b/docs/mcp_server/README.md
@@ -1,0 +1,146 @@
+# MCP Server Setup Guide
+
+Connect your AI client to the Refactor Platform MCP server.
+
+## Prerequisites
+
+1. The backend is running (locally or deployed) — see the [main README](../../README.md)
+2. You have a Personal Access Token (PAT) — create one via the REST API:
+
+```bash
+# Log in to get a session cookie
+curl -X POST http://localhost:4000/login \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "email=your@email.com&password=yourpassword"
+
+# Create a PAT (use the session cookie from login)
+curl -X POST http://localhost:4000/users/<your-user-id>/tokens \
+  -H "Cookie: <session-cookie-from-login>"
+```
+
+The response contains a `token` field — **save it now**, it's shown only once.
+
+## Connection Details
+
+| Setting | Value |
+|---------|-------|
+| URL | `http://localhost:4000/mcp` (local) or `https://myrefactor.com/mcp` (production) |
+| Transport | Streamable HTTP |
+| Auth | `Authorization: Bearer <your-PAT>` |
+
+## Warp
+
+In Warp, go to **Settings → MCP Servers → Add Server**, then choose **Streamable HTTP** and enter:
+
+- **Name**: `refactor-platform`
+- **URL**: `http://localhost:4000/mcp`
+- **Headers**: `Authorization: Bearer <your-PAT>`
+
+Or paste this JSON block in the MCP server config:
+
+```json
+{
+  "refactor-platform": {
+    "url": "http://localhost:4000/mcp",
+    "headers": {
+      "Authorization": "Bearer <your-PAT>"
+    }
+  }
+}
+```
+
+> **Note:** If you have secret redaction enabled (Settings → Privacy → Secret redaction), Warp will block saving the config because the PAT is detected as a secret. Temporarily disable secret redaction, save the MCP server config, then re-enable it.
+
+## Claude Code
+
+Use the CLI to add the server:
+
+```bash
+claude mcp add --transport http refactor-platform http://localhost:4000/mcp \
+  --header "Authorization: Bearer <your-PAT>"
+```
+
+Or add to `.mcp.json` in your project root (or `~/.claude/settings.json` for global):
+
+```json
+{
+  "mcpServers": {
+    "refactor-platform": {
+      "type": "http",
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-PAT>"
+      }
+    }
+  }
+}
+```
+
+## Claude Desktop
+
+Claude Desktop does not natively support `url`-based MCP servers with custom headers. Use the `mcp-remote` bridge:
+
+Edit `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) or `%APPDATA%\Claude\claude_desktop_config.json` (Windows):
+
+```json
+{
+  "mcpServers": {
+    "refactor-platform": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "mcp-remote",
+        "http://localhost:4000/mcp",
+        "--header",
+        "Authorization: Bearer <your-PAT>"
+      ]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after editing.
+
+## Cursor
+
+Edit `.cursor/mcp.json` in your project root or `~/.cursor/mcp.json` globally:
+
+```json
+{
+  "mcpServers": {
+    "refactor-platform": {
+      "url": "http://localhost:4000/mcp",
+      "headers": {
+        "Authorization": "Bearer <your-PAT>"
+      }
+    }
+  }
+}
+```
+
+## Verify
+
+After connecting, ask your AI client:
+
+> List my coachees
+
+It should call `list_coachees` and return data. If you get a 401, check that your PAT is valid and the `Authorization` header is formatted correctly (`Bearer ` + token, with a space).
+
+## Available Tools
+
+| Tool | Description |
+|------|-------------|
+| `list_coachees` | List all coachees for the authenticated coach |
+| `get_coachee` | Coachee profile with optional goals, actions, notes |
+| `list_sessions` | Coaching sessions with optional date range filter |
+| `list_actions` | Actions with session, status, and keyword filters |
+| `get_session` | Full session bundle (notes, actions, agreements, goals) |
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| 401 Unauthorized | PAT is missing, expired, or deactivated. Generate a new one. |
+| Connection refused | Backend isn't running. Start it with `cargo run`. |
+| No tools listed | The `initialize` handshake succeeded but `tools/list` returned empty. Check the server logs for errors. |
+| Forbidden on tool call | You're querying a coachee you don't have a coaching relationship with. |

--- a/domain/src/agreement.rs
+++ b/domain/src/agreement.rs
@@ -4,7 +4,9 @@ use entity_api::query::{IntoQueryFilterMap, QuerySort};
 use entity_api::{agreements, query};
 use sea_orm::DatabaseConnection;
 
-pub use entity_api::agreement::{create, delete_by_id, find_by_id, update};
+pub use entity_api::agreement::{
+    create, delete_by_id, find_by_coaching_session_id, find_by_id, update,
+};
 
 pub async fn find_by<P>(db: &DatabaseConnection, params: P) -> Result<Vec<Model>, Error>
 where

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -14,7 +14,8 @@ use sea_orm::{DatabaseConnection, IntoActiveModel, TransactionTrait};
 use service::config::Config;
 
 pub use entity_api::coaching_session::{
-    find_by_id, find_by_user_with_includes, EnrichedSession, IncludeOptions, SessionQueryOptions,
+    find_by_id, find_by_user, find_by_user_with_includes, EnrichedSession, IncludeOptions,
+    SessionQueryOptions,
 };
 
 /// Wraps the entity_api function to convert `entity_api::Error` into `domain::Error`,

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -13,7 +13,8 @@ pub use entity_api::{
 pub use entity_api::{
     actions, agreements, coachees, coaches, coaching_relationships, coaching_sessions,
     coaching_sessions_goals, goals, jwts, magic_link_tokens, notes, oauth_connections,
-    organizations, provider, query::QuerySort, status, user_roles, users, Id,
+    organizations, pat_status, personal_access_tokens, provider, query::QuerySort, status,
+    user_roles, users, Id,
 };
 
 pub mod action;
@@ -31,6 +32,7 @@ pub mod note;
 pub mod oauth_connection;
 pub mod oauth_token_storage;
 pub mod organization;
+pub mod personal_access_token;
 pub mod user;
 
 pub mod gateway;

--- a/domain/src/personal_access_token.rs
+++ b/domain/src/personal_access_token.rs
@@ -97,6 +97,15 @@ pub async fn find_active_by_user(
     Ok(model)
 }
 
+/// Update the `last_used_at` timestamp for a personal access token.
+pub async fn touch_last_used(
+    db: &impl ConnectionTrait,
+    pat_id: Id,
+) -> Result<personal_access_tokens::Model, Error> {
+    let model = entity_api::personal_access_token::touch_last_used(db, pat_id).await?;
+    Ok(model)
+}
+
 /// Deactivate a personal access token.
 pub async fn deactivate_token(
     db: &impl ConnectionTrait,

--- a/domain/src/personal_access_token.rs
+++ b/domain/src/personal_access_token.rs
@@ -1,0 +1,239 @@
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
+use log::*;
+use rand::RngCore;
+use sea_orm::{ConnectionTrait, DatabaseConnection, TransactionTrait};
+use sha2::{Digest, Sha256};
+
+use crate::error::{DomainErrorKind, EntityErrorKind, Error, InternalErrorKind};
+use crate::{pat_status::PATStatus, personal_access_tokens, users, Id};
+
+/// Create a new personal access token for a user.
+///
+/// If the user already has an active PAT, it is deactivated first.
+/// Returns the raw token string (shown once, never stored) and the persisted model.
+pub async fn create_token(
+    db: &DatabaseConnection,
+    user_id: Id,
+) -> Result<(String, personal_access_tokens::Model), Error> {
+    let txn = db.begin().await.map_err(|e| Error {
+        source: Some(Box::new(e)),
+        error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(
+            EntityErrorKind::DbTransaction,
+        )),
+    })?;
+
+    // Deactivate any existing active PAT for this user
+    if let Some(existing) =
+        entity_api::personal_access_token::find_active_by_user(&txn, user_id).await?
+    {
+        info!(
+            "Deactivating existing active PAT {} for user {user_id}",
+            existing.id
+        );
+        entity_api::personal_access_token::deactivate(&txn, existing.id).await?;
+    }
+
+    // Generate a cryptographically secure random token
+    let mut raw_bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut raw_bytes);
+    let raw_token = URL_SAFE_NO_PAD.encode(raw_bytes);
+    let token_hash = hash_token(&raw_token);
+
+    let model = entity_api::personal_access_token::create(&txn, user_id, token_hash).await?;
+
+    txn.commit().await.map_err(|e| Error {
+        source: Some(Box::new(e)),
+        error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(
+            EntityErrorKind::DbTransaction,
+        )),
+    })?;
+
+    info!("Created new PAT {} for user {user_id}", model.id);
+    Ok((raw_token, model))
+}
+
+/// Validate a raw PAT string.
+///
+/// Hashes the input, looks up the PAT by hash, checks that it is active,
+/// and returns the associated user with roles populated.
+pub async fn validate_token(
+    db: &impl ConnectionTrait,
+    raw_token: &str,
+) -> Result<(users::Model, personal_access_tokens::Model), Error> {
+    let token_hash = hash_token(raw_token);
+
+    let pat = entity_api::personal_access_token::find_by_token_hash(db, &token_hash)
+        .await?
+        .ok_or_else(|| {
+            warn!("PAT not found for provided token");
+            Error {
+                source: None,
+                error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(
+                    EntityErrorKind::Unauthenticated,
+                )),
+            }
+        })?;
+
+    if pat.status != PATStatus::Active {
+        warn!("PAT {} is not active (status: {})", pat.id, pat.status);
+        return Err(Error {
+            source: None,
+            error_kind: DomainErrorKind::Internal(InternalErrorKind::Entity(
+                EntityErrorKind::Unauthenticated,
+            )),
+        });
+    }
+
+    let user = entity_api::user::find_by_id(db, pat.user_id).await?;
+    Ok((user, pat))
+}
+
+/// Find the active personal access token for a user, if one exists.
+pub async fn find_active_by_user(
+    db: &impl ConnectionTrait,
+    user_id: Id,
+) -> Result<Option<personal_access_tokens::Model>, Error> {
+    let model = entity_api::personal_access_token::find_active_by_user(db, user_id).await?;
+    Ok(model)
+}
+
+/// Deactivate a personal access token.
+pub async fn deactivate_token(
+    db: &impl ConnectionTrait,
+    pat_id: Id,
+) -> Result<personal_access_tokens::Model, Error> {
+    let model = entity_api::personal_access_token::deactivate(db, pat_id).await?;
+    info!("Deactivated PAT {pat_id}");
+    Ok(model)
+}
+
+/// Compute the SHA-256 hex digest of a raw token string.
+fn hash_token(raw_token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(raw_token.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_token_is_deterministic() {
+        let hash1 = hash_token("test_pat_token");
+        let hash2 = hash_token("test_pat_token");
+        assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn hash_token_produces_64_char_hex() {
+        let hash = hash_token("any_input");
+        assert_eq!(hash.len(), 64);
+        assert!(hash.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn hash_token_differs_for_different_inputs() {
+        assert_ne!(hash_token("token_a"), hash_token("token_b"));
+    }
+
+    #[cfg(feature = "mock")]
+    mod mock_tests {
+        use super::*;
+        use crate::error::{DomainErrorKind, EntityErrorKind, InternalErrorKind};
+        use chrono::Utc;
+        use entity_api::{personal_access_tokens, user_roles, users};
+        use sea_orm::{DatabaseBackend, MockDatabase};
+        use uuid::Uuid;
+
+        fn test_pat_model(user_id: Uuid, status: PATStatus) -> personal_access_tokens::Model {
+            let now = Utc::now();
+            personal_access_tokens::Model {
+                id: Uuid::new_v4(),
+                user_id,
+                token_hash: hash_token("raw_token"),
+                status,
+                last_used_at: None,
+                created_at: now.into(),
+                updated_at: now.into(),
+            }
+        }
+
+        fn test_user_model(id: Uuid) -> users::Model {
+            users::Model {
+                id,
+                email: "test@example.com".into(),
+                first_name: "Test".into(),
+                last_name: "User".into(),
+                display_name: None,
+                password: None,
+                github_username: None,
+                github_profile_url: None,
+                timezone: "UTC".into(),
+                role: Default::default(),
+                roles: vec![],
+                invite_status: None,
+                created_at: Utc::now().into(),
+                updated_at: Utc::now().into(),
+            }
+        }
+
+        #[tokio::test]
+        async fn validate_token_rejects_unknown_token() {
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![Vec::<personal_access_tokens::Model>::new()])
+                .into_connection();
+
+            let result = validate_token(&db, "nonexistent_token").await;
+            let err = result.unwrap_err();
+            assert_eq!(
+                err.error_kind,
+                DomainErrorKind::Internal(InternalErrorKind::Entity(
+                    EntityErrorKind::Unauthenticated
+                ))
+            );
+        }
+
+        #[tokio::test]
+        async fn validate_token_rejects_inactive_token() {
+            let user_id = Uuid::new_v4();
+            let pat = test_pat_model(user_id, PATStatus::Inactive);
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results(vec![vec![pat]])
+                .into_connection();
+
+            let result = validate_token(&db, "raw_token").await;
+            let err = result.unwrap_err();
+            assert_eq!(
+                err.error_kind,
+                DomainErrorKind::Internal(InternalErrorKind::Entity(
+                    EntityErrorKind::Unauthenticated
+                ))
+            );
+        }
+
+        #[tokio::test]
+        async fn validate_token_returns_user_for_active_token() {
+            let user_id = Uuid::new_v4();
+            let pat = test_pat_model(user_id, PATStatus::Active);
+            let user = test_user_model(user_id);
+
+            let db = MockDatabase::new(DatabaseBackend::Postgres)
+                // find_by_token_hash
+                .append_query_results(vec![vec![pat.clone()]])
+                // find_by_id (uses find_with_related)
+                .append_query_results::<(users::Model, Option<user_roles::Model>), _, _>(vec![
+                    vec![(user.clone(), None)],
+                ])
+                .into_connection();
+
+            let result = validate_token(&db, "raw_token").await;
+            assert!(result.is_ok());
+
+            let (returned_user, returned_pat) = result.unwrap();
+            assert_eq!(returned_user.id, user_id);
+            assert_eq!(returned_pat.id, pat.id);
+        }
+    }
+}

--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -18,6 +18,8 @@ pub mod magic_link_tokens;
 pub mod notes;
 pub mod oauth_connections;
 pub mod organizations;
+pub mod pat_status;
+pub mod personal_access_tokens;
 pub mod provider;
 pub mod roles;
 pub mod status;

--- a/entity/src/pat_status.rs
+++ b/entity/src/pat_status.rs
@@ -1,0 +1,23 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(
+    Debug, Clone, Eq, PartialEq, EnumIter, Deserialize, Serialize, DeriveActiveEnum, Default,
+)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "pat_status")]
+pub enum PATStatus {
+    #[sea_orm(string_value = "active")]
+    #[default]
+    Active,
+    #[sea_orm(string_value = "inactive")]
+    Inactive,
+}
+
+impl std::fmt::Display for PATStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Active => write!(f, "active"),
+            Self::Inactive => write!(f, "inactive"),
+        }
+    }
+}

--- a/entity/src/personal_access_tokens.rs
+++ b/entity/src/personal_access_tokens.rs
@@ -1,0 +1,44 @@
+use crate::pat_status::PATStatus;
+use crate::Id;
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, Serialize, Deserialize)]
+#[sea_orm(
+    schema_name = "refactor_platform",
+    table_name = "personal_access_tokens"
+)]
+pub struct Model {
+    #[serde(skip_deserializing)]
+    #[sea_orm(primary_key)]
+    pub id: Id,
+    pub user_id: Id,
+    #[serde(skip_serializing)]
+    pub token_hash: String,
+    pub status: PATStatus,
+    pub last_used_at: Option<DateTimeWithTimeZone>,
+    #[serde(skip_deserializing)]
+    pub created_at: DateTimeWithTimeZone,
+    #[serde(skip_deserializing)]
+    pub updated_at: DateTimeWithTimeZone,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::users::Entity",
+        from = "Column::UserId",
+        to = "super::users::Column::Id",
+        on_update = "NoAction",
+        on_delete = "Cascade"
+    )]
+    Users,
+}
+
+impl Related<super::users::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Users.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/entity/src/prelude.rs
+++ b/entity/src/prelude.rs
@@ -4,4 +4,5 @@ pub use super::coaching_relationships::Entity as CoachingRelationships;
 pub use super::magic_link_tokens::Entity as MagicLinkTokens;
 pub use super::oauth_connections::Entity as OauthConnections;
 pub use super::organizations::Entity as Organizations;
+pub use super::personal_access_tokens::Entity as PersonalAccessTokens;
 pub use super::users::Entity as Users;

--- a/entity_api/src/agreement.rs
+++ b/entity_api/src/agreement.rs
@@ -66,6 +66,17 @@ pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> 
     Ok(())
 }
 
+/// Find all agreements for a coaching session.
+pub async fn find_by_coaching_session_id(
+    db: &DatabaseConnection,
+    coaching_session_id: Id,
+) -> Result<Vec<Model>, Error> {
+    Ok(Entity::find()
+        .filter(entity::agreements::Column::CoachingSessionId.eq(coaching_session_id))
+        .all(db)
+        .await?)
+}
+
 pub async fn find_by_id(db: &DatabaseConnection, id: Id) -> Result<Model, Error> {
     Entity::find_by_id(id).one(db).await?.ok_or_else(|| Error {
         source: None,

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -5,8 +5,8 @@ use sea_orm::{ActiveModelTrait, DatabaseConnection, Set};
 pub use entity::{
     actions, actions_users, agreements, coachees, coaches, coaching_relationships,
     coaching_sessions, coaching_sessions_goals, goals, jwts, magic_link_tokens, notes,
-    oauth_connections, organizations, provider, status, user_invite_status, user_roles, users,
-    users::Role, Id,
+    oauth_connections, organizations, pat_status, personal_access_tokens, provider, status,
+    user_invite_status, user_roles, users, users::Role, Id,
 };
 
 pub mod action;
@@ -23,6 +23,7 @@ pub mod mutate;
 pub mod note;
 pub mod oauth_connection;
 pub mod organization;
+pub mod personal_access_token;
 pub mod query;
 pub mod user;
 pub mod user_role;

--- a/entity_api/src/personal_access_token.rs
+++ b/entity_api/src/personal_access_token.rs
@@ -1,0 +1,192 @@
+use super::error::Error;
+
+use chrono::Utc;
+use entity::pat_status::PATStatus;
+use entity::personal_access_tokens::{ActiveModel, Column, Entity, Model};
+use entity::Id;
+use sea_orm::{entity::prelude::*, ConnectionTrait, Set};
+
+/// Insert a new personal access token row.
+pub async fn create(
+    db: &impl ConnectionTrait,
+    user_id: Id,
+    token_hash: String,
+) -> Result<Model, Error> {
+    let now = Utc::now();
+
+    let active_model = ActiveModel {
+        user_id: Set(user_id),
+        token_hash: Set(token_hash),
+        status: Set(PATStatus::Active),
+        created_at: Set(now.into()),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    };
+
+    Ok(active_model.insert(db).await?)
+}
+
+/// Look up a personal access token by its SHA-256 hash.
+pub async fn find_by_token_hash(
+    db: &impl ConnectionTrait,
+    token_hash: &str,
+) -> Result<Option<Model>, Error> {
+    Ok(Entity::find()
+        .filter(Column::TokenHash.eq(token_hash))
+        .one(db)
+        .await?)
+}
+
+/// Find the active personal access token for a user (at most one due to partial unique index).
+pub async fn find_active_by_user(
+    db: &impl ConnectionTrait,
+    user_id: Id,
+) -> Result<Option<Model>, Error> {
+    Ok(Entity::find()
+        .filter(Column::UserId.eq(user_id))
+        .filter(Column::Status.eq(PATStatus::Active))
+        .one(db)
+        .await?)
+}
+
+/// Deactivate a personal access token by setting its status to inactive.
+pub async fn deactivate(db: &impl ConnectionTrait, pat_id: Id) -> Result<Model, Error> {
+    let now = Utc::now();
+
+    let active_model = ActiveModel {
+        id: Set(pat_id),
+        status: Set(PATStatus::Inactive),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    };
+
+    Ok(active_model.update(db).await?)
+}
+
+/// Update the `last_used_at` timestamp for a personal access token.
+pub async fn touch_last_used(db: &impl ConnectionTrait, pat_id: Id) -> Result<Model, Error> {
+    let now = Utc::now();
+
+    let active_model = ActiveModel {
+        id: Set(pat_id),
+        last_used_at: Set(Some(now.into())),
+        updated_at: Set(now.into()),
+        ..Default::default()
+    };
+
+    Ok(active_model.update(db).await?)
+}
+
+#[cfg(test)]
+#[cfg(feature = "mock")]
+mod tests {
+    use super::*;
+    use entity::pat_status::PATStatus;
+    use entity::personal_access_tokens;
+    use entity::Id;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    fn test_pat_model(user_id: Id, status: PATStatus) -> personal_access_tokens::Model {
+        let now = Utc::now();
+        personal_access_tokens::Model {
+            id: Id::new_v4(),
+            user_id,
+            token_hash: "abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+                .to_string(),
+            status,
+            last_used_at: None,
+            created_at: now.into(),
+            updated_at: now.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_inserts_active_pat() {
+        let user_id = Id::new_v4();
+        let expected = test_pat_model(user_id, PATStatus::Active);
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![expected.clone()]])
+            .into_connection();
+
+        let result = create(&db, user_id, expected.token_hash.clone()).await;
+        assert!(result.is_ok());
+
+        let pat = result.unwrap();
+        assert_eq!(pat.user_id, user_id);
+        assert_eq!(pat.status, PATStatus::Active);
+    }
+
+    #[tokio::test]
+    async fn find_by_token_hash_returns_matching_pat() {
+        let user_id = Id::new_v4();
+        let expected = test_pat_model(user_id, PATStatus::Active);
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![expected.clone()]])
+            .into_connection();
+
+        let result = find_by_token_hash(&db, &expected.token_hash).await;
+        assert!(result.is_ok());
+
+        let pat = result.unwrap();
+        assert!(pat.is_some());
+        assert_eq!(pat.unwrap().token_hash, expected.token_hash);
+    }
+
+    #[tokio::test]
+    async fn find_by_token_hash_returns_none_for_unknown() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![Vec::<personal_access_tokens::Model>::new()])
+            .into_connection();
+
+        let result = find_by_token_hash(&db, "nonexistent_hash").await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn find_active_by_user_returns_active_pat() {
+        let user_id = Id::new_v4();
+        let expected = test_pat_model(user_id, PATStatus::Active);
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![expected.clone()]])
+            .into_connection();
+
+        let result = find_active_by_user(&db, user_id).await;
+        assert!(result.is_ok());
+
+        let pat = result.unwrap();
+        assert!(pat.is_some());
+        assert_eq!(pat.unwrap().status, PATStatus::Active);
+    }
+
+    #[tokio::test]
+    async fn find_active_by_user_returns_none_when_no_active() {
+        let user_id = Id::new_v4();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![Vec::<personal_access_tokens::Model>::new()])
+            .into_connection();
+
+        let result = find_active_by_user(&db, user_id).await;
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn deactivate_sets_status_to_inactive() {
+        let user_id = Id::new_v4();
+        let mut expected = test_pat_model(user_id, PATStatus::Inactive);
+        expected.status = PATStatus::Inactive;
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![expected.clone()]])
+            .into_connection();
+
+        let result = deactivate(&db, expected.id).await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().status, PATStatus::Inactive);
+    }
+}

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -23,6 +23,7 @@ mod m20260312_000000_add_goal_id_to_actions;
 mod m20260316_000000_fix_goals_session_fk_on_delete;
 mod m20260317_000000_add_on_hold_to_status_enum;
 mod m20260330_000000_add_magic_link_tokens;
+mod m20260429_000000_add_personal_access_tokens;
 
 pub struct Migrator;
 
@@ -53,6 +54,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260316_000000_fix_goals_session_fk_on_delete::Migration),
             Box::new(m20260317_000000_add_on_hold_to_status_enum::Migration),
             Box::new(m20260330_000000_add_magic_link_tokens::Migration),
+            Box::new(m20260429_000000_add_personal_access_tokens::Migration),
         ]
     }
 }

--- a/migration/src/m20260429_000000_add_personal_access_tokens.rs
+++ b/migration/src/m20260429_000000_add_personal_access_tokens.rs
@@ -1,0 +1,75 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Create the pat_status enum (separate from the existing `status` enum)
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE TYPE refactor_platform.pat_status AS ENUM ('active', 'inactive')",
+            )
+            .await?;
+
+        // Create personal_access_tokens table
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE TABLE IF NOT EXISTS refactor_platform.personal_access_tokens (
+                id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+                user_id UUID NOT NULL REFERENCES refactor_platform.users(id) ON DELETE CASCADE,
+                token_hash VARCHAR(64) NOT NULL UNIQUE,
+                status refactor_platform.pat_status NOT NULL DEFAULT 'active',
+                last_used_at TIMESTAMPTZ,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "ALTER TABLE refactor_platform.personal_access_tokens OWNER TO refactor",
+            )
+            .await?;
+
+        // Partial unique index: only one active PAT per user
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE UNIQUE INDEX idx_personal_access_tokens_one_active_per_user
+                 ON refactor_platform.personal_access_tokens(user_id)
+                 WHERE status = 'active'",
+            )
+            .await?;
+
+        // Index on token_hash for fast lookups during auth
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE INDEX IF NOT EXISTS idx_personal_access_tokens_token_hash
+                 ON refactor_platform.personal_access_tokens(token_hash)",
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TABLE IF EXISTS refactor_platform.personal_access_tokens")
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TYPE IF EXISTS refactor_platform.pat_status")
+            .await?;
+
+        Ok(())
+    }
+}

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -30,6 +30,7 @@ utoipa-rapidoc = { version = "3.0.0", features = ["axum"] }
 async-trait = "0.1.88"
 async-stream = "0.3"
 futures = "0.3.31"
+rmcp = { version = "1.5", features = ["server", "macros", "transport-streamable-http-server"] }
 
 [dependencies.sea-orm]
 version = "1.1.0" # sea-orm version

--- a/web/src/controller/user/mod.rs
+++ b/web/src/controller/user/mod.rs
@@ -4,3 +4,4 @@ pub(crate) mod coaching_session_controller;
 pub(crate) mod goal_controller;
 pub(crate) mod organization_controller;
 pub(crate) mod password_controller;
+pub(crate) mod pat_controller;

--- a/web/src/controller/user/pat_controller.rs
+++ b/web/src/controller/user/pat_controller.rs
@@ -1,0 +1,118 @@
+use crate::extractors::{
+    authenticated_user::AuthenticatedUser, compare_api_version::CompareApiVersion,
+};
+use crate::{controller::ApiResponse, AppState, Error};
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json,
+};
+use domain::{personal_access_token as PatApi, Id};
+use service::config::ApiVersion;
+
+/// POST /users/:user_id/tokens
+///
+/// Create a new personal access token for the authenticated user.
+/// If an active PAT already exists, it is deactivated and replaced.
+/// The raw token value is returned once in the response and never stored.
+#[utoipa::path(
+    post,
+    path = "/users/{user_id}/tokens",
+    params(
+        ApiVersion,
+        ("user_id" = Id, Path, description = "User ID"),
+    ),
+    responses(
+        (status = 201, description = "Successfully created a personal access token"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 500, description = "Internal server error"),
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn create(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    State(app_state): State<AppState>,
+    Path(user_id): Path<Id>,
+) -> Result<impl IntoResponse, Error> {
+    let (raw_token, pat) = PatApi::create_token(app_state.db_conn_ref(), user_id).await?;
+
+    let response = serde_json::json!({
+        "token": raw_token,
+        "id": pat.id,
+        "status": pat.status,
+        "created_at": pat.created_at,
+    });
+
+    Ok(Json(ApiResponse::new(StatusCode::CREATED.into(), response)))
+}
+
+/// GET /users/:user_id/tokens
+///
+/// Show the active personal access token metadata for the authenticated user.
+/// The raw token value is never returned — only metadata (id, status, timestamps).
+#[utoipa::path(
+    get,
+    path = "/users/{user_id}/tokens",
+    params(
+        ApiVersion,
+        ("user_id" = Id, Path, description = "User ID"),
+    ),
+    responses(
+        (status = 200, description = "Successfully retrieved active token metadata"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 404, description = "No active token exists"),
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn index(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    State(app_state): State<AppState>,
+    Path(user_id): Path<Id>,
+) -> Result<impl IntoResponse, Error> {
+    let pat = PatApi::find_active_by_user(app_state.db_conn_ref(), user_id).await?;
+
+    match pat {
+        Some(token) => Ok(Json(ApiResponse::new(StatusCode::OK.into(), token)).into_response()),
+        None => Ok((StatusCode::NOT_FOUND, "No active token exists").into_response()),
+    }
+}
+
+/// PUT /users/:user_id/tokens/:token_id/deactivate
+///
+/// Deactivate a personal access token. Idempotent — deactivating an already-inactive token succeeds.
+#[utoipa::path(
+    put,
+    path = "/users/{user_id}/tokens/{token_id}/deactivate",
+    params(
+        ApiVersion,
+        ("user_id" = Id, Path, description = "User ID"),
+        ("token_id" = Id, Path, description = "Token ID"),
+    ),
+    responses(
+        (status = 200, description = "Successfully deactivated the token"),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden"),
+        (status = 500, description = "Internal server error"),
+    ),
+    security(
+        ("cookie_auth" = [])
+    )
+)]
+pub async fn deactivate(
+    CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(_user): AuthenticatedUser,
+    State(app_state): State<AppState>,
+    Path((_user_id, token_id)): Path<(Id, Id)>,
+) -> Result<impl IntoResponse, Error> {
+    let pat = PatApi::deactivate_token(app_state.db_conn_ref(), token_id).await?;
+    Ok(Json(ApiResponse::new(StatusCode::OK.into(), pat)))
+}

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -24,6 +24,7 @@ use tower_http::cors::{AllowOrigin, CorsLayer};
 mod controller;
 mod error;
 pub(crate) mod extractors;
+pub(crate) mod mcp;
 pub(crate) mod middleware;
 pub(crate) mod params;
 pub(crate) mod protect;

--- a/web/src/mcp/auth.rs
+++ b/web/src/mcp/auth.rs
@@ -1,0 +1,2 @@
+// PAT bearer auth middleware for MCP endpoints.
+// Implemented in a later step.

--- a/web/src/mcp/auth.rs
+++ b/web/src/mcp/auth.rs
@@ -1,2 +1,69 @@
-// PAT bearer auth middleware for MCP endpoints.
-// Implemented in a later step.
+use crate::AppState;
+use axum::{
+    body::Body,
+    extract::{Request, State},
+    http::{HeaderMap, StatusCode},
+    middleware::Next,
+    response::{IntoResponse, Response},
+};
+use domain::personal_access_token;
+use log::*;
+
+/// Extract the bearer token from the Authorization header.
+fn extract_bearer_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get("Authorization")
+        .and_then(|value| value.to_str().ok())
+        .and_then(|auth_header| {
+            auth_header
+                .strip_prefix("Bearer ")
+                .map(|stripped| stripped.to_string())
+        })
+}
+
+/// Axum middleware that validates a PAT bearer token for MCP endpoints.
+///
+/// Extracts `Authorization: Bearer <token>`, validates via domain layer,
+/// and inserts the authenticated `users::Model` into request extensions.
+/// Returns 401 if the token is missing, invalid, or inactive.
+pub(crate) async fn require_pat_auth(
+    State(app_state): State<AppState>,
+    headers: HeaderMap,
+    mut request: Request<Body>,
+    next: Next,
+) -> Response {
+    let raw_token = match extract_bearer_token(&headers) {
+        Some(token) => token,
+        None => {
+            warn!("MCP request missing Authorization header");
+            return (
+                StatusCode::UNAUTHORIZED,
+                "Unauthorized: missing bearer token",
+            )
+                .into_response();
+        }
+    };
+
+    match personal_access_token::validate_token(app_state.db_conn_ref(), &raw_token).await {
+        Ok((user, pat)) => {
+            // Fire-and-forget: update last_used_at for observability.
+            // Non-critical — don't fail the request if this errors.
+            let db = app_state.database_connection.clone();
+            let pat_id = pat.id;
+            tokio::spawn(async move {
+                if let Err(e) = personal_access_token::touch_last_used(&*db, pat_id).await {
+                    warn!("Failed to update PAT last_used_at: {e}");
+                }
+            });
+
+            // Insert the authenticated user into request extensions
+            // so tool handlers can access it via RequestContext.extensions
+            request.extensions_mut().insert(user);
+            next.run(request).await
+        }
+        Err(_) => {
+            warn!("MCP request with invalid PAT");
+            (StatusCode::UNAUTHORIZED, "Unauthorized: invalid token").into_response()
+        }
+    }
+}

--- a/web/src/mcp/mod.rs
+++ b/web/src/mcp/mod.rs
@@ -1,0 +1,2 @@
+pub(crate) mod auth;
+pub(crate) mod tools;

--- a/web/src/mcp/tools/mod.rs
+++ b/web/src/mcp/tools/mod.rs
@@ -1,10 +1,58 @@
 use crate::AppState;
-use domain::{coaching_relationship, user, users, Id};
+use domain::{
+    action, agreement, coaching_relationship, coaching_session, goal, note, user, users, Id,
+};
 use rmcp::{
+    handler::server::wrapper::Parameters,
     model::{CallToolResult, Content},
+    schemars,
     service::RequestContext,
     tool, tool_handler, tool_router, ErrorData as McpError, RoleServer, ServerHandler,
 };
+use serde::Deserialize;
+use std::collections::HashMap;
+
+// ── Parameter structs ────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct GetCoacheeParams {
+    /// UUID of the coachee to look up. Required for coaches.
+    coachee_id: Option<String>,
+    /// Comma-separated list of related data to include: goals, actions, notes
+    include: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ListSessionsParams {
+    /// UUID of the coachee. Required for coaches.
+    coachee_id: Option<String>,
+    /// Start date filter (YYYY-MM-DD)
+    date_from: Option<String>,
+    /// End date filter (YYYY-MM-DD)
+    date_to: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ListActionsParams {
+    /// UUID of the coachee. Required for coaches.
+    coachee_id: Option<String>,
+    /// Filter to actions from a specific session
+    coaching_session_id: Option<String>,
+    /// Filter by status (not_started, in_progress, completed, on_hold, wont_do)
+    status: Option<String>,
+    /// Search keyword in action body
+    keyword: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct GetSessionParams {
+    /// UUID of the coachee. Required for coaches.
+    coachee_id: Option<String>,
+    /// UUID of the session. Defaults to most recent.
+    session_id: Option<String>,
+}
+
+// ── Handler ──────────────────────────────────────────────────────────
 
 /// MCP tool handler. Holds application state for DB access.
 /// The authenticated user is NOT stored here — it flows through
@@ -14,16 +62,11 @@ pub(crate) struct McpToolHandler {
     pub(crate) app_state: AppState,
 }
 
-/// Extract the authenticated user from the MCP request context.
-///
-/// The PAT auth middleware inserts `users::Model` into HTTP request extensions.
-/// `rmcp` propagates HTTP `Parts` into `RequestContext.extensions`.
 fn extract_user(ctx: &RequestContext<RoleServer>) -> Result<users::Model, McpError> {
     let parts = ctx
         .extensions
         .get::<axum::http::request::Parts>()
         .ok_or_else(|| McpError::internal_error("Missing HTTP request parts in context", None))?;
-
     parts
         .extensions
         .get::<users::Model>()
@@ -31,18 +74,49 @@ fn extract_user(ctx: &RequestContext<RoleServer>) -> Result<users::Model, McpErr
         .ok_or_else(|| McpError::internal_error("Missing authenticated user in context", None))
 }
 
+/// Resolve and authorize a target user ID from an optional coachee_id param.
+async fn resolve_target_user(
+    db: &sea_orm::DatabaseConnection,
+    caller: &users::Model,
+    coachee_id: &Option<String>,
+) -> Result<Id, McpError> {
+    match coachee_id {
+        Some(id_str) => {
+            let id = Id::parse_str(id_str)
+                .map_err(|_| McpError::invalid_params("Invalid coachee_id UUID", None))?;
+            if id != caller.id {
+                let is_coach = coaching_relationship::is_coach_of(db, caller.id, id)
+                    .await
+                    .map_err(|e| {
+                        McpError::internal_error(format!("Authz check failed: {e}"), None)
+                    })?;
+                if !is_coach {
+                    return Err(McpError::invalid_params(
+                        "Forbidden: not a coach of this coachee",
+                        None,
+                    ));
+                }
+            }
+            Ok(id)
+        }
+        None => Ok(caller.id),
+    }
+}
+
+fn to_json<T: serde::Serialize>(value: &T) -> Result<String, McpError> {
+    serde_json::to_string_pretty(value)
+        .map_err(|e| McpError::internal_error(format!("Serialization error: {e}"), None))
+}
+
+// ── Tools ────────────────────────────────────────────────────────────
+
 #[tool_router]
 impl McpToolHandler {
     pub(crate) fn new(app_state: AppState) -> Self {
         Self { app_state }
     }
 
-    /// List all coachees for the authenticated coach.
-    /// Returns coachee profiles (id, name, email) for each coaching relationship
-    /// where the authenticated user is the coach.
-    #[tool(description = "List all coachees for the authenticated coach. \
-        No parameters needed — the coach is identified via the PAT token. \
-        Returns an array of coachee profiles.")]
+    #[tool(description = "List all coachees for the authenticated coach. No parameters needed.")]
     async fn list_coachees(
         &self,
         ctx: RequestContext<RoleServer>,
@@ -52,11 +126,8 @@ impl McpToolHandler {
 
         let relationships = coaching_relationship::find_by_user(db, user.id)
             .await
-            .map_err(|e| {
-                McpError::internal_error(format!("Failed to query relationships: {e}"), None)
-            })?;
+            .map_err(|e| McpError::internal_error(format!("Query failed: {e}"), None))?;
 
-        // Filter to relationships where the authenticated user is the coach
         let coachee_ids: Vec<Id> = relationships
             .iter()
             .filter(|r| r.coach_id == user.id)
@@ -65,18 +136,233 @@ impl McpToolHandler {
 
         if coachee_ids.is_empty() {
             return Ok(CallToolResult::success(vec![Content::text(
-                "No coachees found. You may not have any coaching relationships as a coach.",
+                "No coachees found.",
             )]));
         }
 
-        let coachees = user::find_by_ids(db, &coachee_ids).await.map_err(|e| {
-            McpError::internal_error(format!("Failed to query coachees: {e}"), None)
-        })?;
+        let coachees = user::find_by_ids(db, &coachee_ids)
+            .await
+            .map_err(|e| McpError::internal_error(format!("Query failed: {e}"), None))?;
 
-        let json = serde_json::to_string_pretty(&coachees)
-            .map_err(|e| McpError::internal_error(format!("Serialization error: {e}"), None))?;
+        Ok(CallToolResult::success(vec![Content::text(to_json(
+            &coachees,
+        )?)]))
+    }
 
-        Ok(CallToolResult::success(vec![Content::text(json)]))
+    #[tool(
+        description = "Get a coachee profile. Coaches must provide coachee_id. \
+            Coachees can omit it. Use include (comma-separated: goals,actions,notes) \
+            to inline related data."
+    )]
+    async fn get_coachee(
+        &self,
+        Parameters(params): Parameters<GetCoacheeParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let user = extract_user(&ctx)?;
+        let db = self.app_state.db_conn_ref();
+        let target_id = resolve_target_user(db, &user, &params.coachee_id).await?;
+
+        let coachee = user::find_by_id(db, target_id)
+            .await
+            .map_err(|e| McpError::internal_error(format!("Query failed: {e}"), None))?;
+
+        let mut response = serde_json::json!({ "profile": coachee });
+
+        let includes: Vec<&str> = params
+            .include
+            .as_deref()
+            .map(|s| s.split(',').map(|p| p.trim()).collect())
+            .unwrap_or_default();
+
+        if includes.contains(&"goals") {
+            let rels = coaching_relationship::find_by_user(db, target_id)
+                .await
+                .unwrap_or_default();
+            let mut all_goals = Vec::new();
+            for rel in &rels {
+                let sids = goal::find_session_ids_by_coaching_relationship_id(db, rel.id)
+                    .await
+                    .unwrap_or_default();
+                if !sids.is_empty() {
+                    let grouped = goal::find_goals_grouped_by_session_ids(db, &sids)
+                        .await
+                        .unwrap_or_default();
+                    for gs in grouped.into_values() {
+                        all_goals.extend(gs);
+                    }
+                }
+            }
+            response["goals"] = serde_json::to_value(&all_goals).unwrap_or_default();
+        }
+
+        if includes.contains(&"actions") {
+            let actions = action::find_by_user(db, target_id, action::FindByUserParams::default())
+                .await
+                .unwrap_or_default();
+            response["actions"] = serde_json::to_value(&actions).unwrap_or_default();
+        }
+
+        if includes.contains(&"notes") {
+            let sessions = coaching_session::find_by_user(db, target_id)
+                .await
+                .unwrap_or_default();
+            let mut all_notes = Vec::new();
+            for s in &sessions {
+                let mut p = HashMap::new();
+                p.insert("coaching_session_id".to_string(), s.id.to_string());
+                all_notes.extend(note::find_by(db, p).await.unwrap_or_default());
+            }
+            response["notes"] = serde_json::to_value(&all_notes).unwrap_or_default();
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(to_json(
+            &response,
+        )?)]))
+    }
+
+    #[tool(
+        description = "List coaching sessions. Coaches must provide coachee_id. \
+            Optional date_from/date_to (YYYY-MM-DD)."
+    )]
+    async fn list_sessions(
+        &self,
+        Parameters(params): Parameters<ListSessionsParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let user = extract_user(&ctx)?;
+        let db = self.app_state.db_conn_ref();
+        let target_id = resolve_target_user(db, &user, &params.coachee_id).await?;
+
+        let mut sessions = coaching_session::find_by_user(db, target_id)
+            .await
+            .map_err(|e| McpError::internal_error(format!("Query failed: {e}"), None))?;
+
+        if let Some(from) = &params.date_from {
+            if let Ok(d) = chrono::NaiveDate::parse_from_str(from, "%Y-%m-%d") {
+                sessions.retain(|s| s.date.date() >= d);
+            }
+        }
+        if let Some(to) = &params.date_to {
+            if let Ok(d) = chrono::NaiveDate::parse_from_str(to, "%Y-%m-%d") {
+                sessions.retain(|s| s.date.date() <= d);
+            }
+        }
+
+        sessions.sort_by(|a, b| b.date.cmp(&a.date));
+
+        Ok(CallToolResult::success(vec![Content::text(to_json(
+            &sessions,
+        )?)]))
+    }
+
+    #[tool(description = "List actions. Coaches must provide coachee_id. \
+            Optional: coaching_session_id, status, keyword.")]
+    async fn list_actions(
+        &self,
+        Parameters(params): Parameters<ListActionsParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let user = extract_user(&ctx)?;
+        let db = self.app_state.db_conn_ref();
+        let target_id = resolve_target_user(db, &user, &params.coachee_id).await?;
+
+        let action_params = action::FindByUserParams {
+            coaching_session_id: params
+                .coaching_session_id
+                .as_deref()
+                .and_then(|s| Id::parse_str(s).ok()),
+            status: params.status.as_deref().map(domain::status::Status::from),
+            ..Default::default()
+        };
+
+        let mut results = action::find_by_user(db, target_id, action_params)
+            .await
+            .map_err(|e| McpError::internal_error(format!("Query failed: {e}"), None))?;
+
+        if let Some(kw) = &params.keyword {
+            let kw_lower = kw.to_lowercase();
+            results.retain(|a| {
+                a.action
+                    .body
+                    .as_deref()
+                    .map(|b| b.to_lowercase().contains(&kw_lower))
+                    .unwrap_or(false)
+            });
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(to_json(
+            &results,
+        )?)]))
+    }
+
+    #[tool(
+        description = "Get a session with notes, actions, agreements, and goals. \
+            Coaches must provide coachee_id. Defaults to most recent session."
+    )]
+    async fn get_session(
+        &self,
+        Parameters(params): Parameters<GetSessionParams>,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let user = extract_user(&ctx)?;
+        let db = self.app_state.db_conn_ref();
+        let target_id = resolve_target_user(db, &user, &params.coachee_id).await?;
+
+        let mut sessions = coaching_session::find_by_user(db, target_id)
+            .await
+            .map_err(|e| McpError::internal_error(format!("Query failed: {e}"), None))?;
+
+        sessions.sort_by(|a, b| b.date.cmp(&a.date));
+
+        let session = if let Some(sid_str) = &params.session_id {
+            let sid = Id::parse_str(sid_str)
+                .map_err(|_| McpError::invalid_params("Invalid session_id", None))?;
+            sessions
+                .into_iter()
+                .find(|s| s.id == sid)
+                .ok_or_else(|| McpError::invalid_params("Session not found", None))?
+        } else {
+            sessions
+                .into_iter()
+                .next()
+                .ok_or_else(|| McpError::invalid_params("No sessions found", None))?
+        };
+
+        let mut np = HashMap::new();
+        np.insert("coaching_session_id".to_string(), session.id.to_string());
+        let session_notes = note::find_by(db, np).await.unwrap_or_default();
+
+        let session_actions = action::find_by_user(
+            db,
+            target_id,
+            action::FindByUserParams {
+                coaching_session_id: Some(session.id),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap_or_default();
+
+        let session_agreements = agreement::find_by_coaching_session_id(db, session.id)
+            .await
+            .unwrap_or_default();
+
+        let session_goals = goal::find_goals_by_coaching_session_id(db, session.id)
+            .await
+            .unwrap_or_default();
+
+        let response = serde_json::json!({
+            "session": session,
+            "notes": session_notes,
+            "actions": session_actions,
+            "agreements": session_agreements,
+            "goals": session_goals,
+        });
+
+        Ok(CallToolResult::success(vec![Content::text(to_json(
+            &response,
+        )?)]))
     }
 }
 
@@ -84,8 +370,7 @@ impl McpToolHandler {
     name = "refactor-platform",
     version = "1.0.0",
     instructions = "MCP server for the Refactor Coaching & Mentoring Platform. \
-        Provides tools for coaches and coachees to query coaching data including \
-        coachees, sessions, goals, actions, and notes."
+        Provides tools for coaches and coachees to query coaching data."
 )]
 impl ServerHandler for McpToolHandler {}
 

--- a/web/src/mcp/tools/mod.rs
+++ b/web/src/mcp/tools/mod.rs
@@ -1,2 +1,39 @@
-// MCP tool handler and tool implementations.
-// Implemented in a later step.
+use crate::AppState;
+use rmcp::{tool_handler, tool_router, ServerHandler};
+
+/// MCP tool handler. Holds application state for DB access.
+/// The authenticated user is NOT stored here — it flows through
+/// `RequestContext.extensions` on each tool call via HTTP request Parts.
+#[derive(Clone)]
+pub(crate) struct McpToolHandler {
+    pub(crate) app_state: AppState,
+}
+
+#[tool_router]
+impl McpToolHandler {
+    pub(crate) fn new(app_state: AppState) -> Self {
+        Self { app_state }
+    }
+}
+
+#[tool_handler(
+    name = "refactor-platform",
+    version = "1.0.0",
+    instructions = "MCP server for the Refactor Coaching & Mentoring Platform. \
+        Provides tools for coaches and coachees to query coaching data including \
+        coachees, sessions, goals, actions, and notes."
+)]
+impl ServerHandler for McpToolHandler {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handler_implements_server_handler() {
+        // Compile-time check: if McpToolHandler doesn't implement
+        // ServerHandler, this function won't compile.
+        fn assert_server_handler<T: ServerHandler>() {}
+        assert_server_handler::<McpToolHandler>();
+    }
+}

--- a/web/src/mcp/tools/mod.rs
+++ b/web/src/mcp/tools/mod.rs
@@ -1,5 +1,10 @@
 use crate::AppState;
-use rmcp::{tool_handler, tool_router, ServerHandler};
+use domain::{coaching_relationship, user, users, Id};
+use rmcp::{
+    model::{CallToolResult, Content},
+    service::RequestContext,
+    tool, tool_handler, tool_router, ErrorData as McpError, RoleServer, ServerHandler,
+};
 
 /// MCP tool handler. Holds application state for DB access.
 /// The authenticated user is NOT stored here — it flows through
@@ -9,10 +14,69 @@ pub(crate) struct McpToolHandler {
     pub(crate) app_state: AppState,
 }
 
+/// Extract the authenticated user from the MCP request context.
+///
+/// The PAT auth middleware inserts `users::Model` into HTTP request extensions.
+/// `rmcp` propagates HTTP `Parts` into `RequestContext.extensions`.
+fn extract_user(ctx: &RequestContext<RoleServer>) -> Result<users::Model, McpError> {
+    let parts = ctx
+        .extensions
+        .get::<axum::http::request::Parts>()
+        .ok_or_else(|| McpError::internal_error("Missing HTTP request parts in context", None))?;
+
+    parts
+        .extensions
+        .get::<users::Model>()
+        .cloned()
+        .ok_or_else(|| McpError::internal_error("Missing authenticated user in context", None))
+}
+
 #[tool_router]
 impl McpToolHandler {
     pub(crate) fn new(app_state: AppState) -> Self {
         Self { app_state }
+    }
+
+    /// List all coachees for the authenticated coach.
+    /// Returns coachee profiles (id, name, email) for each coaching relationship
+    /// where the authenticated user is the coach.
+    #[tool(description = "List all coachees for the authenticated coach. \
+        No parameters needed — the coach is identified via the PAT token. \
+        Returns an array of coachee profiles.")]
+    async fn list_coachees(
+        &self,
+        ctx: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, McpError> {
+        let user = extract_user(&ctx)?;
+        let db = self.app_state.db_conn_ref();
+
+        let relationships = coaching_relationship::find_by_user(db, user.id)
+            .await
+            .map_err(|e| {
+                McpError::internal_error(format!("Failed to query relationships: {e}"), None)
+            })?;
+
+        // Filter to relationships where the authenticated user is the coach
+        let coachee_ids: Vec<Id> = relationships
+            .iter()
+            .filter(|r| r.coach_id == user.id)
+            .map(|r| r.coachee_id)
+            .collect();
+
+        if coachee_ids.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "No coachees found. You may not have any coaching relationships as a coach.",
+            )]));
+        }
+
+        let coachees = user::find_by_ids(db, &coachee_ids).await.map_err(|e| {
+            McpError::internal_error(format!("Failed to query coachees: {e}"), None)
+        })?;
+
+        let json = serde_json::to_string_pretty(&coachees)
+            .map_err(|e| McpError::internal_error(format!("Serialization error: {e}"), None))?;
+
+        Ok(CallToolResult::success(vec![Content::text(json)]))
     }
 }
 
@@ -31,8 +95,6 @@ mod tests {
 
     #[test]
     fn handler_implements_server_handler() {
-        // Compile-time check: if McpToolHandler doesn't implement
-        // ServerHandler, this function won't compile.
         fn assert_server_handler<T: ServerHandler>() {}
         assert_server_handler::<McpToolHandler>();
     }

--- a/web/src/mcp/tools/mod.rs
+++ b/web/src/mcp/tools/mod.rs
@@ -1,0 +1,2 @@
+// MCP tool handler and tool implementations.
+// Implemented in a later step.

--- a/web/src/protect/users/tokens.rs
+++ b/web/src/protect/users/tokens.rs
@@ -8,50 +8,41 @@ use axum::{
 use domain::Id;
 use log::*;
 
-pub(crate) mod actions;
-pub(crate) mod coaching_sessions;
-pub(crate) mod goals;
-pub(crate) mod organizations;
-pub(crate) mod passwords;
-pub(crate) mod tokens;
-
-/// Checks that the `user_id` matches the `authenticated_user.id`
-pub(crate) async fn read(
+/// Checks that the `user_id` in the path matches the authenticated user's id.
+/// Users can only manage their own tokens.
+pub(crate) async fn manage(
     State(_app_state): State<AppState>,
     AuthenticatedUser(authenticated_user): AuthenticatedUser,
     Path(user_id): Path<Id>,
     request: Request,
     next: Next,
 ) -> impl IntoResponse {
-    // check that we are only allowing authenticated users to read themselves (for now)
     if authenticated_user.id == user_id {
         next.run(request).await
     } else {
         error!(
-            "Unauthorized: user_id {} does not match authenticated_user_id {}",
+            "Forbidden: user_id {} does not match authenticated_user_id {} when managing tokens",
             user_id, authenticated_user.id
         );
-        (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+        (StatusCode::FORBIDDEN, "FORBIDDEN").into_response()
     }
 }
 
-/// Checks that the `user_id` matches the `authenticated_user.id`
-pub(crate) async fn update(
+/// Variant for routes with both user_id and token_id in the path.
+pub(crate) async fn manage_with_token_id(
     State(_app_state): State<AppState>,
     AuthenticatedUser(authenticated_user): AuthenticatedUser,
-    Path(user_id): Path<Id>,
+    Path((user_id, _token_id)): Path<(Id, Id)>,
     request: Request,
     next: Next,
 ) -> impl IntoResponse {
-    info!("Authenticated user id: {}", authenticated_user.id);
-    // check that we are only allowing authenticated users to update themselves (for now)
     if authenticated_user.id == user_id {
         next.run(request).await
     } else {
         error!(
-            "Unauthorized: user_id {} does not match authenticated_user_id {}",
+            "Forbidden: user_id {} does not match authenticated_user_id {} when managing tokens",
             user_id, authenticated_user.id
         );
-        (StatusCode::UNAUTHORIZED, "Unauthorized").into_response()
+        (StatusCode::FORBIDDEN, "FORBIDDEN").into_response()
     }
 }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -148,6 +148,7 @@ pub fn define_routes(app_state: AppState) -> Router {
         .merge(user_coaching_sessions_routes(app_state.clone()))
         .merge(user_goals_routes(app_state.clone()))
         .merge(user_coaching_relationships_routes(app_state.clone()))
+        .merge(user_token_routes(app_state.clone()))
         .merge(magic_link_routes(app_state.clone()))
         .merge(user_session_routes())
         .merge(user_session_protected_routes(app_state.clone()))
@@ -587,6 +588,42 @@ fn user_coaching_relationships_routes(app_state: AppState) -> Router {
                     get(user::coaching_relationships_controller::index),
                 )
                 .route_layer(from_fn_with_state(app_state.clone(), protect::users::read)),
+        )
+        .route_layer(from_fn(require_auth))
+        .with_state(app_state)
+}
+
+fn user_token_routes(app_state: AppState) -> Router {
+    Router::new()
+        .merge(
+            // POST /users/:user_id/tokens
+            Router::new()
+                .route("/users/:user_id/tokens", post(user::pat_controller::create))
+                .route_layer(from_fn_with_state(
+                    app_state.clone(),
+                    protect::users::tokens::manage,
+                )),
+        )
+        .merge(
+            // GET /users/:user_id/tokens
+            Router::new()
+                .route("/users/:user_id/tokens", get(user::pat_controller::index))
+                .route_layer(from_fn_with_state(
+                    app_state.clone(),
+                    protect::users::tokens::manage,
+                )),
+        )
+        .merge(
+            // PUT /users/:user_id/tokens/:token_id/deactivate
+            Router::new()
+                .route(
+                    "/users/:user_id/tokens/:token_id/deactivate",
+                    put(user::pat_controller::deactivate),
+                )
+                .route_layer(from_fn_with_state(
+                    app_state.clone(),
+                    protect::users::tokens::manage_with_token_id,
+                )),
         )
         .route_layer(from_fn(require_auth))
         .with_state(app_state)

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -1,12 +1,17 @@
 use crate::{
     controller::{health_check_controller, oauth_callback_controller},
+    mcp::{auth::require_pat_auth, tools::McpToolHandler},
     middleware::auth::require_auth,
     params, protect, AppState,
 };
 use axum::{
-    middleware::{from_fn, from_fn_with_state},
+    middleware::{self, from_fn, from_fn_with_state},
     routing::{delete, get, post, put},
     Router,
+};
+use rmcp::transport::{
+    streamable_http_server::{session::local::LocalSessionManager, tower::StreamableHttpService},
+    StreamableHttpServerConfig,
 };
 use tower_http::services::ServeDir;
 
@@ -130,6 +135,7 @@ impl Modify for SecurityAddon {
 
 pub fn define_routes(app_state: AppState) -> Router {
     Router::new()
+        .merge(mcp_routes(app_state.clone()))
         .merge(sse_routes(app_state.clone()))
         .merge(action_routes(app_state.clone()))
         .merge(agreement_routes(app_state.clone()))
@@ -627,6 +633,24 @@ fn user_token_routes(app_state: AppState) -> Router {
         )
         .route_layer(from_fn(require_auth))
         .with_state(app_state)
+}
+
+fn mcp_routes(app_state: AppState) -> Router {
+    let app_state_for_factory = app_state.clone();
+
+    let config = StreamableHttpServerConfig::default()
+        .with_stateful_mode(false)
+        .with_json_response(true);
+
+    let mcp_service = StreamableHttpService::new(
+        move || Ok(McpToolHandler::new(app_state_for_factory.clone())),
+        LocalSessionManager::default().into(),
+        config,
+    );
+
+    Router::new()
+        .nest_service("/mcp", mcp_service)
+        .layer(middleware::from_fn_with_state(app_state, require_pat_auth))
 }
 
 fn sse_routes(app_state: AppState) -> Router {


### PR DESCRIPTION
## Description
A proof of concept that implements #297 . Note that this POC assumes the design decisions are final when they are actually subject to change, but does do a good job of highlighting the technical choices in detail.

> [!note]
> this is a oneshot implementation. the actual ADR breaks up backend implementation into three discrete PRs

Commits are atomic and bottom-up, creating data models and functionality before using them in the MCP "glue". 

This MCP server is ready for use, to configure take a look at the [mcp setup readme](https://github.com/refactor-group/refactor-platform-rs/blob/2b49c2d9ae77b9c36914000d04e185fff7b24f8f/docs/mcp_server/README.md)

There was a [detailed plan file](https://github.com/refactor-group/refactor-platform-rs/blob/258c009c4c0f5c931a55430b912cb7cca1196405/docs/architecture/mcp_server/implementation-plan.md) used to create this laying out each commit that was refined iteratively. It's verbose, and ultimately not as useful as the ADR in summarizing design decisions, but it does get technical. 

### Changes
* Implements #297 , which lays out the actual changes to make.

### Testing Strategy
See [mcp setup readme](https://github.com/refactor-group/refactor-platform-rs/blob/2b49c2d9ae77b9c36914000d04e185fff7b24f8f/docs/mcp_server/README.md)

This walks you through steps to create a PAT associated with a user. Requires logging in through the API. In an end to end solution, this would be done through the Frontend UI.

Command your AI to use the tools below.
- `list_coachees`
- `get_coachee`
- `list_sessions`
- `list_actions`
- `get_session`

### Testing
Create a PAT via API
```bash
❯ curl -s -c /tmp/refactor_cookies.txt -X POST http://127.0.0.1:4000/login \
  -H "Content-Type: application/x-www-form-urlencoded" \
  -d "email=$YOUR_EMAIL&password=$YOUR_PASSWORD"
{"status_code":200,"data":{"display_name":"Joseph","email":"wumbabum@gmail.com","first_name":"Joseph","id":"489796ee-d817-4e6a-adfa-534a46656605","last_name":"Toney","role":"User","roles":[{"created_at":"2026-04-17T14:59:21.899543Z","id":"de163b68-a76e-4376-805d-3c9359442e08","organization_id":"d1963aff-6bcd-47e4-af38-99b431ec13db","role":"User","updated_at":"2026-04-17T14:59:21.899543Z","user_id":"489796ee-d817-4e6a-adfa-534a46656605"}],"timezone":"America/Chicago"}}%
```
```bash
❯ curl -s -b /tmp/refactor_cookies.txt -X POST \
  -H "x-version: 1.0.0-beta1" \
  http://127.0.0.1:4000/users/$YOUR_USER_ID/tokens
{"status_code":201,"data":{"created_at":"2026-04-29T16:18:55.303548Z","id":"616b8b7e-8af7-43d1-a286-c2faf0117535","status":"Active","token":"Yif72P0IdPk711touBzQZ7-9PqviZmOAEemCqU9aD5M"}}%
```
Set up configuration (warp). The URL could easily be a remote URL with no other changes.
```
{
  "refactor-platform": {
    "url": "http://127.0.0.1:4000/mcp",
    "headers": {
      "Authorization": "Bearer YOUR_TOKEN_HERE"
    }
  }
}
```

#### Initialization (handshake using PAT)
<img width="1429" height="248" alt="Screenshot 2026-04-29 at 12 00 55 PM" src="https://github.com/user-attachments/assets/de707b2e-e24f-4ae7-867f-9bf3932744cf" />


#### Tool usage
<img width="1326" height="542" alt="Screenshot 2026-04-29 at 11 13 56 AM" src="https://github.com/user-attachments/assets/0b5dd165-7334-4f9a-91c9-d0778d492aff" />
