### PR TITLE
chore(deps): bump openssl to 0.10.79 to fix Dependabot alerts #54 and #55

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,15 +2450,14 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -2491,9 +2490,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
## Description
Fixes the two outstanding Dependabot alerts on `main` for the `openssl` Rust crate. Dependabot was unable to auto-update these because a transitive constraint kept the resolver pinned at `0.10.78`; bumping with `cargo update -p openssl --precise 0.10.79` resolves both.

(Supersedes #309, which was opened on a branch name containing uppercase characters — `build-test-push.yml` composes a Docker registry tag from the branch name and Docker rejects uppercase, so CI failed. Same commit, re-pushed to a lowercase-only branch.)

#### GitHub Issue: Resolves Dependabot alerts #54 and #55

### Changes
* `Cargo.lock`: `openssl` `0.10.78` → `0.10.79`
* `Cargo.lock`: `openssl-sys` `0.9.114` → `0.9.115` (transitive)

### Vulnerabilities fixed
- **Alert #54** — `X509Ref::ocsp_responders` returns OCSP responder URLs as `OpensslString` via `str::from_utf8_unchecked`. A certificate with non-UTF-8 bytes in its OCSP `accessLocation` causes safe Rust code to construct a `&str` that violates the UTF-8 invariant — undefined behavior. Patched in `openssl 0.10.79`.
- **Alert #55** *(moderate, CVSS 5.1)* — `CipherCtxRef::cipher_update`, `CipherCtxRef::cipher_update_vec`, and `symm::Crypter::update` incorrectly sized output buffers when used with AES key-wrap-with-padding ciphers (`EVP_aes_{128,192,256}_wrap_pad`). For non-multiple-of-8 input, OpenSSL writes up to 7 bytes past the end of the caller's buffer/Vec, producing attacker-controllable heap corruption when plaintext length is attacker-influenced. Patched in `openssl 0.10.79`.

### Testing Strategy
- `cargo build --workspace` — succeeds
- `cargo test --workspace --no-fail-fast` — all suites pass, 0 failures
- `cargo clippy --workspace --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean
- `cargo audit` — both `openssl` advisories cleared; the only remaining `error` is `RUSTSEC-2023-0071` (rsa Marvin Attack), which has no fixed upgrade available upstream and is pre-existing

### Concerns
The project's top-level `Cargo.toml` still pins `openssl-sys = "0.9.107"`; the caret requirement satisfies `0.9.115` so no manifest edit is needed.

Separately, `build-test-push.yml` line 156 should lowercase `BRANCH_NAME` before forming the Docker tag so future branches with uppercase letters don't hit the same failure. I drafted that one-line change but my session lacks the `workflows` permission needed to push it — flagging here for follow-up.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RZ2iwx8hr8qdXiYi8nZWkJ)_