### PR TITLE
Make backend log level configurable per deploy

### DIFF
--- a/.github/workflows/ci-deploy-pr-preview.yml
+++ b/.github/workflows/ci-deploy-pr-preview.yml
@@ -75,6 +75,12 @@ on:
                 required: false
                 type: string
                 default: ""
+            # Backend log filter level for the deployed container (Rust env_logger / tracing-subscriber filter directive)
+            log_level:
+                description: "Backend log filter level (e.g. INFO, DEBUG, TRACE, WARN, ERROR)"
+                required: false
+                type: string
+                default: "INFO"
         # =========================================================================
         # SECRETS
         # =========================================================================
@@ -1079,7 +1085,7 @@ jobs:
                   RUST_BACKTRACE=1
                   BACKEND_INTERFACE=0.0.0.0
                   BACKEND_ALLOWED_ORIGINS=*
-                  BACKEND_LOG_FILTER_LEVEL=INFO
+                  BACKEND_LOG_FILTER_LEVEL=${{ inputs.log_level }}
                   BACKEND_SESSION_EXPIRY_SECONDS=86400
                   DB_MAX_CONNECTIONS=19
                   DB_MIN_CONNECTIONS=5

--- a/.github/workflows/dispatch-pr-preview.yml
+++ b/.github/workflows/dispatch-pr-preview.yml
@@ -52,6 +52,17 @@ on:
         required: false
         type: string
         default: ""
+      log_level:
+        description: "Backend log filter level for this preview deploy"
+        required: false
+        type: choice
+        default: INFO
+        options:
+          - ERROR
+          - WARN
+          - INFO
+          - DEBUG
+          - TRACE
 # Prevent multiple manual deployments for the same PR
 concurrency:
   group: pr-preview-backend-dispatch-${{ inputs.backend_commit }}
@@ -187,4 +198,5 @@ jobs:
       backend_sha: ${{ needs.validate.outputs.backend_sha }}
       frontend_sha: ${{ needs.validate.outputs.frontend_sha }}
       force_rebuild: false
+      log_level: ${{ inputs.log_level }}
     secrets: inherit


### PR DESCRIPTION
## Summary

- Adds an optional `log_level` input to the reusable `ci-deploy-pr-preview.yml` workflow (default `INFO`) and threads it into `BACKEND_LOG_FILTER_LEVEL` in the generated env file.
- Surfaces the same knob on `dispatch-pr-preview.yml` as a choice dropdown (`ERROR`, `WARN`, `INFO`, `DEBUG`, `TRACE`) so it can be selected from the **Run workflow** UI per deploy.

## Why

The PR preview workflow hardcoded `BACKEND_LOG_FILTER_LEVEL=INFO`. There was no way to ship a preview at `DEBUG` for debugging without editing the workflow on a branch — local `.env` settings have no effect on the deployed container, which reads from the workflow-generated env file.

Came up while debugging a 401 from MailerSend on a PR preview: the running container reported `INFO` even though the developer expected `DEBUG`, which was the first clue that the deployed env was workflow-driven, not `.env`-driven.

## Backward compatibility

Default is `INFO`, matching the previously hardcoded value. Existing deploys are unaffected — including the cross-repo frontend caller, which calls `ci-deploy-pr-preview.yml` directly via `workflow_call` and does not pass `log_level`.

## Test plan

- [ ] Run `Deploy PR Preview (Manual Select)` with `log_level=DEBUG` against an open PR; confirm container logs show `Log level: DEBUG`.
- [ ] Run the same dispatch with no `log_level` selection (default); confirm container logs show `Log level: INFO`.
- [ ] Confirm the frontend dispatch (cross-repo `workflow_call` without `log_level`) still deploys cleanly and lands at `INFO`.