### PR TITLE
ci: fix cleanup pull_request_target trigger + simplify dispatch UX

### DIFF
--- a/.github/workflows/cleanup-pr-preview-backend.yml
+++ b/.github/workflows/cleanup-pr-preview-backend.yml
@@ -9,8 +9,13 @@
 name: Cleanup PR Preview (Backend)
 
 on:
-  pull_request:
-    # Trigger on PR close (includes merge)
+  # pull_request_target loads the workflow file from the BASE branch (main)
+  # rather than the PR head SHA. This is immune to the gh-pr-merge
+  # --delete-branch race that orphans the head SHA seconds before this run is
+  # scheduled (which causes startup_failure under the older `pull_request`
+  # trigger). Safe here because we never `actions/checkout` PR code and only
+  # run after close.
+  pull_request_target:
     types: [closed]
 
 permissions:

--- a/.github/workflows/dispatch-pr-preview.yml
+++ b/.github/workflows/dispatch-pr-preview.yml
@@ -1,8 +1,8 @@
 # =============================================================================
 # Manual PR Preview Deployment (Backend)
 # =============================================================================
-# Purpose: Deploy a PR preview environment for a backend PR, paired with any
-#          frontend ref (main, branch, SHA, or a frontend PR).
+# Purpose: Deploy a PR preview environment for a backend PR, paired with a
+#          frontend ref (any treeish, including PR#<num>).
 #
 # Inputs are resolved at dispatch time via the GitHub API — this workflow does
 # NOT depend on any pre-populated dropdown lists and does NOT need any external
@@ -10,54 +10,81 @@
 #
 # Usage:
 #   Actions → Deploy PR Preview (Manual Select) → Run workflow
-#     backend_pr_number: 289                (required — PR in this repo)
-#     backend_sha_override: <7+ hex>        (optional — override PR branch HEAD)
-#     frontend_ref:       main              (default; or a branch, SHA, PR#<num>)
+#     backend_ref:  PR#289                  (required — accepts PR#<num>,
+#                                             <num>, branch, tag, full SHA,
+#                                             or short SHA ≥6 hex)
+#     frontend_ref: main                    (required — same vocabulary)
 #
-# Companion helper: the backend repo also hosts `list-preview-refs.yml`, a
-# read-only workflow that prints current main commits + open PRs from both
-# repos to the run summary. Use it when you don't remember a ref.
+# Companion helper: `list-preview-refs.yml` is a read-only workflow that
+# prints current main commits + open PRs from both repos to the run summary.
+# Use it when you don't remember a ref.
+#
+# Note on the "Use workflow from" branch picker that GitHub renders above
+# these inputs: that picker is built into the workflow_dispatch UI and cannot
+# be hidden from YAML. This workflow is only meaningful when dispatched from
+# `main`; the first job rejects any other ref so a mis-selection fails fast
+# with a clear error rather than producing a partial deploy.
 # =============================================================================
 
 name: Deploy PR Preview (Manual Select)
 on:
   workflow_dispatch:
     inputs:
-      backend_pr_number:
-        description: "Backend PR number to deploy (e.g. 289 or PR#289)"
+      backend_ref:
+        description: "Backend ref to deploy: PR#<num>, <num>, branch, tag, full SHA, or short SHA (≥6 hex)"
         required: true
         type: string
-      backend_sha_override:
-        description: "Optional: backend commit treeish — full SHA, 6+ char short SHA, branch, or tag (default: PR HEAD)"
-        required: false
-        type: string
-        default: ""
       frontend_ref:
-        description: "Frontend ref: main (default), branch, tag, full or 6+ char short SHA, or PR#<num>"
-        required: false
+        description: "Frontend ref to deploy: PR#<num>, branch, tag, full SHA, or short SHA (≥6 hex)"
+        required: true
         type: string
-        default: "main"
       reset_db:
         description: "Reset Postgres: drop the per-PR volume and re-seed (default: off — DB preserved across redeploys)"
         required: false
         type: boolean
         default: false
-# Prevent concurrent deployments for the same backend PR
+
+# Concurrency is keyed off the raw input. If a user dispatches the same PR
+# under two different ref forms (e.g. `PR#289` then `feat/foo` for the same
+# PR), they land in separate concurrency groups. Job-level locking inside
+# the deploy stack still prevents actual collisions on RPi5.
 concurrency:
-  group: pr-preview-backend-dispatch-${{ inputs.backend_pr_number }}
+  group: pr-preview-backend-dispatch-${{ inputs.backend_ref }}
   cancel-in-progress: true
+
 permissions:
   contents: read
   packages: write
   pull-requests: write
   attestations: write
   id-token: write
+
 jobs:
   # ===========================================================================
-  # JOB 1: Validate inputs and resolve refs → full SHAs
+  # JOB 0: Reject dispatches that target a non-main ref. The "Use workflow
+  # from" picker is GitHub's built-in UI and cannot be removed, so this guard
+  # turns a silent foot-gun into a fast, obvious error.
+  # ===========================================================================
+  guard-ref:
+    name: Reject non-main dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify dispatch from main
+        run: |
+          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "::error::This workflow must be dispatched from the 'main' branch."
+            echo "::error::You ran from: ${{ github.ref }}"
+            echo "::error::Set the 'Use workflow from' picker to 'Branch: main' and re-dispatch."
+            exit 1
+          fi
+          echo "::notice::Dispatched from main ✓"
+
+  # ===========================================================================
+  # JOB 1: Validate inputs and resolve refs → full SHAs + PR number.
   # ===========================================================================
   validate:
-    name: Validate PR & Resolve Refs
+    name: Validate inputs & resolve refs
+    needs: guard-ref
     runs-on: ubuntu-latest
     outputs:
       backend_sha: ${{ steps.resolve.outputs.backend_sha }}
@@ -65,16 +92,17 @@ jobs:
       branch_name: ${{ steps.resolve.outputs.branch_name }}
       pr_number: ${{ steps.resolve.outputs.pr_number }}
     steps:
-      - name: Resolve PR + refs to full SHAs
+      - name: Resolve refs to full SHAs and derive PR number
         id: resolve
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          INPUT_BACKEND_PR: ${{ inputs.backend_pr_number }}
-          INPUT_BACKEND_SHA_OVERRIDE: ${{ inputs.backend_sha_override }}
+          INPUT_BACKEND_REF: ${{ inputs.backend_ref }}
           INPUT_FRONTEND_REF: ${{ inputs.frontend_ref }}
           OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
+          BE_REPO="$OWNER/refactor-platform-rs"
+          FE_REPO="$OWNER/refactor-platform-fe"
 
           # ------------------------------------------------------------------
           # Field protection: every dispatch input is free-text and flows into
@@ -87,9 +115,8 @@ jobs:
           # Allowed: alphanumerics, dot, underscore, slash, hyphen, hash, plus, at-sign
           SAFE_INPUT_RE='^[A-Za-z0-9._/#+@-]+$'
           validate_input() {
-              local label="$1" value="$2" allow_empty="${3:-no}"
+              local label="$1" value="$2"
               if [[ -z "$value" ]]; then
-                  if [[ "$allow_empty" == "yes" ]]; then return 0; fi
                   echo "::error::$label must not be empty"; exit 1
               fi
               if (( ${#value} > MAX_INPUT_LEN )); then
@@ -103,28 +130,64 @@ jobs:
               fi
           }
 
-          validate_input "backend_pr_number"     "$INPUT_BACKEND_PR"
-          validate_input "backend_sha_override"  "$INPUT_BACKEND_SHA_OVERRIDE" yes
-          validate_input "frontend_ref"          "$INPUT_FRONTEND_REF"
+          validate_input "backend_ref"  "$INPUT_BACKEND_REF"
+          validate_input "frontend_ref" "$INPUT_FRONTEND_REF"
 
           # ------------------------------------------------------------------
-          # Normalize the backend PR number: accept "289" or "PR#289"
+          # Treeish guard: if the input is hex-only, require ≥6 chars to avoid
+          # accidental short-prefix matches at the GitHub API layer.
           # ------------------------------------------------------------------
-          if [[ "$INPUT_BACKEND_PR" =~ ^PR#([0-9]+)$ ]]; then
+          guard_treeish() {
+              local label="$1" value="$2"
+              if [[ "$value" =~ ^[0-9a-fA-F]+$ ]] && (( ${#value} < 6 )); then
+                  echo "::error::$label looks like a SHA but is shorter than 6 chars (got ${#value}). Use at least 6 hex chars, or pass a branch/tag name."
+                  exit 1
+              fi
+          }
+
+          # ------------------------------------------------------------------
+          # Backend resolution. Two arms keyed on the input shape:
+          #   PR# / numeric   → take that PR number directly.
+          #   <treeish>       → resolve to SHA via commits/<ref>, then look up
+          #                     the open PR that contains that SHA. Required
+          #                     because port allocation, comment posting, and
+          #                     concurrency keys all need a PR number.
+          # ------------------------------------------------------------------
+          if [[ "$INPUT_BACKEND_REF" =~ ^PR#([0-9]+)$ ]]; then
               PR_NUMBER="${BASH_REMATCH[1]}"
-          elif [[ "$INPUT_BACKEND_PR" =~ ^[0-9]+$ ]]; then
-              PR_NUMBER="$INPUT_BACKEND_PR"
+          elif [[ "$INPUT_BACKEND_REF" =~ ^[0-9]+$ ]]; then
+              PR_NUMBER="$INPUT_BACKEND_REF"
           else
-              echo "::error::backend_pr_number must be a number or 'PR#<num>', got: $INPUT_BACKEND_PR"
-              exit 1
+              guard_treeish "backend_ref" "$INPUT_BACKEND_REF"
+              BACKEND_FULL_SHA=$(gh api "repos/$BE_REPO/commits/$INPUT_BACKEND_REF" \
+                  --jq '.sha' 2>&1) || {
+                  echo "::error::Backend ref '$INPUT_BACKEND_REF' not found in $BE_REPO (tried as full/short SHA, branch, tag). Run list-preview-refs.yml to see available refs."
+                  exit 1
+              }
+              # Find the open PR(s) whose head, base, or merge-commit chain
+              # contains this SHA. The /pulls endpoint returns all matches.
+              PR_NUMBERS=$(gh api "repos/$BE_REPO/commits/$BACKEND_FULL_SHA/pulls" \
+                  --jq '[.[] | select(.state == "open") | .number] | unique')
+              OPEN_COUNT=$(echo "$PR_NUMBERS" | jq 'length')
+              if (( OPEN_COUNT == 0 )); then
+                  echo "::error::Backend ref '$INPUT_BACKEND_REF' (resolved to ${BACKEND_FULL_SHA:0:7}) is not associated with any open PR in $BE_REPO. Open a PR for that branch/SHA first, or pass an explicit PR# token."
+                  exit 1
+              fi
+              if (( OPEN_COUNT > 1 )); then
+                  PR_LIST=$(echo "$PR_NUMBERS" | jq -r '. | join(", #")')
+                  echo "::error::Backend ref '$INPUT_BACKEND_REF' is associated with multiple open PRs (#${PR_LIST}). Re-dispatch with an explicit PR# token to disambiguate."
+                  exit 1
+              fi
+              PR_NUMBER=$(echo "$PR_NUMBERS" | jq -r '.[0]')
+              echo "::notice::Backend ref '$INPUT_BACKEND_REF' (${BACKEND_FULL_SHA:0:7}) resolved to PR #${PR_NUMBER}"
           fi
 
           # ------------------------------------------------------------------
-          # Validate the backend PR exists and is OPEN (drafts allowed)
+          # Validate the resolved backend PR exists and is OPEN (drafts allowed).
           # ------------------------------------------------------------------
-          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$OWNER/refactor-platform-rs" \
+          PR_JSON=$(gh pr view "$PR_NUMBER" --repo "$BE_REPO" \
               --json state,isDraft,headRefName,headRefOid 2>&1) || {
-              echo "::error::Backend PR #$PR_NUMBER not found in $OWNER/refactor-platform-rs"
+              echo "::error::Backend PR #$PR_NUMBER not found in $BE_REPO"
               exit 1
           }
           PR_STATE=$(echo "$PR_JSON" | jq -r '.state')
@@ -138,45 +201,22 @@ jobs:
           fi
           echo "::notice::Backend PR #$PR_NUMBER is valid (state: $PR_STATE, draft: $PR_IS_DRAFT, branch: $BRANCH_NAME)"
 
-          # ------------------------------------------------------------------
-          # Determine the backend SHA. Accepted forms:
-          #   (empty)    → use the PR branch HEAD
-          #   <treeish>  → anything `gh api commits/<ref>` resolves: full SHA,
-          #                short SHA (≥6 chars), branch, or tag.
-          # The 6-char floor is a guard against single-character collisions
-          # in busy repos; GitHub itself accepts ≥4, but matches get fuzzy.
-          # ------------------------------------------------------------------
-          if [[ -n "$INPUT_BACKEND_SHA_OVERRIDE" ]]; then
-              # If it looks like an all-hex committish, enforce the ≥6 floor.
-              # Anything else (branch, tag, slash-containing ref) is passed
-              # through to the API which will validate semantically.
-              if [[ "$INPUT_BACKEND_SHA_OVERRIDE" =~ ^[0-9a-fA-F]+$ ]] \
-                 && (( ${#INPUT_BACKEND_SHA_OVERRIDE} < 6 )); then
-                  echo "::error::backend_sha_override looks like a SHA but is shorter than 6 chars (got ${#INPUT_BACKEND_SHA_OVERRIDE}). Use at least 6 hex chars, or pass a branch/tag name."
-                  exit 1
-              fi
-              BACKEND_FULL_SHA=$(gh api "repos/$OWNER/refactor-platform-rs/commits/$INPUT_BACKEND_SHA_OVERRIDE" \
-                  --jq '.sha' 2>&1) || {
-                  echo "::error::Backend ref '$INPUT_BACKEND_SHA_OVERRIDE' not found in $OWNER/refactor-platform-rs (tried as full/short SHA, branch, tag). Run list-preview-refs.yml to see available refs."
-                  exit 1
-              }
-              echo "::notice::Using backend ref override '$INPUT_BACKEND_SHA_OVERRIDE' → ${BACKEND_FULL_SHA:0:7}"
-          else
+          # If the backend ref was a PR# / numeric token, deploy the PR's HEAD.
+          # If it was a treeish, BACKEND_FULL_SHA was already resolved above.
+          if [[ -z "${BACKEND_FULL_SHA:-}" ]]; then
               BACKEND_FULL_SHA="$PR_HEAD_SHA"
               echo "::notice::Using backend PR #$PR_NUMBER HEAD: ${BACKEND_FULL_SHA:0:7}"
           fi
 
           # ------------------------------------------------------------------
-          # Resolve the frontend ref. Two arms:
-          #   1. PR#<num>   → look up the PR's HEAD SHA
-          #   2. <treeish>  → `gh api commits/<ref>` (full/short SHA, branch, tag, HEAD)
+          # Frontend resolution. Two arms:
+          #   PR#<num>   → look up the FE PR's HEAD SHA.
+          #   <treeish>  → commits/<ref> (full/short SHA, branch, tag, HEAD).
           #
           # The commits API is ref-type-agnostic: a branch literally named in
-          # 6-40 hex chars resolves the same way as the SHA itself, so we
-          # don't need a separate SHA arm. The 6-char floor still applies
-          # for hex-only inputs.
+          # 6-40 hex chars resolves the same way as the SHA itself. The 6-char
+          # floor still applies for hex-only inputs.
           # ------------------------------------------------------------------
-          FE_REPO="$OWNER/refactor-platform-fe"
           if [[ "$INPUT_FRONTEND_REF" =~ ^PR#([0-9]+)$ ]]; then
               FE_PR="${BASH_REMATCH[1]}"
               FRONTEND_FULL_SHA=$(gh pr view "$FE_PR" --repo "$FE_REPO" \
@@ -186,11 +226,7 @@ jobs:
               }
               echo "::notice::Frontend ref resolved from PR #$FE_PR: ${FRONTEND_FULL_SHA:0:7}"
           else
-              if [[ "$INPUT_FRONTEND_REF" =~ ^[0-9a-fA-F]+$ ]] \
-                 && (( ${#INPUT_FRONTEND_REF} < 6 )); then
-                  echo "::error::frontend_ref looks like a SHA but is shorter than 6 chars (got ${#INPUT_FRONTEND_REF}). Use at least 6 hex chars, or pass a branch/tag name."
-                  exit 1
-              fi
+              guard_treeish "frontend_ref" "$INPUT_FRONTEND_REF"
               FRONTEND_FULL_SHA=$(gh api "repos/$FE_REPO/commits/$INPUT_FRONTEND_REF" \
                   --jq '.sha' 2>&1) || {
                   echo "::error::Frontend ref '$INPUT_FRONTEND_REF' not found in $FE_REPO (tried as full/short SHA, branch, tag). Run list-preview-refs.yml to see available refs."
@@ -205,8 +241,9 @@ jobs:
               echo "branch_name=$BRANCH_NAME"
               echo "pr_number=$PR_NUMBER"
           } >> "$GITHUB_OUTPUT"
+
   # ===========================================================================
-  # JOB 2: Deploy using the reusable workflow
+  # JOB 2: Deploy using the reusable workflow.
   # ===========================================================================
   deploy:
     name: Deploy PR Preview

--- a/.github/workflows/tests/dispatch-pr-preview.bats
+++ b/.github/workflows/tests/dispatch-pr-preview.bats
@@ -56,6 +56,28 @@ classify_treeish_input() {
     fi
 }
 
+# Backend-ref classifier used by the unified `backend_ref` input on the
+# dispatch workflow. The workflow checks PR# / numeric first and uses that
+# PR number directly; anything else falls through to treeish handling
+# (resolve to SHA via commits/<ref>, then look up the open PR via
+# commits/<sha>/pulls). Returns one of:
+#   PR_HASH <num>     — explicit PR# token
+#   NUMERIC <num>     — bare digits, treated as a PR number
+#   TOO_SHORT_HEX     — hex-only input below the 6-char floor
+#   TREEISH <ref>     — branch / tag / SHA / hex-named branch
+classify_backend_ref_input() {
+    local input="$1"
+    if [[ "$input" =~ ^PR#([0-9]+)$ ]]; then
+        echo "PR_HASH ${BASH_REMATCH[1]}"
+    elif [[ "$input" =~ ^[0-9]+$ ]]; then
+        echo "NUMERIC $input"
+    elif [[ "$input" =~ ^[0-9a-fA-F]+$ ]] && (( ${#input} < 6 )); then
+        echo "TOO_SHORT_HEX"
+    else
+        echo "TREEISH $input"
+    fi
+}
+
 # The new override validator (used for *_sha_override and the *_ref input).
 # Treeish-shape: any non-empty string that the field-protection layer has
 # already accepted, with the only extra rule being the 6-char floor for
@@ -703,4 +725,124 @@ validate_input() {
 @test "Lifecycle: empty reset arg defaults to false" {
     run decide_db_lifecycle "yes" ""
     [ "$output" = "UPDATE" ]
+}
+
+# ---------------------------------------------------------------------------
+# Backend-ref classification (unified `backend_ref` input).
+# Mirrors the 4-arm chain in dispatch-pr-preview.yml's resolver step:
+#   PR_HASH > NUMERIC > TOO_SHORT_HEX > TREEISH.
+# PR_HASH and NUMERIC are short-circuit paths (no API SHA lookup needed);
+# TREEISH triggers SHA resolution + commits/<sha>/pulls to derive the PR.
+# ---------------------------------------------------------------------------
+@test "BERef: 'PR#289' parsed as PR_HASH 289" {
+    run classify_backend_ref_input "PR#289"
+    [ "$output" = "PR_HASH 289" ]
+}
+
+@test "BERef: bare '289' parsed as NUMERIC 289" {
+    run classify_backend_ref_input "289"
+    [ "$output" = "NUMERIC 289" ]
+}
+
+@test "BERef: 'PR#1' single-digit parsed as PR_HASH 1" {
+    run classify_backend_ref_input "PR#1"
+    [ "$output" = "PR_HASH 1" ]
+}
+
+@test "BERef: '0' parsed as NUMERIC 0 (semantic check is later)" {
+    run classify_backend_ref_input "0"
+    [ "$output" = "NUMERIC 0" ]
+}
+
+@test "BERef: 'main' falls through as TREEISH (no associated PR check is later)" {
+    run classify_backend_ref_input "main"
+    [ "$output" = "TREEISH main" ]
+}
+
+@test "BERef: feature branch 'feat/foo' falls through as TREEISH" {
+    run classify_backend_ref_input "feat/foo"
+    [ "$output" = "TREEISH feat/foo" ]
+}
+
+@test "BERef: tag-like 'v1.0.0' falls through as TREEISH" {
+    run classify_backend_ref_input "v1.0.0"
+    [ "$output" = "TREEISH v1.0.0" ]
+}
+
+@test "BERef: 6-char hex accepted as TREEISH (lower bound)" {
+    run classify_backend_ref_input "abc123"
+    [ "$output" = "TREEISH abc123" ]
+}
+
+@test "BERef: 7-char hex accepted as TREEISH" {
+    run classify_backend_ref_input "abc1234"
+    [ "$output" = "TREEISH abc1234" ]
+}
+
+@test "BERef: 40-char full SHA accepted as TREEISH" {
+    run classify_backend_ref_input "0123456789abcdef0123456789abcdef01234567"
+    [ "$output" = "TREEISH 0123456789abcdef0123456789abcdef01234567" ]
+}
+
+@test "BERef: 5-char hex rejected as TOO_SHORT_HEX (below SHA floor)" {
+    run classify_backend_ref_input "abcde"
+    [ "$output" = "TOO_SHORT_HEX" ]
+}
+
+@test "BERef: 1-char hex rejected as TOO_SHORT_HEX" {
+    run classify_backend_ref_input "a"
+    [ "$output" = "TOO_SHORT_HEX" ]
+}
+
+@test "BERef: branch literally named 'deadbeef' (hex) classified as TREEISH" {
+    # Same precedence note as classify_treeish_input: hex-only 6+ char inputs
+    # always look like SHAs. The /commits/<ref> endpoint resolves both
+    # identically, so the classification is correct from the workflow's view.
+    run classify_backend_ref_input "deadbeef"
+    [ "$output" = "TREEISH deadbeef" ]
+}
+
+@test "BERef: 'PR#abc' (non-numeric after PR#) falls through as TREEISH" {
+    # Workflow will then attempt commits/PR%23abc which 404s — the expected
+    # user error. The classifier doesn't reject; the gh API does.
+    run classify_backend_ref_input "PR#abc"
+    [ "$output" = "TREEISH PR#abc" ]
+}
+
+@test "BERef: empty string falls through as TREEISH (field-protection rejects earlier)" {
+    # In the live workflow, validate_input rejects empty inputs BEFORE this
+    # classifier runs. The classifier itself doesn't have a special-case for
+    # empty strings — it just classifies. Pinning that contract here.
+    run classify_backend_ref_input ""
+    [ "$output" = "TREEISH " ]
+}
+
+# ---------------------------------------------------------------------------
+# Cross-cutting: backend_ref contract guarantees
+# ---------------------------------------------------------------------------
+@test "Contract: backend_ref PR# precedence holds even when number could also be a SHA" {
+    # 'PR#1234567' has 7 hex-compatible digits after PR#. PR# arm wins.
+    run classify_backend_ref_input "PR#1234567"
+    [ "$output" = "PR_HASH 1234567" ]
+}
+
+@test "Contract: backend_ref NUMERIC precedence over hex (bare digits never classified as SHA)" {
+    # '1234567' is hex-compatible but the NUMERIC arm runs before the
+    # treeish arm — so a bare integer is always interpreted as a PR number,
+    # never as a hex SHA. Documents intentional ambiguity resolution.
+    run classify_backend_ref_input "1234567"
+    [ "$output" = "NUMERIC 1234567" ]
+}
+
+@test "Contract: backend_ref classifier never silently mis-resolves hex-only short input" {
+    # A hex-only input below 6 chars must hit TOO_SHORT_HEX, never TREEISH.
+    # Catches the regression where short SHAs accidentally resolved to a
+    # different commit at the GitHub API.
+    for input in "a" "ab" "abc" "abcd" "abcde"; do
+        result=$(classify_backend_ref_input "$input")
+        [[ "$result" == "TOO_SHORT_HEX" ]] || {
+            echo "expected TOO_SHORT_HEX for '$input', got '$result'"
+            return 1
+        }
+    done
 }


### PR DESCRIPTION
Closes #306. Two coupled CI fixes — A reverts the regression introduced by #305, B is a dispatch UX simplification.

## A. Cleanup `pull_request_target` (rolls back regression from #305)

#305 dropped the leaf reusable workflow's `pull_request: closed` trigger and pinned the backend caller's `uses:` to `@main`. The `@main` pin only governs how the *called* workflow is fetched — it does not fix the `gh pr merge --delete-branch` race, because GitHub still loads the *caller* workflow file from the PR head SHA, which is orphaned seconds before scheduling. Reproduced post-merge on PR #305: run [25636421269](https://github.com/refactor-group/refactor-platform-rs/actions/runs/25636421269) ended in `startup_failure`, 0 jobs, 1 s duration.

Net effect today: any merged BE PR with a deployed preview would receive **no cleanup at all** until this lands. (PR #305 itself wasn't affected because no preview was deployed for it, but that masking effect doesn't generalize.)

**Fix**: switch `cleanup-pr-preview-backend.yml`'s trigger from `pull_request: types: [closed]` to `pull_request_target: types: [closed]`. `pull_request_target` loads the workflow file from the base branch (`main`) instead of the PR head SHA, so it's immune to head-branch deletion. Safe here because we never `actions/checkout` PR code and only run after close. Event payload (`pull_request.number`, `.merged`, `.head.ref`, `.head.sha`) is identical to `pull_request`.

## B. Dispatch UX simplification

Before:

| Field | Required | Accepts |
|---|---|---|
| `backend_pr_number` | yes | `289` or `PR#289` |
| `backend_sha_override` | no | full/short SHA, branch, tag |
| `frontend_ref` | no (default `main`) | full/short SHA, branch, tag, `PR#<num>` |

After:

| Field | Required | Accepts |
|---|---|---|
| `backend_ref` | yes | `PR#<num>`, `<num>`, branch, tag, full SHA, short SHA (≥6 hex) |
| `frontend_ref` | yes | `PR#<num>`, branch, tag, full SHA, short SHA (≥6 hex) |

Both fields share the treeish vocabulary already vetted by the BATS suite. Backend port allocation, comment posting, and concurrency keys still need a PR number; the resolver derives one as follows:

- `PR#<num>` / `<num>` input → use directly.
- Treeish input → resolve to SHA via `commits/<ref>`, then look up the open PR via `commits/<sha>/pulls`. Errors out if the SHA touches no open PR or multiple open PRs (asks user to disambiguate).

GitHub's built-in `Use workflow from` branch picker cannot be hidden from YAML. A new `guard-ref` job rejects any dispatch where `github.ref != refs/heads/main` with a clear, actionable error so a mis-selection fails fast instead of producing a partial deploy.

## Validation (all locally before push)

- `actionlint` repo-wide: 0 new findings (only pre-existing info-level shellcheck noise on untouched script blocks).
- `ruby -ryaml` parse OK on all changed files.
- `bats .github/workflows/tests/dispatch-pr-preview.bats`: **126/126 pass** (110 existing + 16 new for the backend-ref classifier covering PR_HASH / NUMERIC / TOO_SHORT_HEX / TREEISH precedence and contract guarantees).
- `act --list -W cleanup-pr-preview-backend.yml`: events shown as `pull_request_target` (the fix is in effect).
- `act --list -W dispatch-pr-preview.yml`: 3 jobs in correct topology — `guard-ref → validate → deploy`.

## Edge cases covered

| Scenario | Behavior |
|---|---|
| BE merge with `--delete-branch`, no preview deployed | `check-preview` finds no comment → cleanup skipped. No `startup_failure`. |
| BE merge with `--delete-branch`, preview was deployed | `check-preview` triggers full teardown via the leaf workflow. No `startup_failure`. |
| Dispatch with `backend_ref: PR#289` | Direct PR# arm; deploys PR head SHA. |
| Dispatch with `backend_ref: 289` | Numeric arm; deploys PR head SHA. |
| Dispatch with `backend_ref: feat/foo` | Treeish arm; resolves to SHA, finds associated open PR, deploys. |
| Dispatch with `backend_ref: <sha>` | Treeish arm; deploys exactly that SHA. |
| Dispatch with `backend_ref: main` | Treeish arm; SHA resolves but no open PR found → clear error. |
| Dispatch with `backend_ref: <sha>` matching multiple open PRs | Clear error listing the PRs; asks user to use `PR#<num>` to disambiguate. |
| Dispatch with `backend_ref: ab` (hex < 6) | `TOO_SHORT_HEX` guard fires before any API call. |
| Dispatch from a non-main branch via the `Use workflow from` picker | `guard-ref` job fails fast with the offending ref echoed. |
| `frontend_ref` with any treeish form | Same vocabulary, resolved via `commits/<ref>`. |
| `frontend_ref: PR#<num>` | Resolves the FE PR's head SHA. |

## Out of scope

- `dispatch-pr-preview-frontend.yml` in the FE repo (same UX pattern; separate repo and PR).
- The FE PR cleanup workflow (already correctly pinned to `@main` via cross-repo `uses:`).
- Renaming the `main-arm64` rebuild step out of `cleanup-pr-preview.yml`.

## Test plan

- [ ] Land this PR with `--delete-branch`. Verify the post-merge `Cleanup PR Preview (Backend)` run shows `success` (or correctly skips), **no** `startup_failure`.
- [ ] Open the dispatch dialog from `Actions → Deploy PR Preview (Manual Select)` and confirm only two text inputs (plus the `reset_db` checkbox) are shown, both required.
- [ ] Dispatch with `backend_ref: PR#<some-open-pr>` and `frontend_ref: main` → verify deploy succeeds end-to-end.
- [ ] Dispatch with `backend_ref: <branch-of-an-open-pr>` → verify resolver finds the PR and deploy succeeds.
- [ ] Dispatch with `backend_ref: main` → verify it fails with the "no associated open PR" error and exits cleanly before any deploy work.
- [ ] (Optional) Dispatch with `Use workflow from: <some-other-branch>` — verify the `guard-ref` job fails immediately.