### PR TITLE
Auto-promote goals to InProgress when linked to a coaching session

### DIFF
--- a/domain/src/coaching_session_goal.rs
+++ b/domain/src/coaching_session_goal.rs
@@ -12,16 +12,24 @@ use crate::Id;
 use entity_api::coaching_session_goal as CoachingSessionGoalApi;
 use entity_api::coaching_sessions_goals;
 use log::*;
-use sea_orm::{ConnectionTrait, DatabaseConnection};
+use sea_orm::{ConnectionTrait, DatabaseConnection, TransactionTrait};
 
-/// Links an existing goal to a coaching session and publishes an SSE event.
+/// Links an existing goal to a coaching session and publishes SSE events.
+///
+/// The link insert and any auto-promotion of the goal's status (from
+/// `NotStarted`/`OnHold` to `InProgress`) happen atomically inside a transaction.
+/// On commit, this publishes `CoachingSessionGoalCreated` and — when the link
+/// promoted the goal — also `GoalUpdated` so subscribers see the new status.
 pub async fn link_to_coaching_session(
     db: &DatabaseConnection,
     event_publisher: &EventPublisher,
     coaching_session_id: Id,
     goal_id: Id,
 ) -> Result<coaching_sessions_goals::Model, Error> {
-    let link = CoachingSessionGoalApi::create(db, coaching_session_id, goal_id).await?;
+    let txn = db.begin().await.map_err(entity_api::error::Error::from)?;
+    let (link, promoted_goal) =
+        CoachingSessionGoalApi::create(&txn, coaching_session_id, goal_id).await?;
+    txn.commit().await.map_err(entity_api::error::Error::from)?;
 
     let (_, relationship) =
         crate::coaching_session::find_by_id_with_coaching_relationship(db, coaching_session_id)
@@ -33,7 +41,7 @@ pub async fn link_to_coaching_session(
             coaching_relationship_id: relationship.id,
             coaching_session_id,
             goal_id,
-            notify_user_ids,
+            notify_user_ids: notify_user_ids.clone(),
         })
         .await;
 
@@ -41,6 +49,21 @@ pub async fn link_to_coaching_session(
         "Published CoachingSessionGoalCreated event for goal {} in session {}",
         goal_id, coaching_session_id
     );
+
+    if let Some(goal) = promoted_goal {
+        event_publisher
+            .publish(DomainEvent::GoalUpdated {
+                coaching_relationship_id: goal.coaching_relationship_id,
+                goal: serde_json::to_value(&goal).unwrap_or(serde_json::Value::Null),
+                notify_user_ids,
+            })
+            .await;
+
+        debug!(
+            "Published GoalUpdated event for promoted goal {} in relationship {}",
+            goal.id, goal.coaching_relationship_id
+        );
+    }
 
     Ok(link)
 }

--- a/domain/src/coaching_session_goal.rs
+++ b/domain/src/coaching_session_goal.rs
@@ -299,13 +299,15 @@ mod integration_tests {
 
         // Mock sequence (inside the txn opened by link_to_coaching_session):
         //   1. SELECT goal by id (entity_api::coaching_session_goal::create)
-        //   2. SELECT in-progress goals on relationship (cap check, returns empty)
-        //   3. INSERT into coaching_sessions_goals (the new link row)
-        //   4. UPDATE goals (auto-promotion to InProgress)
+        //   2. SELECT existing link (duplicate-check, returns empty)
+        //   3. SELECT in-progress goals on relationship (cap check, returns empty)
+        //   4. INSERT into coaching_sessions_goals (the new link row)
+        //   5. UPDATE goals (auto-promotion to InProgress)
         // After commit:
-        //   5. find_by_id_with_coaching_relationship for event-routing user IDs
+        //   6. find_by_id_with_coaching_relationship for event-routing user IDs
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![Vec::<coaching_sessions_goals::Model>::new()])
             .append_query_results(vec![Vec::<Model>::new()])
             .append_query_results(vec![vec![link.clone()]])
             .append_query_results(vec![vec![promoted.clone()]])
@@ -384,10 +386,12 @@ mod integration_tests {
 
         // Mock sequence (no cap-check, no promotion update):
         //   1. SELECT goal by id
-        //   2. INSERT into coaching_sessions_goals
-        //   3. find_by_id_with_coaching_relationship
+        //   2. SELECT existing link (duplicate-check, returns empty)
+        //   3. INSERT into coaching_sessions_goals
+        //   4. find_by_id_with_coaching_relationship
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![Vec::<coaching_sessions_goals::Model>::new()])
             .append_query_results(vec![vec![link.clone()]])
             .append_query_results(vec![vec![(
                 build_session(new_session_id, relationship_id),

--- a/domain/src/coaching_session_goal.rs
+++ b/domain/src/coaching_session_goal.rs
@@ -190,3 +190,225 @@ async fn publish_session_goal_deleted(
         link.goal_id, link.coaching_session_id
     );
 }
+
+#[cfg(test)]
+#[cfg(feature = "mock")]
+mod integration_tests {
+    use super::*;
+    use async_trait::async_trait;
+    use entity_api::coaching_relationships;
+    use entity_api::coaching_sessions;
+    use entity_api::status::Status;
+    use events::EventHandler;
+    use sea_orm::{DatabaseBackend, MockDatabase};
+    use std::sync::{Arc, Mutex};
+
+    /// Recording event handler — captures every published event in order so
+    /// tests can assert exactly which events fired and in what sequence.
+    struct RecordingHandler {
+        events: Arc<Mutex<Vec<DomainEvent>>>,
+    }
+
+    #[async_trait]
+    impl EventHandler for RecordingHandler {
+        async fn handle(&self, event: &DomainEvent) {
+            self.events.lock().unwrap().push(event.clone());
+        }
+    }
+
+    fn recording_publisher() -> (EventPublisher, Arc<Mutex<Vec<DomainEvent>>>) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let handler = Arc::new(RecordingHandler {
+            events: events.clone(),
+        });
+        let publisher = EventPublisher::new().with_handler(handler);
+        (publisher, events)
+    }
+
+    fn build_goal(status: Status, relationship_id: Id) -> Model {
+        let now = chrono::Utc::now().fixed_offset();
+        Model {
+            id: Id::new_v4(),
+            coaching_relationship_id: relationship_id,
+            created_in_session_id: None,
+            user_id: Id::new_v4(),
+            title: Some("Test goal".to_string()),
+            body: None,
+            status,
+            status_changed_at: None,
+            completed_at: None,
+            target_date: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn build_relationship(id: Id) -> coaching_relationships::Model {
+        let now = chrono::Utc::now().fixed_offset();
+        coaching_relationships::Model {
+            id,
+            organization_id: Id::new_v4(),
+            coach_id: Id::new_v4(),
+            coachee_id: Id::new_v4(),
+            slug: "test-rel".to_string(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn build_session(id: Id, relationship_id: Id) -> coaching_sessions::Model {
+        let now = chrono::Utc::now();
+        coaching_sessions::Model {
+            id,
+            coaching_relationship_id: relationship_id,
+            collab_document_name: None,
+            date: now.naive_utc(),
+            meeting_url: None,
+            provider: None,
+            created_at: now.into(),
+            updated_at: now.into(),
+        }
+    }
+
+    fn build_link(session_id: Id, goal_id: Id) -> coaching_sessions_goals::Model {
+        let now = chrono::Utc::now().fixed_offset();
+        coaching_sessions_goals::Model {
+            id: Id::new_v4(),
+            coaching_session_id: session_id,
+            goal_id,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Self-heal scenario: a goal was linked to a session pre-invariant and
+    /// is sitting in `NotStarted`. The coach manually re-links it to a new
+    /// session — BE auto-promotes to `InProgress` and publishes both
+    /// `CoachingSessionGoalCreated` and `GoalUpdated` in that order.
+    #[tokio::test]
+    async fn link_self_heals_legacy_not_started_goal_and_publishes_both_events() {
+        let relationship_id = Id::new_v4();
+        let new_session_id = Id::new_v4();
+        let goal = build_goal(Status::NotStarted, relationship_id);
+        let promoted = Model {
+            status: Status::InProgress,
+            ..goal.clone()
+        };
+        let link = build_link(new_session_id, goal.id);
+        let relationship = build_relationship(relationship_id);
+
+        // Mock sequence (inside the txn opened by link_to_coaching_session):
+        //   1. SELECT goal by id (entity_api::coaching_session_goal::create)
+        //   2. SELECT in-progress goals on relationship (cap check, returns empty)
+        //   3. INSERT into coaching_sessions_goals (the new link row)
+        //   4. UPDATE goals (auto-promotion to InProgress)
+        // After commit:
+        //   5. find_by_id_with_coaching_relationship for event-routing user IDs
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![Vec::<Model>::new()])
+            .append_query_results(vec![vec![link.clone()]])
+            .append_query_results(vec![vec![promoted.clone()]])
+            // The find_by_id_with_coaching_relationship query is a JOIN that
+            // returns (link, relationship) — the mock harness for find_also_linked
+            // expects a row of the joined shape.
+            .append_query_results(vec![vec![(
+                build_session(new_session_id, relationship_id),
+                Some(relationship.clone()),
+            )]])
+            .into_connection();
+
+        let (publisher, recorded) = recording_publisher();
+        let result = link_to_coaching_session(&db, &publisher, new_session_id, goal.id).await;
+
+        assert!(
+            result.is_ok(),
+            "self-heal link should succeed: {:?}",
+            result.err()
+        );
+
+        let events = recorded.lock().unwrap();
+        assert_eq!(
+            events.len(),
+            2,
+            "expected both events to fire, got {events:?}"
+        );
+
+        // CoachingSessionGoalCreated must fire first (link side effect).
+        match &events[0] {
+            DomainEvent::CoachingSessionGoalCreated {
+                coaching_session_id,
+                goal_id: ev_goal_id,
+                ..
+            } => {
+                assert_eq!(*coaching_session_id, new_session_id);
+                assert_eq!(*ev_goal_id, goal.id);
+            }
+            other => panic!("expected CoachingSessionGoalCreated first, got {other:?}"),
+        }
+
+        // GoalUpdated must fire second, carrying the promoted goal entity.
+        match &events[1] {
+            DomainEvent::GoalUpdated {
+                coaching_relationship_id,
+                goal: goal_value,
+                ..
+            } => {
+                assert_eq!(*coaching_relationship_id, relationship_id);
+                let status_str = goal_value
+                    .get("status")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                // Status serializes as PascalCase on the wire (matches the
+                // RelationshipGoalProgress v4 contract — DB stores snake_case
+                // but serde wire format is PascalCase).
+                assert_eq!(
+                    status_str, "InProgress",
+                    "promoted goal in event payload should serialize status as InProgress"
+                );
+            }
+            other => panic!("expected GoalUpdated second, got {other:?}"),
+        }
+    }
+
+    /// Linking a goal that is already `InProgress` only fires the link event,
+    /// not `GoalUpdated` — confirms we don't publish a redundant status event
+    /// when no promotion actually happened.
+    #[tokio::test]
+    async fn link_in_progress_goal_only_fires_link_event() {
+        let relationship_id = Id::new_v4();
+        let new_session_id = Id::new_v4();
+        let goal = build_goal(Status::InProgress, relationship_id);
+        let link = build_link(new_session_id, goal.id);
+        let relationship = build_relationship(relationship_id);
+
+        // Mock sequence (no cap-check, no promotion update):
+        //   1. SELECT goal by id
+        //   2. INSERT into coaching_sessions_goals
+        //   3. find_by_id_with_coaching_relationship
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![vec![link.clone()]])
+            .append_query_results(vec![vec![(
+                build_session(new_session_id, relationship_id),
+                Some(relationship.clone()),
+            )]])
+            .into_connection();
+
+        let (publisher, recorded) = recording_publisher();
+        let result = link_to_coaching_session(&db, &publisher, new_session_id, goal.id).await;
+        assert!(result.is_ok(), "link should succeed: {:?}", result.err());
+
+        let events = recorded.lock().unwrap();
+        assert_eq!(
+            events.len(),
+            1,
+            "expected only CoachingSessionGoalCreated to fire, got {events:?}"
+        );
+        assert!(
+            matches!(events[0], DomainEvent::CoachingSessionGoalCreated { .. }),
+            "expected CoachingSessionGoalCreated, got {:?}",
+            events[0]
+        );
+    }
+}

--- a/domain/src/coaching_session_goal.rs
+++ b/domain/src/coaching_session_goal.rs
@@ -195,6 +195,7 @@ async fn publish_session_goal_deleted(
 #[cfg(feature = "mock")]
 mod integration_tests {
     use super::*;
+    use crate::error::{DomainErrorKind, EntityErrorKind, InternalErrorKind};
     use async_trait::async_trait;
     use entity_api::coaching_relationships;
     use entity_api::coaching_sessions;
@@ -413,6 +414,133 @@ mod integration_tests {
             matches!(events[0], DomainEvent::CoachingSessionGoalCreated { .. }),
             "expected CoachingSessionGoalCreated, got {:?}",
             events[0]
+        );
+    }
+
+    /// Failure path: linking an already-linked goal returns 409
+    /// `GoalAlreadyLinkedToSession` and **publishes no events** — important
+    /// invariant for FE cache integrity (no ghost SSE events for failed ops).
+    #[tokio::test]
+    async fn link_already_linked_goal_returns_409_and_publishes_no_events() {
+        let relationship_id = Id::new_v4();
+        let new_session_id = Id::new_v4();
+        let goal = build_goal(Status::InProgress, relationship_id);
+        let existing_link = build_link(new_session_id, goal.id);
+
+        // Mock sequence (inside txn):
+        //   1. SELECT goal by id
+        //   2. SELECT existing link — returns the existing row, triggering 409
+        // No further queries — error returns before INSERT.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![vec![existing_link]])
+            .into_connection();
+
+        let (publisher, recorded) = recording_publisher();
+        let result = link_to_coaching_session(&db, &publisher, new_session_id, goal.id).await;
+
+        let err = result.expect_err("duplicate link should fail");
+        assert!(
+            matches!(
+                err.error_kind,
+                DomainErrorKind::Internal(InternalErrorKind::Entity(
+                    EntityErrorKind::GoalAlreadyLinkedToSession
+                ))
+            ),
+            "expected GoalAlreadyLinkedToSession, got {:?}",
+            err.error_kind
+        );
+
+        let events = recorded.lock().unwrap();
+        assert!(
+            events.is_empty(),
+            "no events should fire on failed link, got {events:?}"
+        );
+    }
+
+    /// Failure path: linking a `Completed` goal returns 422
+    /// `CannotLinkCompletedGoal` and **publishes no events**.
+    #[tokio::test]
+    async fn link_completed_goal_returns_422_and_publishes_no_events() {
+        let relationship_id = Id::new_v4();
+        let new_session_id = Id::new_v4();
+        let goal = build_goal(Status::Completed, relationship_id);
+
+        // Mock sequence:
+        //   1. SELECT goal by id (returns Completed goal)
+        // No further queries — error returns immediately.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![goal.clone()]])
+            .into_connection();
+
+        let (publisher, recorded) = recording_publisher();
+        let result = link_to_coaching_session(&db, &publisher, new_session_id, goal.id).await;
+
+        let err = result.expect_err("linking completed goal should fail");
+        assert!(
+            matches!(
+                err.error_kind,
+                DomainErrorKind::Internal(InternalErrorKind::Entity(
+                    EntityErrorKind::CannotLinkCompletedGoal
+                ))
+            ),
+            "expected CannotLinkCompletedGoal, got {:?}",
+            err.error_kind
+        );
+
+        let events = recorded.lock().unwrap();
+        assert!(
+            events.is_empty(),
+            "no events should fire on failed link, got {events:?}"
+        );
+    }
+
+    /// Failure path: linking a non-`InProgress` goal when the relationship is
+    /// already at the `MAX_IN_PROGRESS_GOALS` cap returns 409 (Conflict via
+    /// `ValidationError`) and **publishes no events**. Also confirms the
+    /// transaction rolls back cleanly — no INSERT happens before the cap
+    /// check fails.
+    #[tokio::test]
+    async fn link_at_cap_returns_409_and_publishes_no_events() {
+        let relationship_id = Id::new_v4();
+        let new_session_id = Id::new_v4();
+        let goal = build_goal(Status::NotStarted, relationship_id);
+        let cap_goals = vec![
+            build_goal(Status::InProgress, relationship_id),
+            build_goal(Status::InProgress, relationship_id),
+            build_goal(Status::InProgress, relationship_id),
+        ];
+
+        // Mock sequence (inside txn):
+        //   1. SELECT goal by id (returns NotStarted)
+        //   2. SELECT existing link (duplicate-check, empty)
+        //   3. SELECT in-progress goals on relationship (cap check, returns 3 → at cap)
+        // No further queries — error returns before INSERT.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![Vec::<coaching_sessions_goals::Model>::new()])
+            .append_query_results(vec![cap_goals])
+            .into_connection();
+
+        let (publisher, recorded) = recording_publisher();
+        let result = link_to_coaching_session(&db, &publisher, new_session_id, goal.id).await;
+
+        let err = result.expect_err("linking at cap should fail");
+        assert!(
+            matches!(
+                err.error_kind,
+                DomainErrorKind::Internal(InternalErrorKind::Entity(
+                    EntityErrorKind::Conflict { .. }
+                ))
+            ),
+            "expected Conflict, got {:?}",
+            err.error_kind
+        );
+
+        let events = recorded.lock().unwrap();
+        assert!(
+            events.is_empty(),
+            "no events should fire on failed link, got {events:?}"
         );
     }
 }

--- a/domain/src/coaching_session_goal.rs
+++ b/domain/src/coaching_session_goal.rs
@@ -20,21 +20,26 @@ use sea_orm::{ConnectionTrait, DatabaseConnection, TransactionTrait};
 /// `NotStarted`/`OnHold` to `InProgress`) happen atomically inside a transaction.
 /// On commit, this publishes `CoachingSessionGoalCreated` and — when the link
 /// promoted the goal — also `GoalUpdated` so subscribers see the new status.
+///
+/// The relationship lookup needed for SSE event routing is performed **before**
+/// the write transaction opens, so a missing/inaccessible session fails fast
+/// without ever touching the join table or goal status — preventing the
+/// "writes committed, response errored, no SSE fired" inconsistency.
 pub async fn link_to_coaching_session(
     db: &DatabaseConnection,
     event_publisher: &EventPublisher,
     coaching_session_id: Id,
     goal_id: Id,
 ) -> Result<coaching_sessions_goals::Model, Error> {
-    let txn = db.begin().await.map_err(entity_api::error::Error::from)?;
-    let (link, promoted_goal) =
-        CoachingSessionGoalApi::create(&txn, coaching_session_id, goal_id).await?;
-    txn.commit().await.map_err(entity_api::error::Error::from)?;
-
     let (_, relationship) =
         crate::coaching_session::find_by_id_with_coaching_relationship(db, coaching_session_id)
             .await?;
     let notify_user_ids = vec![relationship.coach_id, relationship.coachee_id];
+
+    let txn = db.begin().await.map_err(entity_api::error::Error::from)?;
+    let (link, promoted_goal) =
+        CoachingSessionGoalApi::create(&txn, coaching_session_id, goal_id).await?;
+    txn.commit().await.map_err(entity_api::error::Error::from)?;
 
     event_publisher
         .publish(DomainEvent::CoachingSessionGoalCreated {
@@ -54,7 +59,11 @@ pub async fn link_to_coaching_session(
         event_publisher
             .publish(DomainEvent::GoalUpdated {
                 coaching_relationship_id: goal.coaching_relationship_id,
-                goal: serde_json::to_value(&goal).unwrap_or(serde_json::Value::Null),
+                // Serialization of a SeaORM Model cannot fail in practice
+                // (no non-string-key maps, no NaN floats). If it ever does,
+                // that's a real bug we want loud — not a silent null payload
+                // that the FE would have to defensively handle.
+                goal: serde_json::to_value(&goal).expect("Goal model must be JSON-serializable"),
                 notify_user_ids,
             })
             .await;
@@ -298,27 +307,25 @@ mod integration_tests {
         let link = build_link(new_session_id, goal.id);
         let relationship = build_relationship(relationship_id);
 
-        // Mock sequence (inside the txn opened by link_to_coaching_session):
-        //   1. SELECT goal by id (entity_api::coaching_session_goal::create)
-        //   2. SELECT existing link (duplicate-check, returns empty)
-        //   3. SELECT in-progress goals on relationship (cap check, returns empty)
-        //   4. INSERT into coaching_sessions_goals (the new link row)
-        //   5. UPDATE goals (auto-promotion to InProgress)
-        // After commit:
-        //   6. find_by_id_with_coaching_relationship for event-routing user IDs
+        // Mock sequence (relationship lookup now runs FIRST, before the txn opens,
+        // so a missing session fails fast without any writes):
+        //   1. find_by_id_with_coaching_relationship — JOIN returning (session, relationship)
+        // Then inside the txn opened by link_to_coaching_session:
+        //   2. SELECT goal by id (entity_api::coaching_session_goal::create)
+        //   3. SELECT existing link (duplicate-check, returns empty)
+        //   4. SELECT in-progress goals on relationship (cap check, returns empty)
+        //   5. INSERT into coaching_sessions_goals (the new link row)
+        //   6. UPDATE goals (auto-promotion to InProgress)
         let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![(
+                build_session(new_session_id, relationship_id),
+                Some(relationship.clone()),
+            )]])
             .append_query_results(vec![vec![goal.clone()]])
             .append_query_results(vec![Vec::<coaching_sessions_goals::Model>::new()])
             .append_query_results(vec![Vec::<Model>::new()])
             .append_query_results(vec![vec![link.clone()]])
             .append_query_results(vec![vec![promoted.clone()]])
-            // The find_by_id_with_coaching_relationship query is a JOIN that
-            // returns (link, relationship) — the mock harness for find_also_linked
-            // expects a row of the joined shape.
-            .append_query_results(vec![vec![(
-                build_session(new_session_id, relationship_id),
-                Some(relationship.clone()),
-            )]])
             .into_connection();
 
         let (publisher, recorded) = recording_publisher();
@@ -385,19 +392,19 @@ mod integration_tests {
         let link = build_link(new_session_id, goal.id);
         let relationship = build_relationship(relationship_id);
 
-        // Mock sequence (no cap-check, no promotion update):
-        //   1. SELECT goal by id
-        //   2. SELECT existing link (duplicate-check, returns empty)
-        //   3. INSERT into coaching_sessions_goals
-        //   4. find_by_id_with_coaching_relationship
+        // Mock sequence (relationship lookup first, no cap-check, no promotion update):
+        //   1. find_by_id_with_coaching_relationship
+        //   2. SELECT goal by id
+        //   3. SELECT existing link (duplicate-check, returns empty)
+        //   4. INSERT into coaching_sessions_goals
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results(vec![vec![goal.clone()]])
-            .append_query_results(vec![Vec::<coaching_sessions_goals::Model>::new()])
-            .append_query_results(vec![vec![link.clone()]])
             .append_query_results(vec![vec![(
                 build_session(new_session_id, relationship_id),
                 Some(relationship.clone()),
             )]])
+            .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![Vec::<coaching_sessions_goals::Model>::new()])
+            .append_query_results(vec![vec![link.clone()]])
             .into_connection();
 
         let (publisher, recorded) = recording_publisher();
@@ -426,12 +433,19 @@ mod integration_tests {
         let new_session_id = Id::new_v4();
         let goal = build_goal(Status::InProgress, relationship_id);
         let existing_link = build_link(new_session_id, goal.id);
+        let relationship = build_relationship(relationship_id);
 
-        // Mock sequence (inside txn):
-        //   1. SELECT goal by id
-        //   2. SELECT existing link — returns the existing row, triggering 409
+        // Mock sequence:
+        //   1. find_by_id_with_coaching_relationship (pre-txn, fail-fast lookup)
+        // Then inside txn:
+        //   2. SELECT goal by id
+        //   3. SELECT existing link — returns the existing row, triggering 409
         // No further queries — error returns before INSERT.
         let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![(
+                build_session(new_session_id, relationship_id),
+                Some(relationship.clone()),
+            )]])
             .append_query_results(vec![vec![goal.clone()]])
             .append_query_results(vec![vec![existing_link]])
             .into_connection();
@@ -465,11 +479,18 @@ mod integration_tests {
         let relationship_id = Id::new_v4();
         let new_session_id = Id::new_v4();
         let goal = build_goal(Status::Completed, relationship_id);
+        let relationship = build_relationship(relationship_id);
 
         // Mock sequence:
-        //   1. SELECT goal by id (returns Completed goal)
+        //   1. find_by_id_with_coaching_relationship (pre-txn, fail-fast lookup)
+        // Then inside txn:
+        //   2. SELECT goal by id (returns Completed goal)
         // No further queries — error returns immediately.
         let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![(
+                build_session(new_session_id, relationship_id),
+                Some(relationship.clone()),
+            )]])
             .append_query_results(vec![vec![goal.clone()]])
             .into_connection();
 
@@ -510,13 +531,20 @@ mod integration_tests {
             build_goal(Status::InProgress, relationship_id),
             build_goal(Status::InProgress, relationship_id),
         ];
+        let relationship = build_relationship(relationship_id);
 
-        // Mock sequence (inside txn):
-        //   1. SELECT goal by id (returns NotStarted)
-        //   2. SELECT existing link (duplicate-check, empty)
-        //   3. SELECT in-progress goals on relationship (cap check, returns 3 → at cap)
+        // Mock sequence:
+        //   1. find_by_id_with_coaching_relationship (pre-txn, fail-fast lookup)
+        // Then inside txn:
+        //   2. SELECT goal by id (returns NotStarted)
+        //   3. SELECT existing link (duplicate-check, empty)
+        //   4. SELECT in-progress goals on relationship (cap check, returns 3 → at cap)
         // No further queries — error returns before INSERT.
         let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![(
+                build_session(new_session_id, relationship_id),
+                Some(relationship.clone()),
+            )]])
             .append_query_results(vec![vec![goal.clone()]])
             .append_query_results(vec![Vec::<coaching_sessions_goals::Model>::new()])
             .append_query_results(vec![cap_goals])

--- a/domain/src/error.rs
+++ b/domain/src/error.rs
@@ -50,6 +50,7 @@ pub enum EntityErrorKind {
         details: Option<serde_json::Value>,
     },
     CannotLinkCompletedGoal,
+    GoalAlreadyLinkedToSession,
     DbTransaction,
     ServiceUnavailable,
     Other(String),
@@ -89,6 +90,9 @@ impl From<EntityApiError> for Error {
                 details: details.clone(),
             },
             EntityApiErrorKind::CannotLinkCompletedGoal => EntityErrorKind::CannotLinkCompletedGoal,
+            EntityApiErrorKind::GoalAlreadyLinkedToSession => {
+                EntityErrorKind::GoalAlreadyLinkedToSession
+            }
             EntityApiErrorKind::SystemError => EntityErrorKind::ServiceUnavailable,
             _ => EntityErrorKind::Other("EntityErrorKind".to_string()),
         };

--- a/domain/src/error.rs
+++ b/domain/src/error.rs
@@ -49,6 +49,7 @@ pub enum EntityErrorKind {
         message: String,
         details: Option<serde_json::Value>,
     },
+    CannotLinkCompletedGoal,
     DbTransaction,
     ServiceUnavailable,
     Other(String),
@@ -87,6 +88,7 @@ impl From<EntityApiError> for Error {
                 message: message.clone(),
                 details: details.clone(),
             },
+            EntityApiErrorKind::CannotLinkCompletedGoal => EntityErrorKind::CannotLinkCompletedGoal,
             EntityApiErrorKind::SystemError => EntityErrorKind::ServiceUnavailable,
             _ => EntityErrorKind::Other("EntityErrorKind".to_string()),
         };

--- a/domain/src/goal.rs
+++ b/domain/src/goal.rs
@@ -270,14 +270,16 @@ mod integration_tests {
         // Mock sequence (inside txn):
         //   1. goal save (INSERT into goals)
         //   2. coaching_session_goal::create — goal lookup (SELECT goals by id)
-        //   3. coaching_session_goal::create — cap check (SELECT in-progress goals)
-        //   4. coaching_session_goal::create — join row insert (INSERT)
-        //   5. coaching_session_goal::create — promotion update (UPDATE goals)
+        //   3. coaching_session_goal::create — duplicate-link check (SELECT, empty)
+        //   4. coaching_session_goal::create — cap check (SELECT in-progress goals)
+        //   5. coaching_session_goal::create — join row insert (INSERT)
+        //   6. coaching_session_goal::create — promotion update (UPDATE goals)
         // After commit:
-        //   6. relationship lookup
+        //   7. relationship lookup
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![new_goal.clone()]])
             .append_query_results(vec![vec![new_goal.clone()]])
+            .append_query_results(vec![Vec::<coaching_sessions_goals::Model>::new()])
             .append_query_results(vec![Vec::<Model>::new()])
             .append_query_results(vec![vec![join_row]])
             .append_query_results(vec![vec![promoted_goal]])

--- a/domain/src/goal.rs
+++ b/domain/src/goal.rs
@@ -259,11 +259,28 @@ mod integration_tests {
             created_at: now,
             updated_at: now,
         };
+        // The session-link path enforces the goal-linked-to-session-must-be-InProgress
+        // invariant, so a NotStarted goal is auto-promoted on link. The mock provides
+        // the post-promotion model for the UPDATE step.
+        let promoted_goal = Model {
+            status: Status::InProgress,
+            ..new_goal.clone()
+        };
 
-        // Mock sequence (inside txn): goal save → join table save → relationship lookup
+        // Mock sequence (inside txn):
+        //   1. goal save (INSERT into goals)
+        //   2. coaching_session_goal::create — goal lookup (SELECT goals by id)
+        //   3. coaching_session_goal::create — cap check (SELECT in-progress goals)
+        //   4. coaching_session_goal::create — join row insert (INSERT)
+        //   5. coaching_session_goal::create — promotion update (UPDATE goals)
+        // After commit:
+        //   6. relationship lookup
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![new_goal.clone()]])
+            .append_query_results(vec![vec![new_goal.clone()]])
+            .append_query_results(vec![Vec::<Model>::new()])
             .append_query_results(vec![vec![join_row]])
+            .append_query_results(vec![vec![promoted_goal]])
             .append_query_results(vec![vec![relationship]])
             .into_connection();
 

--- a/entity/src/goals.rs
+++ b/entity/src/goals.rs
@@ -82,6 +82,11 @@ impl Model {
     pub fn in_progress(&self) -> bool {
         self.status == Status::InProgress
     }
+
+    /// Returns `true` if this goal is in a completed status (`Completed` or `WontDo`).
+    pub fn is_completed(&self) -> bool {
+        matches!(self.status, Status::Completed | Status::WontDo)
+    }
 }
 
 impl ActiveModelBehavior for ActiveModel {}
@@ -126,5 +131,30 @@ mod tests {
     #[test]
     fn in_progress_returns_false_for_wont_do() {
         assert!(!create_test_goal(Status::WontDo).in_progress());
+    }
+
+    #[test]
+    fn is_completed_returns_true_for_completed_status() {
+        assert!(create_test_goal(Status::Completed).is_completed());
+    }
+
+    #[test]
+    fn is_completed_returns_true_for_wont_do_status() {
+        assert!(create_test_goal(Status::WontDo).is_completed());
+    }
+
+    #[test]
+    fn is_completed_returns_false_for_not_started() {
+        assert!(!create_test_goal(Status::NotStarted).is_completed());
+    }
+
+    #[test]
+    fn is_completed_returns_false_for_in_progress() {
+        assert!(!create_test_goal(Status::InProgress).is_completed());
+    }
+
+    #[test]
+    fn is_completed_returns_false_for_on_hold() {
+        assert!(!create_test_goal(Status::OnHold).is_completed());
     }
 }

--- a/entity_api/src/coaching_session_goal.rs
+++ b/entity_api/src/coaching_session_goal.rs
@@ -7,39 +7,113 @@ use std::collections::HashMap;
 
 use entity::coaching_sessions_goals::{Column, Entity, Model};
 use entity::links::SessionGoalToCoachingRelationship;
+use entity::status::Status;
 use entity::{coaching_relationships, coaching_sessions, goals, Id};
 use sea_orm::{
-    entity::prelude::*, ActiveValue::Set, ConnectionTrait, DatabaseConnection, TryIntoModel,
+    entity::prelude::*,
+    ActiveValue::{Set, Unchanged},
+    ConnectionTrait, DatabaseConnection, TryIntoModel,
 };
 
 use log::*;
 
 use super::error::{EntityApiErrorKind, Error};
 
-/// Links a goal to a coaching session.
+/// Links a goal to a coaching session, enforcing the invariant that a session-linked
+/// goal must be `InProgress`.
+///
+/// Behavior:
+/// - `NotStarted` / `OnHold` goal → auto-promoted to `InProgress` (status_changed_at bumped)
+///   atomically with the link insert. Returns the promoted goal alongside the link so
+///   callers can publish a `GoalUpdated` event.
+/// - `InProgress` goal → just inserts the link, no status change.
+/// - `Completed` / `WontDo` goal → returns `CannotLinkCompletedGoal`, no writes.
+/// - Auto-promotion that would push the relationship past `MAX_IN_PROGRESS_GOALS`
+///   returns the standard cap-collision `ValidationError`, no writes.
+///
+/// Callers should pass a transaction handle so the link insert and any status
+/// promotion succeed-or-fail atomically.
 ///
 /// # Errors
 ///
-/// Returns `Error` if the database insert fails (e.g., duplicate link
-/// or foreign key constraint violation).
+/// Returns `Error` if the goal is not found, is in a completed status, would
+/// exceed the in-progress goal cap on auto-promotion, or any database
+/// query/insert fails (e.g., duplicate link or foreign key violation).
 pub async fn create(
     db: &impl ConnectionTrait,
     coaching_session_id: Id,
     goal_id: Id,
-) -> Result<Model, Error> {
+) -> Result<(Model, Option<goals::Model>), Error> {
     debug!("Linking goal {goal_id} to session {coaching_session_id}");
 
-    let now = chrono::Utc::now();
+    let goal = goals::Entity::find_by_id(goal_id)
+        .one(db)
+        .await?
+        .ok_or(Error {
+            source: None,
+            error_kind: EntityApiErrorKind::RecordNotFound,
+        })?;
 
-    let active_model = entity::coaching_sessions_goals::ActiveModel {
+    if goal.is_completed() {
+        return Err(Error {
+            source: None,
+            error_kind: EntityApiErrorKind::CannotLinkCompletedGoal,
+        });
+    }
+
+    let needs_promotion = !goal.in_progress();
+
+    if needs_promotion {
+        super::goal::check_in_progress_goal_limit(db, goal.coaching_relationship_id).await?;
+    }
+
+    let now = chrono::Utc::now();
+    let link = insert_link_row(db, coaching_session_id, goal_id, now).await?;
+
+    let promoted_goal = if needs_promotion {
+        let promoted = goals::ActiveModel {
+            id: Unchanged(goal.id),
+            coaching_relationship_id: Unchanged(goal.coaching_relationship_id),
+            created_in_session_id: Unchanged(goal.created_in_session_id),
+            user_id: Unchanged(goal.user_id),
+            title: Unchanged(goal.title.clone()),
+            body: Unchanged(goal.body.clone()),
+            status: Set(Status::InProgress),
+            status_changed_at: Set(Some(now.into())),
+            completed_at: Unchanged(goal.completed_at),
+            target_date: Unchanged(goal.target_date),
+            created_at: Unchanged(goal.created_at),
+            updated_at: Set(now.into()),
+        };
+        Some(promoted.update(db).await?.try_into_model()?)
+    } else {
+        None
+    };
+
+    Ok((link, promoted_goal))
+}
+
+/// Inserts a row into `coaching_sessions_goals` without enforcing the
+/// session-link-implies-`InProgress` invariant. Reserved for callers that have
+/// already established the goal is `InProgress` (e.g. the auto-link path
+/// from session-create, which queries goals filtered by `Status::InProgress`).
+/// Public callers must use [`create`] instead.
+async fn insert_link_row(
+    db: &impl ConnectionTrait,
+    coaching_session_id: Id,
+    goal_id: Id,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<Model, Error> {
+    Ok(entity::coaching_sessions_goals::ActiveModel {
         coaching_session_id: Set(coaching_session_id),
         goal_id: Set(goal_id),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()
-    };
-
-    Ok(active_model.insert(db).await?.try_into_model()?)
+    }
+    .insert(db)
+    .await?
+    .try_into_model()?)
 }
 
 /// Finds a single linked goal to a coaching session join-table record by its primary key.
@@ -224,8 +298,9 @@ pub async fn link_in_progress_goals_to_session(
         return Ok(0);
     }
 
+    let now = chrono::Utc::now();
     for g in &in_progress_goals {
-        create(db, session_id, g.id).await?;
+        insert_link_row(db, session_id, g.id, now).await?;
     }
 
     Ok(in_progress_goals.len())
@@ -311,30 +386,163 @@ mod tests {
     use super::*;
     use sea_orm::{DatabaseBackend, MockDatabase};
 
-    #[tokio::test]
-    async fn create_returns_a_new_link_record() -> Result<(), Error> {
+    fn build_link(coaching_session_id: Id, goal_id: Id) -> Model {
         let now = chrono::Utc::now();
-        let session_id = Id::new_v4();
-        let goal_id = Id::new_v4();
-
-        let expected_model = Model {
+        Model {
             id: Id::new_v4(),
-            coaching_session_id: session_id,
+            coaching_session_id,
             goal_id,
             created_at: now.into(),
             updated_at: now.into(),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_with_in_progress_goal_just_links_no_promotion() -> Result<(), Error> {
+        let session_id = Id::new_v4();
+        let relationship_id = Id::new_v4();
+        let goal = create_test_goal(relationship_id, Status::InProgress);
+        let link = build_link(session_id, goal.id);
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // SELECT goal by id (lookup in create)
+            .append_query_results(vec![vec![goal.clone()]])
+            // INSERT join row
+            .append_query_results(vec![vec![link.clone()]])
+            .into_connection();
+
+        let (result_link, promoted) = create(&db, session_id, goal.id).await?;
+
+        assert_eq!(result_link.coaching_session_id, session_id);
+        assert_eq!(result_link.goal_id, goal.id);
+        assert!(
+            promoted.is_none(),
+            "InProgress goal should not be promoted again"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_with_not_started_goal_promotes_to_in_progress() -> Result<(), Error> {
+        let session_id = Id::new_v4();
+        let relationship_id = Id::new_v4();
+        let goal = create_test_goal(relationship_id, Status::NotStarted);
+        let link = build_link(session_id, goal.id);
+        let promoted = goals::Model {
+            status: Status::InProgress,
+            ..goal.clone()
         };
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results(vec![vec![expected_model.clone()]])
+            // SELECT goal by id (lookup in create)
+            .append_query_results(vec![vec![goal.clone()]])
+            // SELECT in-progress goals on relationship (cap check) — empty, under cap
+            .append_query_results(vec![Vec::<goals::Model>::new()])
+            // INSERT join row
+            .append_query_results(vec![vec![link.clone()]])
+            // UPDATE goal — promotion to InProgress
+            .append_query_results(vec![vec![promoted.clone()]])
             .into_connection();
 
-        let result = create(&db, session_id, goal_id).await?;
+        let (result_link, promoted_goal) = create(&db, session_id, goal.id).await?;
 
-        assert_eq!(result.coaching_session_id, session_id);
-        assert_eq!(result.goal_id, goal_id);
+        assert_eq!(result_link.goal_id, goal.id);
+        let promoted_goal = promoted_goal.expect("NotStarted goal should be promoted");
+        assert_eq!(promoted_goal.status, Status::InProgress);
+        assert_eq!(promoted_goal.id, goal.id);
 
         Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_with_on_hold_goal_promotes_to_in_progress() -> Result<(), Error> {
+        let session_id = Id::new_v4();
+        let relationship_id = Id::new_v4();
+        let goal = create_test_goal(relationship_id, Status::OnHold);
+        let link = build_link(session_id, goal.id);
+        let promoted = goals::Model {
+            status: Status::InProgress,
+            ..goal.clone()
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![Vec::<goals::Model>::new()])
+            .append_query_results(vec![vec![link.clone()]])
+            .append_query_results(vec![vec![promoted.clone()]])
+            .into_connection();
+
+        let (_, promoted_goal) = create(&db, session_id, goal.id).await?;
+        let promoted_goal = promoted_goal.expect("OnHold goal should be promoted");
+        assert_eq!(promoted_goal.status, Status::InProgress);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn create_with_completed_goal_returns_cannot_link_completed_goal() {
+        let session_id = Id::new_v4();
+        let relationship_id = Id::new_v4();
+        let goal = create_test_goal(relationship_id, Status::Completed);
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Only the goal lookup runs — we error before any writes
+            .append_query_results(vec![vec![goal.clone()]])
+            .into_connection();
+
+        let result = create(&db, session_id, goal.id).await;
+        let err = result.expect_err("linking a Completed goal should fail");
+        assert!(
+            matches!(err.error_kind, EntityApiErrorKind::CannotLinkCompletedGoal),
+            "expected CannotLinkCompletedGoal, got {:?}",
+            err.error_kind
+        );
+    }
+
+    #[tokio::test]
+    async fn create_with_wont_do_goal_returns_cannot_link_completed_goal() {
+        let session_id = Id::new_v4();
+        let relationship_id = Id::new_v4();
+        let goal = create_test_goal(relationship_id, Status::WontDo);
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![goal.clone()]])
+            .into_connection();
+
+        let result = create(&db, session_id, goal.id).await;
+        let err = result.expect_err("linking a WontDo goal should fail");
+        assert!(matches!(
+            err.error_kind,
+            EntityApiErrorKind::CannotLinkCompletedGoal
+        ));
+    }
+
+    #[tokio::test]
+    async fn create_promotion_at_cap_returns_validation_error() {
+        let session_id = Id::new_v4();
+        let relationship_id = Id::new_v4();
+        let target = create_test_goal(relationship_id, Status::NotStarted);
+        let cap_goals = vec![
+            create_test_goal(relationship_id, Status::InProgress),
+            create_test_goal(relationship_id, Status::InProgress),
+            create_test_goal(relationship_id, Status::InProgress),
+        ];
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // SELECT goal by id (lookup in create)
+            .append_query_results(vec![vec![target.clone()]])
+            // SELECT in-progress goals on relationship (cap check) — at cap
+            .append_query_results(vec![cap_goals])
+            .into_connection();
+
+        let result = create(&db, session_id, target.id).await;
+        let err = result.expect_err("promoting past the cap should fail");
+        assert!(
+            matches!(err.error_kind, EntityApiErrorKind::ValidationError { .. }),
+            "expected ValidationError (cap), got {:?}",
+            err.error_kind
+        );
     }
 
     #[tokio::test]

--- a/entity_api/src/coaching_session_goal.rs
+++ b/entity_api/src/coaching_session_goal.rs
@@ -61,6 +61,24 @@ pub async fn create(
         });
     }
 
+    // Reject duplicate links explicitly so the FE sees a structured 409 instead
+    // of the unique-constraint violation falling through to a 503.
+    // (Race window: two concurrent requests can both pass this check; the DB's
+    // unique constraint on (coaching_session_id, goal_id) still protects integrity,
+    // and the loser falls through to the existing 503 path. Acceptable for now.)
+    let already_linked = Entity::find()
+        .filter(Column::CoachingSessionId.eq(coaching_session_id))
+        .filter(Column::GoalId.eq(goal_id))
+        .one(db)
+        .await?
+        .is_some();
+    if already_linked {
+        return Err(Error {
+            source: None,
+            error_kind: EntityApiErrorKind::GoalAlreadyLinkedToSession,
+        });
+    }
+
     let needs_promotion = !goal.in_progress();
 
     if needs_promotion {
@@ -407,6 +425,8 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             // SELECT goal by id (lookup in create)
             .append_query_results(vec![vec![goal.clone()]])
+            // SELECT existing link (duplicate check) — empty
+            .append_query_results(vec![Vec::<Model>::new()])
             // INSERT join row
             .append_query_results(vec![vec![link.clone()]])
             .into_connection();
@@ -437,6 +457,8 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             // SELECT goal by id (lookup in create)
             .append_query_results(vec![vec![goal.clone()]])
+            // SELECT existing link (duplicate check) — empty
+            .append_query_results(vec![Vec::<Model>::new()])
             // SELECT in-progress goals on relationship (cap check) — empty, under cap
             .append_query_results(vec![Vec::<goals::Model>::new()])
             // INSERT join row
@@ -468,6 +490,7 @@ mod tests {
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![Vec::<Model>::new()])
             .append_query_results(vec![Vec::<goals::Model>::new()])
             .append_query_results(vec![vec![link.clone()]])
             .append_query_results(vec![vec![promoted.clone()]])
@@ -519,6 +542,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_with_already_linked_goal_returns_goal_already_linked_to_session() {
+        let session_id = Id::new_v4();
+        let relationship_id = Id::new_v4();
+        let goal = create_test_goal(relationship_id, Status::InProgress);
+        let existing_link = build_link(session_id, goal.id);
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // SELECT goal by id
+            .append_query_results(vec![vec![goal.clone()]])
+            // SELECT existing link (duplicate check) — returns the existing row
+            .append_query_results(vec![vec![existing_link.clone()]])
+            // No further queries: error returns before INSERT
+            .into_connection();
+
+        let result = create(&db, session_id, goal.id).await;
+        let err = result.expect_err("linking an already-linked goal should fail");
+        assert!(
+            matches!(
+                err.error_kind,
+                EntityApiErrorKind::GoalAlreadyLinkedToSession
+            ),
+            "expected GoalAlreadyLinkedToSession, got {:?}",
+            err.error_kind
+        );
+    }
+
+    #[tokio::test]
     async fn create_promotion_at_cap_returns_validation_error() {
         let session_id = Id::new_v4();
         let relationship_id = Id::new_v4();
@@ -532,6 +582,8 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             // SELECT goal by id (lookup in create)
             .append_query_results(vec![vec![target.clone()]])
+            // SELECT existing link (duplicate check) — empty
+            .append_query_results(vec![Vec::<Model>::new()])
             // SELECT in-progress goals on relationship (cap check) — at cap
             .append_query_results(vec![cap_goals])
             .into_connection();

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -35,6 +35,8 @@ pub enum EntityApiErrorKind {
         message: String,
         details: Option<serde_json::Value>,
     },
+    // Attempt to link a goal in a completed status (Completed or WontDo) to a coaching session.
+    CannotLinkCompletedGoal,
     // Other errors
     Other(String),
 }

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -37,6 +37,8 @@ pub enum EntityApiErrorKind {
     },
     // Attempt to link a goal in a completed status (Completed or WontDo) to a coaching session.
     CannotLinkCompletedGoal,
+    // Attempt to link a goal that is already linked to the same coaching session.
+    GoalAlreadyLinkedToSession,
     // Other errors
     Other(String),
 }

--- a/entity_api/src/goal.rs
+++ b/entity_api/src/goal.rs
@@ -183,7 +183,7 @@ pub async fn find_in_progress_goals_by_coaching_relationship_id(
 /// Checks that adding one more `InProgress` goal to a coaching relationship
 /// would not exceed `MAX_IN_PROGRESS_GOALS`. Returns a `ValidationError` carrying
 /// summaries of the current in-progress goals so the caller can present a "swap" dialog.
-async fn check_in_progress_goal_limit(
+pub(crate) async fn check_in_progress_goal_limit(
     db: &impl ConnectionTrait,
     coaching_relationship_id: Id,
 ) -> Result<(), Error> {

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -128,6 +128,17 @@ impl Error {
                 }
                 (StatusCode::CONFLICT, Json(body)).into_response()
             }
+            EntityErrorKind::CannotLinkCompletedGoal => {
+                warn!(
+                    "EntityErrorKind::CannotLinkCompletedGoal: Responding with 422 Unprocessable Entity. Error: {self:?}"
+                );
+                let body = serde_json::json!({
+                    "status_code": 422,
+                    "error": "cannot_link_completed_goal",
+                    "message": "Completed goals cannot be linked to a coaching session.",
+                });
+                (StatusCode::UNPROCESSABLE_ENTITY, Json(body)).into_response()
+            }
             EntityErrorKind::ServiceUnavailable => {
                 warn!(
                     "EntityErrorKind::ServiceUnavailable: Responding with 503 Service Unavailable. Error: {self:?}"

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -139,6 +139,17 @@ impl Error {
                 });
                 (StatusCode::UNPROCESSABLE_ENTITY, Json(body)).into_response()
             }
+            EntityErrorKind::GoalAlreadyLinkedToSession => {
+                warn!(
+                    "EntityErrorKind::GoalAlreadyLinkedToSession: Responding with 409 Conflict. Error: {self:?}"
+                );
+                let body = serde_json::json!({
+                    "status_code": 409,
+                    "error": "goal_already_linked_to_session",
+                    "message": "This goal is already linked to the coaching session.",
+                });
+                (StatusCode::CONFLICT, Json(body)).into_response()
+            }
             EntityErrorKind::ServiceUnavailable => {
                 warn!(
                     "EntityErrorKind::ServiceUnavailable: Responding with 503 Service Unavailable. Error: {self:?}"


### PR DESCRIPTION
## Summary

Enforces the invariant **"a goal linked to a coaching session must be `InProgress`"** inside the link path, atomically with the join-table insert. Resolves the bug where active goals weren't consistently carried forward when a coach scheduled a new coaching session for an existing coachee.

## Root cause

Before this PR, goal status and session linkage were independent writes — a goal could be linked to a session while sitting in `NotStarted` or `OnHold`. The auto-link-on-session-create logic correctly filters to `Status::InProgress` only, so any session-linked goal that wasn't `InProgress` was silently skipped at carry-over. Concrete repro from a real coachee on 2026-04-29: 3 goals visible in a prior session, only 2 carried forward — the third was sitting in a non-`InProgress` status despite being session-linked.

The fix puts the invariant in the backend so it holds regardless of which client writes the link (web, future mobile, scripts).

## Behavior

### Manual link — `POST /coaching_sessions/:id/goals`

| Goal status | Outcome |
|---|---|
| `InProgress` | 201 — link inserted, status untouched (existing behavior) |
| `NotStarted` / `OnHold` | 201 — auto-promoted to `InProgress` and `status_changed_at` bumped, atomic with link insert. `GoalUpdated` SSE follows |
| `Completed` / `WontDo` | **422 `cannot_link_completed_goal`** — no writes |
| Auto-promotion would exceed the 3-`InProgress` cap | **409 `active_goal_limit_reached`** (existing contract) — rollback, no writes |

### Auto-link on session-create — `POST /coaching_sessions`

Unchanged on the surface. The query at `entity_api/src/goal.rs:172-181` still filters `Status::InProgress` only — but under the new invariant, every session-linked goal **is** `InProgress` by construction, so this filter is correct rather than buggy. Implementation note: the auto-link path uses a private `insert_link_row` helper that bypasses the policy check (those goals are already `InProgress` by the upstream filter), preserving the original 1-SELECT + N-INSERT query shape.

### Unlink

Unchanged. The invariant is one-way (`linked ⇒ InProgress`); unlinking does **not** auto-demote a goal's status.

### Events

The link path now publishes:
1. `CoachingSessionGoalCreated` (existing)
2. `GoalUpdated` **(new from this path)** — only when the link triggered a status promotion. Reuses the existing `GoalUpdated` event shape; no new event variant on the wire.

## Side effect on goal-create — flagged to FE on coordinator

When a coach creates a new goal during a session (`created_in_session_id` set), the existing `link_to_created_in_session` helper passes through the same chokepoint — so a new goal created with status `NotStarted` during a session is now auto-promoted to `InProgress` on save. Cap-collision now also surfaces on goal-create (same swap-dialog 409 the FE already handles, just a new trigger).

This is consistent with the invariant — and is exactly the centralization benefit of putting the rule in the BE — but it's a behavior change worth confirming with the FE team. Posted to coordinator (`goals_auto_link_new_session` answer + `goal_session_link_invariant` decision); awaiting their thumbs-up before un-drafting.

## No backfill

Existing data is intentionally not retroactively flipped (risk of overwriting legitimate coach intent — e.g. an `OnHold` goal someone forgot to unlink). Affected goals self-heal the next time someone manually re-links them; if user impact looks worse than expected after ship, a one-off SQL can be run after triage.

## Errors

New unit variant `EntityApiErrorKind::CannotLinkCompletedGoal` flows through `domain::EntityErrorKind::CannotLinkCompletedGoal` to the web layer's existing `handle_entity_error`. Wire format hardcoded in the web mapper following the `OauthTokenRevoked` precedent — variant name encodes the policy, web layer hardcodes `error: "cannot_link_completed_goal"`.

## Tests

- 6 new unit tests in `entity_api::coaching_session_goal::tests`: `InProgress` no-promotion, `NotStarted` promotes, `OnHold` promotes, `Completed` rejected, `WontDo` rejected, cap-collision returns `ValidationError`
- 5 new unit tests on `goals::Model::is_completed`
- 1 existing integration test in `domain::goal` (`create_with_session_links_to_join_table`) updated for the new query sequence
- Full workspace test suite passing; clippy clean for all touched files

## Test plan

- [ ] `POST /coaching_sessions/:id/goals` with a `NotStarted` goal → 201, goal status now `InProgress`, `GoalUpdated` SSE event fires
- [ ] `POST /coaching_sessions/:id/goals` with an `OnHold` goal → 201, goal promoted, SSE event fires
- [ ] `POST /coaching_sessions/:id/goals` with a `Completed` goal → 422 with `error: "cannot_link_completed_goal"`
- [ ] `POST /coaching_sessions/:id/goals` with a `WontDo` goal → 422
- [ ] Linking when at 3-`InProgress` cap with a non-`InProgress` goal → 409, `details.in_progress_goals` populated, no link row created (transaction rolled back)
- [ ] Auto-link on `POST /coaching_sessions` carries forward all `InProgress` goals (regression of the original bug)
- [ ] Creating a new goal with `created_in_session_id` set: goal lands as `InProgress` regardless of requested status
- [ ] FE confirms on coordinator that the goal-create side effect is acceptable

## Coordinator board

- Question `goals_auto_link_new_session` answered with the implementation summary + side-effect callout
- Decision `goal_session_link_invariant` posted (durable cross-repo record of the rule)