### PR TITLE
Add MCP server ADR

### DIFF
--- a/docs/architecture/mcp_server.md
+++ b/docs/architecture/mcp_server.md
@@ -1,0 +1,169 @@
+# MCP Server
+Add an MCP server to the rust backend so that AI clients can interact with the coaching platform through structured tools.
+
+## Context
+Enable users to interact with the platform without leaving their AI workflow.
+Opens the door to AI automation and generative features like session summarization that the REST API alone cannot provide.
+
+The MCP server will exist inside the existing rust crate as a separate endpoint.
+
+## Data Model
+One new table: `personal_access_tokens`. All MCP tools read from existing tables.
+
+Value is never stored, only the token hash. This means users must be allowed to regenerate their token and deactivate the old one.
+
+Operations: create, show (metadata only, not the raw token), deactivate. No delete — inactive tokens are kept for audit history.
+
+Limit one active PAT per user, enforced by a partial unique index: `UNIQUE (user_id) WHERE status = 'active'`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| id | uuid PK | |
+| user_id | uuid FK → users | Owner of the token |
+| token_hash | varchar | SHA-256 of the raw token (raw token is never stored) |
+| status | enum `pat_status` (active, inactive) | New Postgres enum, separate from existing `refactor_platform.status`. Only active tokens are accepted. Users can deactivate a lost token and generate a new one. |
+| last_used_at | timestamptz | Optional, for observability |
+| created_at | timestamptz | |
+| updated_at | timestamptz | |
+
+## Layer Responsibilities
+
+| Layer | Module | Responsibility |
+|-------|--------|----------------|
+| `entity` | `personal_access_tokens` | SeaORM entity for PAT table |
+| `entity_api` | `personal_access_token` | PAT operations: create, find by token hash, deactivate |
+| `domain` | `personal_access_token` | Business logic: hash on create, validate status |
+| `web` | `mcp/mod` | Module root |
+| `web` | `mcp/auth` | PAT bearer middleware: extract header → hash → lookup user + roles |
+| `web` | `mcp/tools/mod` | `McpToolHandler` struct + `#[tool_router]`/`#[tool_handler]` wiring. Holds `AppState`. |
+| `web` | `mcp/tools/*` | Individual tool methods using `#[tool]` macro |
+| `web` | `router` | MCP service nested via `nest_service("/mcp", service)` in existing `define_routes()` |
+| `web` | `controller/pat_controller` | REST endpoints for PAT management (create, show, deactivate) used by the UI |
+| `web` | `protect/users/tokens` | Authorization middleware for PAT routes: user can only manage own tokens |
+| `migration` | new migration | `personal_access_tokens` table + partial unique index |
+
+## Dependencies
+
+`sha2` + `rand` — added to the `domain` crate for PAT token generation. `rand` (with `OsRng`) generates cryptographically secure random bytes for the raw token value. `sha2` hashes the raw token to produce the `token_hash` stored in the database and also identify and validate PATs. Both are already in the workspace via `meeting-auth`.
+
+`rmcp` — the official Rust MCP SDK (`modelcontextprotocol/rust-sdk`). Added to the `web` crate with the `transport-streamable-http-server` feature. Provides:
+- `StreamableHttpService` — integrates with Axum via `nest_service("/mcp", service)`, handling JSON-RPC parsing, `initialize`/`tools/list`/`tools/call` dispatch, session management, and SSE. `StreamableHttpService::new` accepts a factory closure (`Fn() -> Result<H>`) — after initializing, every session gets its own `McpToolHandler` instance to manage requests and hold app state. The authenticated user is not stored on the handler — it flows through `RequestContext.extensions` on each tool call (see [rmcp integration](./mcp_server/rmcp_integration.md#user-context-propagation)).
+- `#[tool]`, `#[tool_router]`, `#[tool_handler]` macros — generate tool schemas and dispatch from annotated functions.
+- Does not own auth — PAT middleware is applied as a `.layer()` on the Router containing the nested MCP service, matching rmcp's official auth examples. `route_layer` is not used because it only applies to `.route()` registrations, not `nest_service`.
+
+## Authentication
+Personal Access Token (PAT) as bearer token. PATs will be issued through the UI in the personal settings page.
+- New UI to create/view PAT.
+- New endpionts to create and get a PAT, scoped to current user.
+
+## Authorization
+Authorization is built off of the existing authorization model.
+
+- New `mcp` module and submodules for authorization
+- auth submodule for PAT auth middleware. Extract authorization header and authorizes.
+- Utilize existing authorization patterns, like those in `coaching_relationships::is_coach_of`. There is some maintenance burden here if the authorization logic of the API were to change, it would need to be updated for the MCP server too.
+- The PAT middleware inserts the authenticated `users::Model` into HTTP request extensions. `rmcp` propagates these into `RequestContext.extensions`, making the user available inside tool handlers without storing it on the handler struct. See [rmcp integration — user context propagation](./mcp_server/rmcp_integration.md#user-context-propagation) for details.
+
+## Connection Protocols
+- MVP — Stateless Streamable HTTP: `stateful_mode: false` in `StreamableHttpServerConfig`. Every POST is self-contained — no session ID, no persistent handler state. The factory creates a fresh `McpToolHandler` per request. Simpler auth bridging, no stale session cleanup.
+- Later — Stateful mode (`stateful_mode: true`) for SSE streaming and server-initiated events. Handler persists across requests in a session. Same tools and auth, only the config changes.
+- No stdio — the MCP server runs inside the existing backend process.
+
+## Tool List (MVP)
+- [Exhaustive tool list](./mcp_server/exhaustive_list.md)
+- [MVP tool list](./mcp_server/mvp_tools.md)
+
+## Tool Design
+Tools that require a specific resource (session, coachee) expect an exact ID. Discovery tools (`list_coachees`, `list_sessions`) return enough data for the LLM to identify and select the right record. No fuzzy matching or inline disambiguation — the LLM chains a list call before a get call.
+
+### Inputs
+- Input schemas are auto-generated by `rmcp` via `schemars`. Each tool defines a `Parameters<T>` struct deriving `Deserialize` + `schemars::JsonSchema`. The `#[tool]` macro produces the JSON Schema from that struct and returns it in `tools/list`. No manual schema definition needed — field types, optionality, and `#[schemars(description = "...")]` annotations are the single source of truth for what the tool accepts.
+- Tools identify the caller via PAT — no user ID parameter needed.
+- Coach tools that operate on a coachee accept an optional `coachee_id`. Defaults to self when omitted (coachee calling for themselves).
+- `get_coachee` supports an optional `include` array (`["goals", "actions", "notes"]`) to inline related records filtered to active status. Without `include`, returns profile + aggregated stats only.
+- `list_sessions` accepts optional `date_from`, `date_to` for date range filtering.
+- `list_actions` accepts optional `coaching_session_id`, `keyword` (searches body text), `date_from`/`date_to`, `status`. Coaches optionally provide `coachee_id` (defaults to self for coachees). Returns `ActionResponse` arrays (flattened `actions::Model` + `SessionRef` with frontend URL). See [response structs](./mcp_server/mcp_response_structs.md).
+- `get_session` accepts an optional `session_id`. Defaults to the latest session for the coaching relationship.
+
+### Outputs
+- All tools return structured JSON.
+- Existing entity models (e.g. `actions::Model`, `goals::Model`, `users::Model`) already derive `Serialize` with `#[serde(skip_serializing)]` on sensitive fields (passwords, OAuth tokens). Tool handlers serialize these models directly rather than redefining every field. Where a tool needs computed or nested fields not on the entity (e.g. `session_url`, inline `assignees`), a thin response wrapper uses `#[serde(flatten)]` to inline the entity and adds only the extra fields. This avoids duplicating field definitions and keeps the entity model as the source of truth. See [response struct definitions](./mcp_server/mcp_response_structs.md) for the full output shapes.
+- `get_coachee` without `include`: profile fields + stat counts (active goals, open actions, overdue actions, last/next session date).
+- `get_coachee` with `include`: same as above, plus arrays of raw entity models (`goals::Model`, `actions::Model`, `notes::Model`) filtered to active statuses. No nested refs or computed fields — keeps the tool lightweight. Rich action responses (with session URLs, nested goals, assignees) are deferred to a future dedicated action search tool.
+- `list_sessions`: array of session summaries (id, date, meeting_url).
+- `get_session`: structured data bundle of the session record + associated notes, actions, agreements, and linked goals. The client LLM generates the prose summary from this data — no server-side LLM needed.
+
+### Error Handling
+On error, response will have:
+- isError: true
+- ErrorMessage: "Descriptive error including error type and actionable steps"
+
+## Request Flow
+
+```mermaid
+sequenceDiagram
+    participant Client as AI Client (Warp, Claude, etc.)
+    participant MCP as MCP Endpoint
+    participant Auth as PAT Auth Middleware
+    participant Tool as Tool Handler
+    participant Domain as Domain Layer
+    participant DB as Database
+
+    Client->>MCP: POST /mcp (Bearer PAT, tool call)
+    MCP->>Auth: Validate PAT
+    Auth->>DB: Lookup user + roles by PAT
+    alt Invalid/expired PAT
+        Auth-->>Client: isError: "Unauthorized"
+    end
+    Auth->>MCP: Authenticated user with roles
+    MCP->>Tool: Dispatch to tool handler
+    Tool->>Tool: Authorize (role check, ownership check)
+    alt Forbidden
+        Tool-->>Client: isError: "Forbidden"
+    end
+    Tool->>Domain: Call domain function
+    Domain->>DB: Query/mutate
+    DB-->>Domain: Result
+    Domain-->>Tool: Data or error
+    alt Domain error
+        Tool-->>Client: isError: actionable message
+    end
+    Tool-->>Client: Structured JSON result
+```
+
+## Security Considerations
+- **Data ownership via PAT**: Data is scoped by the authorized PAT. Coaches cannot manage other coaches data, only their own and their associated coachees. Coachees can only manage their own data. This pattern is extensible to organizations, if we wanted to add multi tenancy. Associating tools with a PAT also supports auditing and observability of MCP usage, if we wanted it.
+- **No deletes**: MVP excludes all delete operations. Writes are limited to append-only creates and status updates.
+- **Prompt injection via stored data**: Note bodies, goal titles, and action text are user-generated and returned in tool responses. A malicious string in a note could instruct the client LLM to take unintended actions. The MCP server does not sanitize output — this is the client's responsibility.
+- **Data exfiltration**: Tool responses contain names, emails, and session content. This data flows through whatever LLM provider the client uses. Users should be aware their coaching data is sent to third-party models.
+- **Rate limiting**: PAT-scoped rate limits prevent a misbehaving client from enumerating data or overwhelming the backend. Exact limits TBD.
+- **No secrets in responses**: Passwords and PAT values are never included in tool output.
+
+## Future Considerations
+- **OAuth**: PAT is MVP. OAuth enables MCP clients (Claude Desktop, Warp, etc.) to authenticate via browser redirect without manual token generation. The auth middleware will be designed to support a second credential type — OAuth would resolve to the same user + roles as a PAT, reusing the existing authorization layer.
+
+Oauth would require lifecycle management, the mcp server will need to be able to issue access and refresh tokens. Fortunately Axum allows Oauth support through hooks, making it easier to add on later without breaking auth.
+
+- **Admin-only tools**: Post-MVP. Cross-organization data views, user management, platform-wide analytics. Scoped to SuperAdmin role.
+- **Write tools**: MVP is read-only plus status updates. Next tier adds `create_action`, `create_note`, `create_goal`, `create_agreement`, `create_session` — all append-only, no edits or deletes. See [exhaustive tool list](./mcp_server/exhaustive_list.md) for the full set.
+
+## Decisions
+
+- **`rmcp` over hand-rolling the MCP protocol.** The official Rust MCP SDK handles JSON-RPC parsing, session management, and tool dispatch. It integrates with Axum via `nest_service` and doesn't own auth. Saves 1-2 days of protocol boilerplate with no loss of control. This should be the first target for proof of concept to ensure the sdk works with the codebase.
+- **Streamable HTTP only.** No stdio — the MCP server is an endpoint inside the existing backend, not a standalone binary. Streamable HTTP is the current MCP spec transport for remote servers.
+- **Reuse existing authorization patterns.** Try to limit maintenance burden by reusing domain-level ownership functions like `coaching_relationship::is_coach_of`.
+- **No deletes for MVP.** Too destructive for LLM-initiated calls.
+- **PAT-direct as bearer token over access/refresh tokens.** The PAT is sent as `Authorization: Bearer <token>` on every request. No token expiration, no refresh flow, no token endpoint. Simpler for MVP. OAuth will require access/refresh tokens later.
+- **Store only the token hash; support deactivation instead of expiration.** The raw PAT is shown once at creation and never stored. Only the SHA-256 hash is persisted. If a user loses their token, they deactivate the old one and generate a new one. One active PAT per user, enforced by a partial unique index.
+- **`get_coachee` with `include` replaces individual list tools.** Instead of separate `list_goals`, `list_actions`, `list_notes` tools, `get_coachee` accepts an optional `include` array to inline related records filtered to active status. Fewer tools, fewer round-trips, one call answers "how is this coachee doing?"
+- **Disambiguation via separate list/get tools.** Tools that operate on a specific resource require an exact ID. Discovery tools (`list_coachees`, `list_sessions`) return enough identifying data (name, email, date) for the LLM to select the right record. No fuzzy matching or server-side disambiguation — the LLM chains a list call before a get call, matching the pattern used by GitHub and other major MCP servers.
+- **`.layer()` over `route_layer` for MCP auth.** `route_layer` only applies to routes added via `.route()`, not `nest_service`. The auth middleware is applied as a `.layer()` on the Router wrapping the nested `StreamableHttpService`, matching rmcp's official examples.
+- **Factory closure per session, not singleton clone.** `StreamableHttpService::new` takes `Fn() -> Result<H>`, creating a fresh handler per MCP session (per request in stateless mode). The `McpToolHandler` struct owns app state; the authenticated user flows through `RequestContext.extensions` on each tool call.
+- **Stateless mode for MVP.** No session management, no in-memory session map, no stale session cleanup. Every request carries a PAT and is validated independently. SSE streaming deferred to stateful mode later.
+- **No server-side LLM for MVP.** Tools return structured data, not generated prose. The client LLM (Warp, Claude, etc.) handles summarization and natural language from the data. This avoids adding an LLM provider dependency, API keys, token costs, and prompt management to the backend.
+
+## Implementation
+The MCP server is delivered through three PRs:
+- **PR 1 — PAT infrastructure + REST endpoints.** Migration, entity, entity_api, domain, controller, and routes for personal access tokens. Independent of MCP.
+- **PR 2 — MCP skeleton with auth.** `rmcp` dependency, module structure, `ServerHandler` implementation, PAT auth middleware, router integration. Zero tools, but `initialize` and `tools/list` work end-to-end.
+- **PR 3 — MVP tools.** `list_coachees`, `get_coachee` (with `include`), `list_sessions`, `list_actions`, `get_session`. Documentation updates.

--- a/docs/architecture/mcp_server/exhaustive_list.md
+++ b/docs/architecture/mcp_server/exhaustive_list.md
@@ -1,0 +1,39 @@
+# MCP Tools — Exhaustive Tool List
+Prefer not deleting through mcp for now, destructively risky.
+
+## Coach-Only
+1. `list_coachees` — all coachees for this coach
+2. `get_coachee` — profile + aggregated stats for one coachee
+3. `list_overdue_actions` — overdue actions across all coachees
+4. `create_session` — schedule a session
+5. ~~`update_session` — change date, meeting URL~~ - rescheduling is better done in the UI where you see a calendar
+6. ~~`delete_session` — cancel a session~~ - too destructive for LLM-initiated calls, do this in the UI
+7. `create_goal` — create goal for a coachee
+8. ~~`update_goal` — edit goal title/body~~ - editing body text via MCP is awkward; status changes are the high-value operation
+9. ~~`delete_goal` — remove a goal~~ - too destructive for LLM-initiated calls, do this in the UI
+10. `create_action` — create action item with optional assignees and goal link
+11. ~~`update_action` — edit action body/due date~~ - editing body text via MCP is awkward; status changes are the high-value operation
+12. ~~`delete_action` — remove action~~ - too destructive for LLM-initiated calls, do this in the UI
+13. `create_note` — add note to a session
+14. ~~`update_note` — edit a note~~ - low value via MCP, notes are typically written once
+15. `create_agreement` — add agreement to a session
+16. ~~`update_agreement` — edit agreement~~ - low value via MCP, agreements are typically written once
+17. ~~`delete_agreement` — remove agreement~~ - too destructive for LLM-initiated calls, do this in the UI
+18. `weekly_digest` — summary across all coachees (generative)
+19. `prepare_for_session` — pre-session brief (generative)
+20. ~~`suggest_goals` — suggest goals based on session history (generative)~~ - requires LLM on the server, post-MVP
+
+## Coachee-Only
+21. ~~`get_my_coach` — coach profile for a relationship~~ - the coachee already knows their coach; low utility
+22. ~~`create_goal` — coachee creates own goal~~ - coachees can use the UI for this; the value of MCP for coachees is reading, not writing
+
+## Shared (both roles, coach specifies coachee, coachee auto-scoped)
+23. `list_sessions` — sessions by date range, sort
+24. `get_session` — full session detail with notes, actions, agreements, goals via `include` param
+25. `list_goals` — goals filterable by status
+26. `list_actions` — actions filterable by session, goal, status, due date
+27. ~~`list_notes` — notes for a session~~ - folds into `get_session` via `include` parameter
+28. ~~`list_agreements` — agreements for a session~~ - folds into `get_session` via `include` parameter
+29. `update_goal_status` — change goal status
+30. `update_action_status` — change action status
+31. `get_session` — session recap (generative)

--- a/docs/architecture/mcp_server/mcp_response_schemas.md
+++ b/docs/architecture/mcp_server/mcp_response_schemas.md
@@ -1,0 +1,101 @@
+# MCP Request/Response Schemas
+Request and Response types for MCP tool handlers. Entity models already derive `Serialize` with `#[serde(skip_serializing)]` on sensitive fields. Where a tool returns an entity model directly, no wrapper is needed. Where a tool adds computed or nested fields, a thin wrapper uses `#[serde(flatten)]` to inline the entity and only defines the extra fields.
+
+## `get_coachee`
+
+### Input
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| coachee_id | uuid? | Coaches: yes. Coachees: no (defaults to self). | The coachee to look up. |
+| include | string[]? | No | Array of related data to inline. Valid values: `"goals"`, `"actions"`, `"notes"`. |
+
+### `CoacheeResponse`
+Flattens `users::Model` (or `coachees::Model`) and adds computed stats. No entity fields are redefined.
+
+| Extra field | Type | Source |
+|-------------|------|--------|
+| active_goals_count ** | u32 | count of goals where status in (`not_started`, `in_progress`, `on_hold`) |
+| open_actions_count | u32 | count of actions where status in (`not_started`, `in_progress`, `on_hold`) |
+| overdue_actions_count | u32 | count of actions where status in (`not_started`, `in_progress`, `on_hold`) AND `due_by < now` |
+| last_session_date | timestamptz? | most recent `coaching_sessions.date` |
+| next_session_date | timestamptz? | earliest future `coaching_sessions.date` |
+| goals | `goals::Model[]?` | populated when `include` contains `"goals"`, filtered to active statuses |
+| actions | `actions::Model[]?` | populated when `include` contains `"actions"`, filtered to active statuses |
+| notes | `notes::Model[]?` | populated when `include` contains `"notes"` |
+
+**"Active" means status is one of: `not_started`, `in_progress`, `on_hold`. This excludes `completed` and `wont_do`. Applies to `get_coachee` stat counts and `include` arrays.
+
+When `include` is absent or empty, `goals`, `actions`, and `notes` are omitted (not returned as empty arrays).
+
+The `include` arrays return raw entity models directly — no wrappers, no nested refs. This keeps `get_coachee` lightweight.
+
+## `list_actions`
+
+Filters (all optional):
+
+| Filter | Type | Description |
+|--------|------|-------------|
+| coachee_id | uuid? | Required for coaches to scope to a coachee. Defaults to self for coachees. |
+| coaching_session_id | uuid? | Filter to actions from a specific session |
+| keyword | string? | Searches `actions.body` text |
+| date_from | date? | Actions created on or after this date |
+| date_to | date? | Actions created on or before this date |
+| status | string? | Filter by status (`not_started`, `in_progress`, `completed`, `on_hold`, `wont_do`) |
+
+### `ActionResponse`
+Flattens `actions::Model` and adds a session reference with frontend URL.
+
+| Extra field | Type | Source |
+|-------------|------|--------|
+| session | `SessionResponse` | from `coaching_sessions` via `coaching_session_id` |
+
+## Shared response types
+
+### `SessionResponse`
+Flattens `coaching_sessions::Model` and adds a computed frontend URL. Reused by `list_sessions` and nested inside `ActionResponse`.
+
+| Extra field | Type | Source |
+|-------------|------|--------|
+| session_url | string | `{FRONTEND_BASE_URL}/coaching-sessions/{id}` (computed) |
+
+## `list_coachees`
+
+### Input
+No parameters — the coach is identified via PAT.
+
+### Output
+Returns raw `users::Model[]` for each coachee in the coach's coaching relationships.
+
+## `list_sessions`
+
+### Input
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| coachee_id | uuid? | Coaches: yes. Coachees: no (defaults to self). | Scope sessions to this coachee's coaching relationship. |
+| date_from | date? | No | Sessions on or after this date. |
+| date_to | date? | No | Sessions on or before this date. |
+
+### Output
+Returns `SessionResponse[]` — each session with a computed `session_url`.
+
+## `get_session`
+
+### Input
+
+| Param | Type | Required | Description |
+|-------|------|----------|-------------|
+| coachee_id | uuid? | Coaches: yes. Coachees: no (defaults to self). | Identifies the coaching relationship. |
+| session_id | uuid? | No | The session to summarize. Defaults to the most recent session for the coaching relationship. |
+
+### Output
+Returns a structured data bundle for the client LLM to summarize. No server-side LLM needed. All fields are raw entity models.
+
+| Field | Type | Source |
+|-------|------|--------|
+| session | `SessionResponse` | the session with `session_url` |
+| notes | `notes::Model[]` | all notes for the session |
+| actions | `actions::Model[]` | all actions for the session |
+| agreements | `agreements::Model[]` | all agreements for the session |
+| goals | `goals::Model[]` | goals linked to the session via `coaching_sessions_goals` |

--- a/docs/architecture/mcp_server/mvp_tools.md
+++ b/docs/architecture/mcp_server/mvp_tools.md
@@ -1,0 +1,20 @@
+# MCP Tools — MVP
+The MVP set of tools are all needed to summarize a session for a coach/ee. A typical flow for a coach would be
+
+Ask AI to "What have I been working on with Jane?" ->
+`list_coachees` to search for Jane ->
+`get_coachee` to learn about Jane ->
+`list_sessions` to learn about recent sessions
+`get_session` to generate a summary of the most recent session, pulling in other resources like goals, notes, and/or agreements as necessary.
+
+## Coach tools
+- `list_coachees` - list coachees associated with a coach.
+
+## Shared tools for Coach & Coachee
+A Coach can provide a coachee id for shared tools to filter on that coachee.
+
+- `get_coachee` — profile + aggregated stats for a coachee. Optional `include` to get current goals, actions, and notes. defaults to self when no id.
+  - flexibly replaces a lot of index tools like "list_actions" or "list_goals". Filtering was added to support the use case of getting more data about a coachee.
+- `list_sessions` - list sessions. optional date range filter.
+- `list_actions` — list actions. Filters: session id, keyword (searches body), date range, status. Coaches optionally provide a coachee id (defaults to self for coachees).
+- `get_session` — returns structured session data (session + notes + actions + agreements + linked goals) for the client LLM to summarize. No server-side LLM needed. Requires coachee_id for coach users. Optionally accepts session id, defaults to latest.

--- a/docs/architecture/mcp_server/rmcp_integration.md
+++ b/docs/architecture/mcp_server/rmcp_integration.md
@@ -1,0 +1,144 @@
+# rmcp Integration
+
+How the [`rmcp`](https://docs.rs/rmcp/latest/rmcp/) SDK ([`modelcontextprotocol/rust-sdk`](https://github.com/modelcontextprotocol/rust-sdk)) integrates with the Axum backend.
+
+## Dependency
+
+```toml
+rmcp = { version = "0.8", features = ["server", "macros", "transport-streamable-http-server"] }
+```
+
+`rmcp` re-exports [`schemars`](https://docs.rs/schemars/latest/schemars/) and [`serde`](https://docs.rs/serde/latest/serde/) — no separate `schemars` dependency needed in `web/Cargo.toml`.
+
+## Architecture
+
+### Request flow through layers
+
+```
+HTTP Request (Authorization: Bearer <PAT>)
+  │
+  ▼
+Axum Router (.layer → require_pat_auth middleware)
+  │  ✅ Has HTTP request, headers, extensions
+  │  Validates PAT → resolves users::Model
+  │  Inserts users::Model into request extensions
+  │  401 if invalid
+  │
+  ▼
+StreamableHttpService (Tower Service)
+  │  Receives HTTP request, parses JSON-RPC
+  │  Propagates HTTP request Parts into RequestContext.extensions
+  │
+  ▼
+McpToolHandler (ServerHandler trait)
+  │  Owns: app_state (DB connection, config)
+  │  Dispatches to #[tool] methods via self
+  │
+  ▼
+Tool method (e.g. list_coachees)
+   Extracts user from context.extensions.get::<axum::http::request::Parts>()
+   Accesses self.app_state for DB
+```
+
+### User context propagation
+
+`rmcp` propagates the HTTP request [`Parts`](https://docs.rs/http/latest/http/request/struct.Parts.html) into [`RequestContext.extensions`](https://docs.rs/rmcp/latest/rmcp/service/struct.RequestContext.html). This means data inserted into HTTP request extensions by Axum middleware is accessible inside tool handlers.
+
+The auth middleware inserts `users::Model` into request extensions. Tool handlers extract it:
+
+```rust
+// In the tool handler:
+if let Some(axum_parts) = context.extensions.get::<axum::http::request::Parts>() {
+    if let Some(user) = axum_parts.extensions.get::<users::Model>() {
+        // user is the authenticated caller
+    }
+}
+```
+
+This pattern was discovered in [`apollo-mcp-server`](https://github.com/apollographql/apollo-mcp-server/blob/ff28390b/crates/apollo-mcp-server/src/server/states/running.rs), which uses the same approach to propagate validated OAuth tokens from Axum middleware into `rmcp` tool handlers. It is not documented in `rmcp`'s own docs or examples — their [`simple_auth_streamhttp`](https://github.com/modelcontextprotocol/rust-sdk/blob/main/examples/servers/src/simple_auth_streamhttp.rs) example only gates access without passing user identity into tools.
+
+This eliminates the need for `Arc<RwLock<...>>` bridging or storing the user on the handler struct. The `McpToolHandler` only needs `app_state` — the user flows through the request context on every call.
+
+## Stateless mode (MVP)
+
+[`StreamableHttpServerConfig`](https://docs.rs/rmcp/latest/rmcp/transport/streamable_http_server/tower/struct.StreamableHttpServerConfig.html) `{ stateful_mode: false, .. }` — every POST is self-contained. No session ID, no persistent handler. The factory creates a fresh `McpToolHandler` per request.
+
+Stateful mode (`stateful_mode: true`, the default) creates persistent sessions where the handler lives across multiple requests. Deferred to post-MVP for SSE streaming.
+
+## Auth integration
+
+PAT middleware wraps the [`Router`](https://docs.rs/axum/latest/axum/struct.Router.html) containing [`nest_service`](https://docs.rs/axum/latest/axum/struct.Router.html#method.nest_service), not the Tower service directly:
+
+```rust
+let mcp_service = StreamableHttpService::new(factory, session_manager, config);
+
+Router::new()
+    .nest_service("/mcp", mcp_service)
+    .layer(middleware::from_fn_with_state(app_state, require_pat_auth))
+```
+
+- [`.layer()`](https://docs.rs/axum/latest/axum/struct.Router.html#method.layer) applies to all routes and nested services in the Router.
+- [`route_layer`](https://docs.rs/axum/latest/axum/struct.Router.html#method.route_layer) does NOT work here — it only applies to `.route()` registrations.
+- This matches rmcp's official [`simple_auth_streamhttp`](https://github.com/modelcontextprotocol/rust-sdk/blob/main/examples/servers/src/simple_auth_streamhttp.rs) example.
+
+## Tool definition pattern
+
+Tools use three macros together:
+
+```rust
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+struct ListCoacheesParams {
+    // empty — caller identified via PAT in request context
+}
+
+#[tool_router]
+impl McpToolHandler {
+    #[tool(description = "List coachees for the authenticated coach")]
+    async fn list_coachees(
+        &self,
+        Parameters(params): Parameters<ListCoacheesParams>,
+        context: RequestContext<RoleServer>,
+    ) -> String {
+        // Extract user from HTTP request parts propagated by rmcp
+        let parts = context.extensions.get::<axum::http::request::Parts>().unwrap();
+        let user = parts.extensions.get::<users::Model>().unwrap();
+        // self.app_state — DB access
+    }
+}
+
+#[tool_handler(name = "refactor-platform", version = "1.0.0")]
+impl ServerHandler for McpToolHandler {}
+```
+
+- [`#[tool_router]`](https://docs.rs/rmcp/latest/rmcp/attr.tool_router.html) — generates tool dispatch and `list_tools` from annotated methods.
+- [`#[tool]`](https://docs.rs/rmcp/latest/rmcp/attr.tool.html) — marks a method as an MCP tool, generates JSON Schema from the `Parameters<T>` type.
+- [`#[tool_handler]`](https://docs.rs/rmcp/latest/rmcp/attr.tool_handler.html) — auto-generates the [`ServerHandler`](https://docs.rs/rmcp/latest/rmcp/handler/server/trait.ServerHandler.html) impl with server info and tool capabilities. Use this when you need custom name/version.
+- [`Parameters<T>`](https://github.com/modelcontextprotocol/rust-sdk/blob/main/crates/rmcp/src/handler/server/wrapper.rs) — wrapper extractor. `T` must derive `schemars::JsonSchema` + `Deserialize`.
+
+## Handler struct
+
+```rust
+struct McpToolHandler {
+    app_state: AppState,     // DB connection, config
+}
+```
+
+The handler struct does not hold the user. The authenticated user is extracted from [`RequestContext.extensions`](https://docs.rs/rmcp/latest/rmcp/service/struct.RequestContext.html) on each tool call (see [User context propagation](#user-context-propagation) above). The factory closure only needs `app_state`:
+
+```rust
+let app_state = app_state.clone();
+StreamableHttpService::new(
+    move || Ok(McpToolHandler { app_state: app_state.clone() }),
+    session_manager,
+    config,
+)
+```
+
+## OAuth (future)
+
+`rmcp` has built-in [OAuth 2.1 support](https://github.com/modelcontextprotocol/rust-sdk/blob/main/docs/OAUTH_SUPPORT.md) via the `auth` feature flag:
+- PKCE (S256), dynamic client registration, token refresh, scope upgrade
+- Protected Resource Metadata discovery ([RFC 9728](https://datatracker.ietf.org/doc/html/rfc9728))
+- [`AuthClient`](https://docs.rs/rmcp/latest/rmcp/transport/auth/struct.AuthClient.html) wraps `reqwest` with automatic token management
+
+This is client-side support. For the server side, we would implement authorization endpoints (authorize, token, metadata) in Axum, following the pattern in [`complex_auth_streamhttp`](https://github.com/modelcontextprotocol/rust-sdk/blob/main/examples/servers/src/complex_auth_streamhttp.rs). The PAT auth middleware is designed to support a second credential type — OAuth would resolve to the same `users::Model`, reusing the existing authorization layer.


### PR DESCRIPTION
## Description
This is an ADR that specs out how an mcp server would look like if added alongside the existing refactor platform rust backend as a new MCP only endpoint.

> [!NOTE]
> The **## Decisions** section of the ADR highlights the main tradeoffs and choices made for the mcp server design, and I welcome any feedback especially to these points, which are all open to debate. The implementation that follows and proof of concept all assume these decisions are set in stone, but could go either way. Likewise for the supporting documents, these are up for debate.

#### GitHub Issue: [Addresses] # https://github.com/refactor-group/refactor-platform-fe/issues/372

### Changes
* `docs/architecture/mcp_server.md`- Main ADR covering data model (PAT), layer responsibilities, auth, connection protocols, tool design (inputs/outputs/errors), request flow diagram, security considerations, future considerations (OAuth, admin tools, write tools), and implementation decisions.
* `docs/architecture/mcp_server/` - supporting files
  * `mvp_tools.md`- list of tools to implement for the MVP.
  * `exhaustive_list.md`— Full tool inventory. I've dismissed many of these as too risky or low value.
  * `mcp_response_schemas.md`- Request/response schemas for each tool, focusing on structs and shared types.
  * `rmcp_integration.md`- The `rmcp` SDK is a big decision point, this outlines the requirements and benefits of using this dependency. rmcp is pretty standard for mcp servers in the rust ecosystem. There is a decision here to pass self user data via the PAT used during authorization, not a common pattern but not unheard of. The integration takes inspiration from [these mcp servers](https://github.com/modelcontextprotocol/rust-sdk#built-with-rmcp), particularly [apollo-mcp-server](https://github.com/apollographql/apollo-mcp-server) which uses [`RequestContext.extensions`](https://docs.rs/rmcp/latest/rmcp/service/struct.RequestContext.html#structfield.extensions) ([on this line](https://github.com/apollographql/apollo-mcp-server/blob/ff28390b7f3dd18d0f444e14f3eb0c2ffe174e8e/crates/apollo-mcp-server/src/server/states/running.rs#L213)) to feed data to their tools from the initial request. In our case it's the PAT and associated calling user.

### Testing Strategy
This PR is docs-only. However, I plan to use the following testing approach for the implementation. Where possible, tests use existing patterns.
- **Entity API and domain layers** use SeaORM's `MockDatabase` with `#[cfg(feature = "mock")]` gating. Same pattern as existing modules like `note.rs`.
- **Web/middleware tests** use `tower::ServiceExt::oneshot` to send requests through a constructed Axum router with a full mock auth stack. Uses existing `require_auth` approach.
- **MCP tools** are tested by constructing the handler with a mock `AppState`.
- **Integration tests** extend `testing-tools` with an `mcp_client.rs` module that sends JSON-RPC payloads with PAT bearer auth to the live `/mcp` endpoint. This is more or less new to the repo.

AI was used to investigate existing patterns and build on top where possible. The results were stored in a testing-stragegy.md doc and used to validate each step before committing.

### Concerns
1. Read the **Decisions** section in `mcp_server.md` for the key tradeoffs.
2. Review `rmcp_integration.md` for the SDK integration approach — especially the user context propagation pattern discovered in `apollo-mcp-server`.
3. Check `mvp_tools.md` for whether the MVP tool set covers the session summarization use case.
