### PR TITLE
ci: dedupe PR-preview cleanup, fix --delete-branch startup_failure

### DIFF
--- a/.github/workflows/cleanup-pr-preview-backend.yml
+++ b/.github/workflows/cleanup-pr-preview-backend.yml
@@ -52,7 +52,12 @@ jobs:
     name: Cleanup Backend PR Preview
     needs: check-preview
     if: needs.check-preview.outputs.has_preview == 'true'
-    uses: ./.github/workflows/cleanup-pr-preview.yml
+    # Pin to @main so the reusable workflow resolves against main's tip rather
+    # than the calling commit's SHA. When `gh pr merge --delete-branch` runs,
+    # the PR head SHA becomes orphaned and a relative `uses: ./...` reference
+    # fails to resolve, causing a startup_failure. Mirrors the cross-repo
+    # pattern already used in refactor-platform-fe/cleanup-pr-preview-frontend.yml.
+    uses: refactor-group/refactor-platform-rs/.github/workflows/cleanup-pr-preview.yml@main
     with:
       # This is a backend PR cleanup
       repo_type: 'backend'

--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -8,7 +8,10 @@
 
 name: Cleanup PR Preview Environment
 
-# Trigger when PR is closed (includes both close and merge events)
+# Reusable workflow + manual dispatch only.
+# PR-close events are handled by the per-repo overlay workflows
+# (cleanup-pr-preview-backend.yml here, cleanup-pr-preview-frontend.yml in the FE repo),
+# which gate on "was a preview ever deployed?" before invoking this workflow.
 on:
   workflow_call:
     inputs:
@@ -24,10 +27,6 @@ on:
         description: "Branch name associated with the PR"
         required: false
         type: string
-  pull_request:
-    types: [closed]
-    branches:
-      - main
 
   # Manual trigger for cleanup of specific PR numbers
   workflow_dispatch:


### PR DESCRIPTION
Closes #304

## Summary

- Drop the `pull_request: closed` trigger from `cleanup-pr-preview.yml` so the leaf reusable workflow no longer auto-fires alongside the overlay caller. Single entry point per repo: the overlay (`cleanup-pr-preview-backend.yml`) is now the only `pull_request: closed` consumer, and its `check-preview` guard prevents the ~14-minute `main-arm64` cache rebuild on PRs that never had a preview deployed.
- Pin `cleanup-pr-preview-backend.yml`'s `uses:` to `@main` (mirroring the cross-repo pattern in `refactor-platform-fe/.github/workflows/cleanup-pr-preview-frontend.yml`) so reusable-workflow resolution doesn't depend on the PR head SHA — which becomes orphaned ~2 s before workflow scheduling when `gh pr merge --delete-branch` is used. Fixes the `startup_failure` reproduced on [run 25635274812](https://github.com/refactor-group/refactor-platform-rs/actions/runs/25635274812) (PR #291 close, 0 jobs, `run_duration_ms: 1000`, no logs).

The two edits are coupled and must ship together: shipping (1) alone leaves the startup_failure race, and (2) alone leaves duplicate runs and the redundant ARM64 rebuild.

## Validation

- `actionlint` clean (only pre-existing info-level shellcheck noise on untouched script blocks).
- `ruby -ryaml` parse OK on both files.
- `act --list` confirms:
  - `cleanup-pr-preview.yml` events are now `workflow_call,workflow_dispatch` only — `pull_request` removed.
  - `cleanup-pr-preview-backend.yml` jobs `check-preview` → `cleanup-backend-pr` resolve in correct dependency order.
- Repo-wide grep confirms only one `pull_request: closed` trigger remains in BE workflows (`cleanup-pr-preview-backend.yml`), and the only invoking `uses:` reference is the now-pinned `@main` literal.

## Edge cases covered

| Scenario | Behavior |
|---|---|
| BE merge with `--delete-branch`, no preview deployed | Caller fires → `check-preview` finds no comment → cleanup skipped, no ARM64 rebuild. No startup_failure. |
| BE merge with `--delete-branch`, preview was deployed | Caller fires → calls `cleanup-pr-preview.yml@main` → full teardown + `main-arm64` rebuild + GHCR delete + comment. |
| BE close without merge | Same gating (check-preview) applies; teardown runs only if a preview existed. |
| Manual one-off cleanup | `workflow_dispatch` on the leaf still works (input: `pr_number`). |
| FE PR close | Unchanged; FE caller already pins `@main`, calls the same leaf via `workflow_call`. |
| BE PR targeting a non-`main` base | Caller has no `branches:` filter, so cleanup still fires. The leaf's old `branches: [main]` filter is retired — slight broadening of coverage, no regression. |

## Out of scope

- Renaming/relocating the `main-arm64` rebuild step out of `cleanup-pr-preview.yml`.
- Time-based reaping of abandoned previews.
- `cleanup-pr-preview-frontend.yml` (already correct).
- Pre-existing shellcheck info-level findings inside untouched script blocks.

## Test plan

- [ ] Land this PR with `--delete-branch` and verify the post-merge `Cleanup PR Preview (Backend)` run does **not** show `startup_failure`.
- [ ] Confirm the run skips the cleanup job (no preview was deployed for this PR), and that `main-arm64` is **not** rebuilt.
- [ ] On a follow-up backend PR that *does* have a deployed preview, verify the caller fires teardown + main-arm64 rebuild end-to-end exactly once.
- [ ] Verify a frontend PR close still cleans up correctly via the FE caller (no behavioral change expected).