### PR TITLE
Broaden batch actions endpoint to coachees with role-aware visibility

### DIFF
--- a/domain/src/action.rs
+++ b/domain/src/action.rs
@@ -8,7 +8,7 @@ pub use entity_api::action::{
     create, create_with_assignees, delete_by_id, find_by_coach_relationships,
     find_by_coaching_relationship, find_by_id, find_by_id_with_assignees, find_by_user, update,
     update_status, update_with_assignees, ActionWithAssignees, AssigneeFilter, AssigneeScope,
-    FindByRelationshipParams, FindByUserParams, Scope,
+    CallerVisibility, FindByRelationshipParams, FindByUserParams, Scope,
 };
 
 pub async fn find_by<P>(db: &DatabaseConnection, params: P) -> Result<Vec<Model>, Error>

--- a/domain/src/action.rs
+++ b/domain/src/action.rs
@@ -5,10 +5,10 @@ use entity_api::{actions, actions_user, query};
 use sea_orm::DatabaseConnection;
 
 pub use entity_api::action::{
-    create, create_with_assignees, delete_by_id, find_by_coach_relationships,
-    find_by_coaching_relationship, find_by_id, find_by_id_with_assignees, find_by_user, update,
-    update_status, update_with_assignees, ActionWithAssignees, AssigneeFilter, AssigneeScope,
-    CallerVisibility, FindByRelationshipParams, FindByUserParams, Scope,
+    create, create_with_assignees, delete_by_id, find_by_coaching_relationship, find_by_id,
+    find_by_id_with_assignees, find_by_user, find_by_user_relationships, update, update_status,
+    update_with_assignees, ActionWithAssignees, AssigneeFilter, AssigneeScope, CallerVisibility,
+    FindByRelationshipParams, FindByUserParams, Scope,
 };
 
 pub async fn find_by<P>(db: &DatabaseConnection, params: P) -> Result<Vec<Model>, Error>

--- a/domain/src/coaching_relationship.rs
+++ b/domain/src/coaching_relationship.rs
@@ -6,9 +6,9 @@ use sea_orm::{DatabaseConnection, TransactionTrait};
 
 pub use entity_api::coaching_relationship::{
     create, find_by_coach_and_organization, find_by_id, find_by_organization_with_user_names,
-    find_by_user, find_by_user_and_organization_with_user_names, find_by_user_id_with_user_names,
-    get_relationship_with_user_names, is_coach_of, CoachingRelationshipWithUserNames,
-    RoleFilterable,
+    find_by_user, find_by_user_and_organization, find_by_user_and_organization_with_user_names,
+    find_by_user_id_with_user_names, get_relationship_with_user_names, is_coach_of,
+    CoachingRelationshipWithUserNames, RoleFilterable,
 };
 
 pub async fn find_by<P>(db: &DatabaseConnection, params: P) -> Result<Vec<Model>, Error>

--- a/entity_api/src/action.rs
+++ b/entity_api/src/action.rs
@@ -414,6 +414,52 @@ pub enum AssigneeScope {
     User(Id),
 }
 
+/// Role-aware visibility narrowing applied on top of [`AssigneeFilter`] and
+/// `assignee_user_id` scoping. Coaches see the full relationship action set;
+/// coachees see only actions assigned to themselves or unassigned.
+///
+/// `Unrestricted` is the default so that any callsite building
+/// [`FindByRelationshipParams`] via `..Default::default()` retains the
+/// pre-fix coach-equivalent behavior.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub enum CallerVisibility {
+    /// Full visibility across the relationship (coach caller, or any callsite
+    /// that has already authorized membership and wants the full set).
+    #[default]
+    Unrestricted,
+    /// Coachee caller: limit to actions assigned to this user, plus unassigned.
+    CoacheeSelf { user_id: Id },
+}
+
+impl CallerVisibility {
+    /// Predicate: does this caller's visibility allow an action with the given
+    /// assignees through the filter?
+    pub fn allows(&self, assignee_ids: &[Id]) -> bool {
+        match self {
+            Self::Unrestricted => true,
+            Self::CoacheeSelf { user_id } => {
+                assignee_ids.is_empty() || assignee_ids.contains(user_id)
+            }
+        }
+    }
+
+    /// Determines the visibility for a caller against a specific relationship
+    /// by their role in it. Coach role → `Unrestricted`; coachee role →
+    /// `CoacheeSelf`. Falls back to `Unrestricted` for unrecognized users
+    /// (membership is enforced upstream by `CoachingRelationshipAccess` /
+    /// controllers).
+    pub fn for_relationship(
+        user_id: Id,
+        relationship: &entity::coaching_relationships::Model,
+    ) -> Self {
+        match user_id {
+            id if id == relationship.coach_id => Self::Unrestricted,
+            id if id == relationship.coachee_id => Self::CoacheeSelf { user_id: id },
+            _ => Self::Unrestricted,
+        }
+    }
+}
+
 /// Query parameters for finding actions by coaching relationship.
 ///
 /// A simpler parameter set than `FindByUserParams` — no scope or user context needed
@@ -424,6 +470,8 @@ pub struct FindByRelationshipParams {
     pub assignee_filter: AssigneeFilter,
     /// When set, only include actions assigned to this specific user.
     pub assignee_user_id: Option<Id>,
+    /// Role-aware visibility narrowing. Defaults to `Unrestricted`.
+    pub caller_visibility: CallerVisibility,
     pub sort_column: Option<entity::actions::Column>,
     pub sort_order: Option<Order>,
 }
@@ -483,7 +531,9 @@ pub async fn find_by_coaching_relationship(
                 .as_ref()
                 .is_none_or(|id| assignee_ids.contains(id));
 
-            (passes_filter && passes_scope).then_some(ActionWithAssignees {
+            let passes_visibility = params.caller_visibility.allows(&assignee_ids);
+
+            (passes_filter && passes_scope && passes_visibility).then_some(ActionWithAssignees {
                 action,
                 assignee_ids,
             })
@@ -504,6 +554,13 @@ pub async fn find_by_coaching_relationship(
 /// for each one. Returns a HashMap where every coachee gets a key — even if they
 /// have no matching actions (empty vec).
 ///
+/// `caller_user_id` is the authenticated user invoking the query. It determines
+/// the per-relationship [`CallerVisibility`] (coach role → `Unrestricted`,
+/// coachee role → `CoacheeSelf`), which narrows a coachee's visible set to
+/// self-assigned + unassigned actions on a per-relationship basis. This
+/// matters for mixed-role users who are coach in one relationship and coachee
+/// in another within the same organization.
+///
 /// When `assignee_scope` is provided, it is resolved to a concrete user ID per
 /// relationship (Coach → coach_id, Coachee → coachee_id, User(id) → id) and
 /// set on the params so only actions assigned to that user are included.
@@ -515,6 +572,7 @@ pub async fn find_by_coach_relationships(
     relationships: &[entity::coaching_relationships::Model],
     params: FindByRelationshipParams,
     assignee_scope: Option<AssigneeScope>,
+    caller_user_id: Id,
 ) -> Result<HashMap<Id, Vec<ActionWithAssignees>>, Error> {
     let mut result: HashMap<Id, Vec<ActionWithAssignees>> = HashMap::new();
 
@@ -523,12 +581,15 @@ pub async fn find_by_coach_relationships(
     }
 
     for relationship in relationships {
-        let mut relationship_params = params.clone();
-        relationship_params.assignee_user_id = assignee_scope.as_ref().map(|scope| match scope {
-            AssigneeScope::Coach => relationship.coach_id,
-            AssigneeScope::Coachee => relationship.coachee_id,
-            AssigneeScope::User(id) => *id,
-        });
+        let relationship_params = FindByRelationshipParams {
+            caller_visibility: CallerVisibility::for_relationship(caller_user_id, relationship),
+            assignee_user_id: assignee_scope.as_ref().map(|scope| match scope {
+                AssigneeScope::Coach => relationship.coach_id,
+                AssigneeScope::Coachee => relationship.coachee_id,
+                AssigneeScope::User(id) => *id,
+            }),
+            ..params.clone()
+        };
 
         let actions =
             find_by_coaching_relationship(db, relationship.id, relationship_params).await?;
@@ -1169,6 +1230,7 @@ mod tests {
             status: None,
             assignee_filter: AssigneeFilter::All,
             assignee_user_id: None,
+            caller_visibility: CallerVisibility::default(),
             sort_column: None,
             sort_order: None,
         };
@@ -1196,6 +1258,7 @@ mod tests {
             status: Some(Status::InProgress),
             assignee_filter: AssigneeFilter::All,
             assignee_user_id: None,
+            caller_visibility: CallerVisibility::default(),
             sort_column: None,
             sort_order: None,
         };
@@ -1239,6 +1302,7 @@ mod tests {
             status: None,
             assignee_filter: AssigneeFilter::Unassigned,
             assignee_user_id: None,
+            caller_visibility: CallerVisibility::default(),
             sort_column: None,
             sort_order: None,
         };
@@ -1266,6 +1330,7 @@ mod tests {
             status: None,
             assignee_filter: AssigneeFilter::All,
             assignee_user_id: None,
+            caller_visibility: CallerVisibility::default(),
             sort_column: None,
             sort_order: None,
         };
@@ -1328,11 +1393,13 @@ mod tests {
             status: None,
             assignee_filter: AssigneeFilter::All,
             assignee_user_id: None,
+            caller_visibility: CallerVisibility::default(),
             sort_column: None,
             sort_order: None,
         };
 
-        let result = find_by_coach_relationships(&db, &relationships, params, None).await?;
+        let result =
+            find_by_coach_relationships(&db, &relationships, params, None, coach_id).await?;
 
         // All 3 coachees should have keys
         assert_eq!(result.len(), 3, "All coachees should have entries");
@@ -1369,11 +1436,13 @@ mod tests {
             status: None,
             assignee_filter: AssigneeFilter::All,
             assignee_user_id: None,
+            caller_visibility: CallerVisibility::default(),
             sort_column: None,
             sort_order: None,
         };
 
-        let result = find_by_coach_relationships(&db, &relationships, params, None).await?;
+        let result =
+            find_by_coach_relationships(&db, &relationships, params, None, coach_id).await?;
 
         assert_eq!(result.len(), 2, "Both coachees should have entries");
         assert!(result.get(&coachee_1).unwrap().is_empty());
@@ -1392,13 +1461,322 @@ mod tests {
             status: None,
             assignee_filter: AssigneeFilter::All,
             assignee_user_id: None,
+            caller_visibility: CallerVisibility::default(),
             sort_column: None,
             sort_order: None,
         };
 
-        let result = find_by_coach_relationships(&db, &[], params, None).await?;
+        let result = find_by_coach_relationships(&db, &[], params, None, Id::new_v4()).await?;
 
         assert!(result.is_empty());
+
+        Ok(())
+    }
+
+    // ─── CallerVisibility tests ───────────────────────────────────────
+
+    #[test]
+    fn caller_visibility_unrestricted_allows_anything() {
+        let vis = CallerVisibility::Unrestricted;
+        assert!(vis.allows(&[]));
+        assert!(vis.allows(&[Id::new_v4()]));
+        assert!(vis.allows(&[Id::new_v4(), Id::new_v4()]));
+    }
+
+    #[test]
+    fn caller_visibility_coachee_self_allows_unassigned() {
+        let vis = CallerVisibility::CoacheeSelf {
+            user_id: Id::new_v4(),
+        };
+        assert!(vis.allows(&[]));
+    }
+
+    #[test]
+    fn caller_visibility_coachee_self_allows_when_self_in_assignees() {
+        let user_id = Id::new_v4();
+        let vis = CallerVisibility::CoacheeSelf { user_id };
+        assert!(vis.allows(&[user_id]));
+        assert!(vis.allows(&[user_id, Id::new_v4()]));
+    }
+
+    #[test]
+    fn caller_visibility_coachee_self_rejects_when_self_not_in_assignees() {
+        let vis = CallerVisibility::CoacheeSelf {
+            user_id: Id::new_v4(),
+        };
+        assert!(!vis.allows(&[Id::new_v4()]));
+        assert!(!vis.allows(&[Id::new_v4(), Id::new_v4()]));
+    }
+
+    #[test]
+    fn caller_visibility_for_relationship_coach_role_is_unrestricted() {
+        let coach_id = Id::new_v4();
+        let rel = create_test_relationship(Id::new_v4(), coach_id, Id::new_v4(), Id::new_v4());
+        assert_eq!(
+            CallerVisibility::for_relationship(coach_id, &rel),
+            CallerVisibility::Unrestricted
+        );
+    }
+
+    #[test]
+    fn caller_visibility_for_relationship_coachee_role_is_coachee_self() {
+        let coachee_id = Id::new_v4();
+        let rel = create_test_relationship(Id::new_v4(), Id::new_v4(), coachee_id, Id::new_v4());
+        assert_eq!(
+            CallerVisibility::for_relationship(coachee_id, &rel),
+            CallerVisibility::CoacheeSelf {
+                user_id: coachee_id
+            }
+        );
+    }
+
+    // ─── Coachee visibility integration tests ─────────────────────────
+
+    /// Coachee caller sees self-assigned + unassigned, never coach-assigned.
+    #[tokio::test]
+    async fn find_by_coaching_relationship_coachee_visibility_filters_coach_actions(
+    ) -> Result<(), Error> {
+        let relationship_id = Id::new_v4();
+        let session_id = Id::new_v4();
+        let coach_id = Id::new_v4();
+        let coachee_id = Id::new_v4();
+
+        let coach_action_id = Id::new_v4();
+        let coachee_action_id = Id::new_v4();
+        let unassigned_action_id = Id::new_v4();
+        let now = chrono::Utc::now();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![
+                create_test_action(coach_action_id, session_id),
+                create_test_action(coachee_action_id, session_id),
+                create_test_action(unassigned_action_id, session_id),
+            ]])
+            .append_query_results(vec![vec![
+                entity::actions_users::Model {
+                    id: Id::new_v4(),
+                    action_id: coach_action_id,
+                    user_id: coach_id,
+                    created_at: now.into(),
+                    updated_at: now.into(),
+                },
+                entity::actions_users::Model {
+                    id: Id::new_v4(),
+                    action_id: coachee_action_id,
+                    user_id: coachee_id,
+                    created_at: now.into(),
+                    updated_at: now.into(),
+                },
+            ]])
+            .into_connection();
+
+        let params = FindByRelationshipParams {
+            status: None,
+            assignee_filter: AssigneeFilter::All,
+            assignee_user_id: None,
+            caller_visibility: CallerVisibility::CoacheeSelf {
+                user_id: coachee_id,
+            },
+            sort_column: None,
+            sort_order: None,
+        };
+
+        let results = find_by_coaching_relationship(&db, relationship_id, params).await?;
+
+        let returned_ids: std::collections::HashSet<Id> =
+            results.iter().map(|a| a.action.id).collect();
+
+        assert_eq!(results.len(), 2);
+        assert!(returned_ids.contains(&coachee_action_id));
+        assert!(returned_ids.contains(&unassigned_action_id));
+        assert!(
+            !returned_ids.contains(&coach_action_id),
+            "Coach-assigned action must never be returned to a coachee"
+        );
+
+        Ok(())
+    }
+
+    /// Coach caller (Unrestricted visibility) sees all three buckets — regression guard.
+    #[tokio::test]
+    async fn find_by_coaching_relationship_coach_visibility_sees_all_three_buckets(
+    ) -> Result<(), Error> {
+        let relationship_id = Id::new_v4();
+        let session_id = Id::new_v4();
+        let coach_id = Id::new_v4();
+        let coachee_id = Id::new_v4();
+
+        let coach_action_id = Id::new_v4();
+        let coachee_action_id = Id::new_v4();
+        let unassigned_action_id = Id::new_v4();
+        let now = chrono::Utc::now();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![
+                create_test_action(coach_action_id, session_id),
+                create_test_action(coachee_action_id, session_id),
+                create_test_action(unassigned_action_id, session_id),
+            ]])
+            .append_query_results(vec![vec![
+                entity::actions_users::Model {
+                    id: Id::new_v4(),
+                    action_id: coach_action_id,
+                    user_id: coach_id,
+                    created_at: now.into(),
+                    updated_at: now.into(),
+                },
+                entity::actions_users::Model {
+                    id: Id::new_v4(),
+                    action_id: coachee_action_id,
+                    user_id: coachee_id,
+                    created_at: now.into(),
+                    updated_at: now.into(),
+                },
+            ]])
+            .into_connection();
+
+        let params = FindByRelationshipParams {
+            status: None,
+            assignee_filter: AssigneeFilter::All,
+            assignee_user_id: None,
+            caller_visibility: CallerVisibility::Unrestricted,
+            sort_column: None,
+            sort_order: None,
+        };
+
+        let results = find_by_coaching_relationship(&db, relationship_id, params).await?;
+
+        assert_eq!(results.len(), 3, "Coach must see all three buckets");
+
+        Ok(())
+    }
+
+    /// Coachee with `assignee_filter=assigned` sees only self-assigned, not unassigned.
+    /// Combines visibility narrowing with the existing assignee_filter.
+    #[tokio::test]
+    async fn find_by_coaching_relationship_coachee_with_assigned_filter_excludes_unassigned(
+    ) -> Result<(), Error> {
+        let relationship_id = Id::new_v4();
+        let session_id = Id::new_v4();
+        let coachee_id = Id::new_v4();
+
+        let coachee_action_id = Id::new_v4();
+        let unassigned_action_id = Id::new_v4();
+        let now = chrono::Utc::now();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![
+                create_test_action(coachee_action_id, session_id),
+                create_test_action(unassigned_action_id, session_id),
+            ]])
+            .append_query_results(vec![vec![entity::actions_users::Model {
+                id: Id::new_v4(),
+                action_id: coachee_action_id,
+                user_id: coachee_id,
+                created_at: now.into(),
+                updated_at: now.into(),
+            }]])
+            .into_connection();
+
+        let params = FindByRelationshipParams {
+            status: None,
+            assignee_filter: AssigneeFilter::Assigned,
+            assignee_user_id: None,
+            caller_visibility: CallerVisibility::CoacheeSelf {
+                user_id: coachee_id,
+            },
+            sort_column: None,
+            sort_order: None,
+        };
+
+        let results = find_by_coaching_relationship(&db, relationship_id, params).await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].action.id, coachee_action_id);
+
+        Ok(())
+    }
+
+    /// Mixed-role: caller is coach in one relationship, coachee in another.
+    /// Per-relationship visibility resolution narrows only the coachee-side
+    /// relationship, leaving the coach-side relationship unrestricted.
+    #[tokio::test]
+    async fn find_by_coach_relationships_mixed_role_resolves_per_relationship() -> Result<(), Error>
+    {
+        let user_id = Id::new_v4();
+        let other_coach = Id::new_v4();
+        let other_coachee = Id::new_v4();
+        let org_id = Id::new_v4();
+
+        let rel_as_coach = Id::new_v4();
+        let rel_as_coachee = Id::new_v4();
+
+        let session_a = Id::new_v4();
+        let session_b = Id::new_v4();
+
+        let action_in_a = Id::new_v4();
+        let action_in_b_user_assigned = Id::new_v4();
+        let action_in_b_other_assigned = Id::new_v4();
+        let now = chrono::Utc::now();
+
+        let relationships = vec![
+            create_test_relationship(rel_as_coach, user_id, other_coachee, org_id),
+            create_test_relationship(rel_as_coachee, other_coach, user_id, org_id),
+        ];
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![create_test_action(action_in_a, session_a)]])
+            .append_query_results(vec![vec![entity::actions_users::Model {
+                id: Id::new_v4(),
+                action_id: action_in_a,
+                user_id: other_coach,
+                created_at: now.into(),
+                updated_at: now.into(),
+            }]])
+            .append_query_results(vec![vec![
+                create_test_action(action_in_b_user_assigned, session_b),
+                create_test_action(action_in_b_other_assigned, session_b),
+            ]])
+            .append_query_results(vec![vec![
+                entity::actions_users::Model {
+                    id: Id::new_v4(),
+                    action_id: action_in_b_user_assigned,
+                    user_id,
+                    created_at: now.into(),
+                    updated_at: now.into(),
+                },
+                entity::actions_users::Model {
+                    id: Id::new_v4(),
+                    action_id: action_in_b_other_assigned,
+                    user_id: other_coach,
+                    created_at: now.into(),
+                    updated_at: now.into(),
+                },
+            ]])
+            .into_connection();
+
+        let params = FindByRelationshipParams {
+            status: None,
+            assignee_filter: AssigneeFilter::All,
+            assignee_user_id: None,
+            caller_visibility: CallerVisibility::default(),
+            sort_column: None,
+            sort_order: None,
+        };
+
+        let result =
+            find_by_coach_relationships(&db, &relationships, params, None, user_id).await?;
+
+        let coach_side = result.get(&other_coachee).expect("coach-side entry");
+        assert_eq!(
+            coach_side.len(),
+            1,
+            "Coach side returns all actions unrestricted"
+        );
+
+        let coachee_side = result.get(&user_id).expect("coachee-side entry");
+        assert_eq!(coachee_side.len(), 1);
+        assert_eq!(coachee_side[0].action.id, action_in_b_user_assigned);
 
         Ok(())
     }

--- a/entity_api/src/action.rs
+++ b/entity_api/src/action.rs
@@ -435,17 +435,21 @@ impl CallerVisibility {
         }
     }
 
-    /// Coach → `Unrestricted`; everyone else (coachee or unknown caller) →
-    /// fail-closed `CoacheeSelf { user_id }`, which produces an empty set for
-    /// non-participants since their id won't match any assignees.
+    /// Resolves the caller's visibility against a specific relationship.
+    /// Coach → `Some(Unrestricted)`, coachee → `Some(CoacheeSelf)`,
+    /// non-participant → `None`. Returning `Option` makes membership an
+    /// explicit precondition: every callsite is forced to handle the
+    /// non-participant case rather than silently inheriting a default.
     pub fn for_relationship(
         user_id: Id,
         relationship: &entity::coaching_relationships::Model,
-    ) -> Self {
+    ) -> Option<Self> {
         if user_id == relationship.coach_id {
-            Self::Unrestricted
+            Some(Self::Unrestricted)
+        } else if user_id == relationship.coachee_id {
+            Some(Self::CoacheeSelf { user_id })
         } else {
-            Self::CoacheeSelf { user_id }
+            None
         }
     }
 }
@@ -556,8 +560,18 @@ pub async fn find_by_user_relationships(
     }
 
     for relationship in relationships {
+        let Some(caller_visibility) =
+            CallerVisibility::for_relationship(caller_user_id, relationship)
+        else {
+            warn!(
+                "find_by_user_relationships: caller {caller_user_id} is not a participant in relationship {}; skipping",
+                relationship.id
+            );
+            continue;
+        };
+
         let relationship_params = FindByRelationshipParams {
-            caller_visibility: CallerVisibility::for_relationship(caller_user_id, relationship),
+            caller_visibility,
             assignee_user_id: assignee_scope.as_ref().map(|scope| match scope {
                 AssigneeScope::Coach => relationship.coach_id,
                 AssigneeScope::Coachee => relationship.coachee_id,
@@ -1489,7 +1503,7 @@ mod tests {
         let rel = create_test_relationship(Id::new_v4(), coach_id, Id::new_v4(), Id::new_v4());
         assert_eq!(
             CallerVisibility::for_relationship(coach_id, &rel),
-            CallerVisibility::Unrestricted
+            Some(CallerVisibility::Unrestricted)
         );
     }
 
@@ -1499,23 +1513,19 @@ mod tests {
         let rel = create_test_relationship(Id::new_v4(), Id::new_v4(), coachee_id, Id::new_v4());
         assert_eq!(
             CallerVisibility::for_relationship(coachee_id, &rel),
-            CallerVisibility::CoacheeSelf {
+            Some(CallerVisibility::CoacheeSelf {
                 user_id: coachee_id
-            }
+            })
         );
     }
 
-    /// Fail-closed: unknown caller resolves to `CoacheeSelf`.
+    /// Non-participant returns `None`, forcing callers to handle the case
+    /// explicitly rather than inheriting a permissive default.
     #[test]
-    fn caller_visibility_for_relationship_unknown_caller_is_fail_closed_coachee_self() {
+    fn caller_visibility_for_relationship_unknown_caller_is_none() {
         let unknown_id = Id::new_v4();
         let rel = create_test_relationship(Id::new_v4(), Id::new_v4(), Id::new_v4(), Id::new_v4());
-        assert_eq!(
-            CallerVisibility::for_relationship(unknown_id, &rel),
-            CallerVisibility::CoacheeSelf {
-                user_id: unknown_id
-            }
-        );
+        assert_eq!(CallerVisibility::for_relationship(unknown_id, &rel), None);
     }
 
     /// Unknown caller through the full filter chain sees only unassigned.

--- a/entity_api/src/action.rs
+++ b/entity_api/src/action.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use sea_orm::{
     entity::prelude::*,
@@ -35,7 +35,7 @@ impl ActionWithAssignees {
     /// Returns assignee IDs that are present in the current list
     /// but were not in `previous_ids` — i.e., the newly added assignees.
     pub fn added_assignees(&self, previous_ids: &[Id]) -> Vec<Id> {
-        let previous: std::collections::HashSet<&Id> = previous_ids.iter().collect();
+        let previous: HashSet<&Id> = previous_ids.iter().collect();
         self.assignee_ids
             .iter()
             .filter(|id| !previous.contains(id))
@@ -402,7 +402,7 @@ pub async fn find_by_user(
 /// Identifies the assignee by their role within a coaching relationship,
 /// or by a specific user ID.
 ///
-/// Used with [`find_by_coach_relationships`] to filter actions based on
+/// Used with [`find_by_user_relationships`] to filter actions based on
 /// who they are assigned to relative to each coaching relationship.
 #[derive(Clone, Debug)]
 pub enum AssigneeScope {
@@ -414,26 +414,18 @@ pub enum AssigneeScope {
     User(Id),
 }
 
-/// Role-aware visibility narrowing applied on top of [`AssigneeFilter`] and
-/// `assignee_user_id` scoping. Coaches see the full relationship action set;
-/// coachees see only actions assigned to themselves or unassigned.
-///
-/// `Unrestricted` is the default so that any callsite building
-/// [`FindByRelationshipParams`] via `..Default::default()` retains the
-/// pre-fix coach-equivalent behavior.
+/// Role-aware visibility narrowing layered on top of [`AssigneeFilter`] and
+/// `assignee_user_id` scoping. `Unrestricted` is the default to preserve
+/// pre-fix coach-equivalent behavior for callsites using `..Default::default()`.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub enum CallerVisibility {
-    /// Full visibility across the relationship (coach caller, or any callsite
-    /// that has already authorized membership and wants the full set).
     #[default]
     Unrestricted,
-    /// Coachee caller: limit to actions assigned to this user, plus unassigned.
+    /// Limits visibility to actions assigned to `user_id` or unassigned.
     CoacheeSelf { user_id: Id },
 }
 
 impl CallerVisibility {
-    /// Predicate: does this caller's visibility allow an action with the given
-    /// assignees through the filter?
     pub fn allows(&self, assignee_ids: &[Id]) -> bool {
         match self {
             Self::Unrestricted => true,
@@ -443,19 +435,17 @@ impl CallerVisibility {
         }
     }
 
-    /// Determines the visibility for a caller against a specific relationship
-    /// by their role in it. Coach role → `Unrestricted`; coachee role →
-    /// `CoacheeSelf`. Falls back to `Unrestricted` for unrecognized users
-    /// (membership is enforced upstream by `CoachingRelationshipAccess` /
-    /// controllers).
+    /// Coach → `Unrestricted`; everyone else (coachee or unknown caller) →
+    /// fail-closed `CoacheeSelf { user_id }`, which produces an empty set for
+    /// non-participants since their id won't match any assignees.
     pub fn for_relationship(
         user_id: Id,
         relationship: &entity::coaching_relationships::Model,
     ) -> Self {
-        match user_id {
-            id if id == relationship.coach_id => Self::Unrestricted,
-            id if id == relationship.coachee_id => Self::CoacheeSelf { user_id: id },
-            _ => Self::Unrestricted,
+        if user_id == relationship.coach_id {
+            Self::Unrestricted
+        } else {
+            Self::CoacheeSelf { user_id }
         }
     }
 }
@@ -548,26 +538,11 @@ pub async fn find_by_coaching_relationship(
     Ok(filtered_actions)
 }
 
-/// Finds actions across multiple coaching relationships, grouped by coachee user ID.
-///
-/// Iterates over the provided relationships, calling `find_by_coaching_relationship`
-/// for each one. Returns a HashMap where every coachee gets a key — even if they
-/// have no matching actions (empty vec).
-///
-/// `caller_user_id` is the authenticated user invoking the query. It determines
-/// the per-relationship [`CallerVisibility`] (coach role → `Unrestricted`,
-/// coachee role → `CoacheeSelf`), which narrows a coachee's visible set to
-/// self-assigned + unassigned actions on a per-relationship basis. This
-/// matters for mixed-role users who are coach in one relationship and coachee
-/// in another within the same organization.
-///
-/// When `assignee_scope` is provided, it is resolved to a concrete user ID per
-/// relationship (Coach → coach_id, Coachee → coachee_id, User(id) → id) and
-/// set on the params so only actions assigned to that user are included.
-///
-/// The `params` are cloned for each relationship query to apply the same filters
-/// across all relationships.
-pub async fn find_by_coach_relationships(
+/// Actions across the supplied relationships, grouped by coachee user id.
+/// `caller_user_id` determines per-relationship [`CallerVisibility`], so
+/// mixed-role callers (coach in one rel, coachee in another) get correct
+/// narrowing per relationship.
+pub async fn find_by_user_relationships(
     db: &DatabaseConnection,
     relationships: &[entity::coaching_relationships::Model],
     params: FindByRelationshipParams,
@@ -1342,9 +1317,9 @@ mod tests {
         Ok(())
     }
 
-    /// Tests that find_by_coach_relationships groups actions by coachee user ID.
+    /// Tests that find_by_user_relationships groups actions by coachee user ID.
     #[tokio::test]
-    async fn find_by_coach_relationships_groups_by_coachee() -> Result<(), Error> {
+    async fn find_by_user_relationships_groups_by_coachee() -> Result<(), Error> {
         let coach_id = Id::new_v4();
         let org_id = Id::new_v4();
 
@@ -1399,7 +1374,7 @@ mod tests {
         };
 
         let result =
-            find_by_coach_relationships(&db, &relationships, params, None, coach_id).await?;
+            find_by_user_relationships(&db, &relationships, params, None, coach_id).await?;
 
         // All 3 coachees should have keys
         assert_eq!(result.len(), 3, "All coachees should have entries");
@@ -1410,10 +1385,10 @@ mod tests {
         Ok(())
     }
 
-    /// Tests that find_by_coach_relationships includes coachees with no actions
+    /// Tests that find_by_user_relationships includes coachees with no actions
     /// as empty arrays in the result.
     #[tokio::test]
-    async fn find_by_coach_relationships_includes_coachees_with_no_actions() -> Result<(), Error> {
+    async fn find_by_user_relationships_includes_coachees_with_no_actions() -> Result<(), Error> {
         let coach_id = Id::new_v4();
         let org_id = Id::new_v4();
         let coachee_1 = Id::new_v4();
@@ -1442,7 +1417,7 @@ mod tests {
         };
 
         let result =
-            find_by_coach_relationships(&db, &relationships, params, None, coach_id).await?;
+            find_by_user_relationships(&db, &relationships, params, None, coach_id).await?;
 
         assert_eq!(result.len(), 2, "Both coachees should have entries");
         assert!(result.get(&coachee_1).unwrap().is_empty());
@@ -1451,10 +1426,10 @@ mod tests {
         Ok(())
     }
 
-    /// Tests that find_by_coach_relationships returns empty HashMap when no
+    /// Tests that find_by_user_relationships returns empty HashMap when no
     /// relationships are provided.
     #[tokio::test]
-    async fn find_by_coach_relationships_returns_empty_for_no_relationships() -> Result<(), Error> {
+    async fn find_by_user_relationships_returns_empty_for_no_relationships() -> Result<(), Error> {
         let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
 
         let params = FindByRelationshipParams {
@@ -1466,7 +1441,7 @@ mod tests {
             sort_order: None,
         };
 
-        let result = find_by_coach_relationships(&db, &[], params, None, Id::new_v4()).await?;
+        let result = find_by_user_relationships(&db, &[], params, None, Id::new_v4()).await?;
 
         assert!(result.is_empty());
 
@@ -1530,6 +1505,76 @@ mod tests {
         );
     }
 
+    /// Fail-closed: unknown caller resolves to `CoacheeSelf`.
+    #[test]
+    fn caller_visibility_for_relationship_unknown_caller_is_fail_closed_coachee_self() {
+        let unknown_id = Id::new_v4();
+        let rel = create_test_relationship(Id::new_v4(), Id::new_v4(), Id::new_v4(), Id::new_v4());
+        assert_eq!(
+            CallerVisibility::for_relationship(unknown_id, &rel),
+            CallerVisibility::CoacheeSelf {
+                user_id: unknown_id
+            }
+        );
+    }
+
+    /// Unknown caller through the full filter chain sees only unassigned.
+    #[tokio::test]
+    async fn find_by_coaching_relationship_unknown_caller_returns_empty() -> Result<(), Error> {
+        let relationship_id = Id::new_v4();
+        let session_id = Id::new_v4();
+        let coach_id = Id::new_v4();
+        let coachee_id = Id::new_v4();
+        let unknown_id = Id::new_v4();
+
+        let coach_action_id = Id::new_v4();
+        let coachee_action_id = Id::new_v4();
+        let unassigned_action_id = Id::new_v4();
+        let now = chrono::Utc::now();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![
+                create_test_action(coach_action_id, session_id),
+                create_test_action(coachee_action_id, session_id),
+                create_test_action(unassigned_action_id, session_id),
+            ]])
+            .append_query_results(vec![vec![
+                entity::actions_users::Model {
+                    id: Id::new_v4(),
+                    action_id: coach_action_id,
+                    user_id: coach_id,
+                    created_at: now.into(),
+                    updated_at: now.into(),
+                },
+                entity::actions_users::Model {
+                    id: Id::new_v4(),
+                    action_id: coachee_action_id,
+                    user_id: coachee_id,
+                    created_at: now.into(),
+                    updated_at: now.into(),
+                },
+            ]])
+            .into_connection();
+
+        let params = FindByRelationshipParams {
+            status: None,
+            assignee_filter: AssigneeFilter::All,
+            assignee_user_id: None,
+            caller_visibility: CallerVisibility::CoacheeSelf {
+                user_id: unknown_id,
+            },
+            sort_column: None,
+            sort_order: None,
+        };
+
+        let results = find_by_coaching_relationship(&db, relationship_id, params).await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].action.id, unassigned_action_id);
+
+        Ok(())
+    }
+
     // ─── Coachee visibility integration tests ─────────────────────────
 
     /// Coachee caller sees self-assigned + unassigned, never coach-assigned.
@@ -1583,8 +1628,7 @@ mod tests {
 
         let results = find_by_coaching_relationship(&db, relationship_id, params).await?;
 
-        let returned_ids: std::collections::HashSet<Id> =
-            results.iter().map(|a| a.action.id).collect();
+        let returned_ids: HashSet<Id> = results.iter().map(|a| a.action.id).collect();
 
         assert_eq!(results.len(), 2);
         assert!(returned_ids.contains(&coachee_action_id));
@@ -1701,7 +1745,7 @@ mod tests {
     /// Per-relationship visibility resolution narrows only the coachee-side
     /// relationship, leaving the coach-side relationship unrestricted.
     #[tokio::test]
-    async fn find_by_coach_relationships_mixed_role_resolves_per_relationship() -> Result<(), Error>
+    async fn find_by_user_relationships_mixed_role_resolves_per_relationship() -> Result<(), Error>
     {
         let user_id = Id::new_v4();
         let other_coach = Id::new_v4();
@@ -1764,8 +1808,7 @@ mod tests {
             sort_order: None,
         };
 
-        let result =
-            find_by_coach_relationships(&db, &relationships, params, None, user_id).await?;
+        let result = find_by_user_relationships(&db, &relationships, params, None, user_id).await?;
 
         let coach_side = result.get(&other_coachee).expect("coach-side entry");
         assert_eq!(

--- a/entity_api/src/action.rs
+++ b/entity_api/src/action.rs
@@ -1641,7 +1641,7 @@ mod tests {
         Ok(())
     }
 
-    /// Coach caller (Unrestricted visibility) sees all three buckets — regression guard.
+    /// Coach caller (Unrestricted visibility) sees all three buckets. Regression guard.
     #[tokio::test]
     async fn find_by_coaching_relationship_coach_visibility_sees_all_three_buckets(
     ) -> Result<(), Error> {

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -140,6 +140,29 @@ pub async fn find_by_coach_and_organization(
     Ok(relationships)
 }
 
+/// Finds coaching relationships where the given user is a participant
+/// (coach OR coachee), within a specific organization.
+pub async fn find_by_user_and_organization(
+    db: &DatabaseConnection,
+    user_id: Id,
+    organization_id: Id,
+) -> Result<Vec<Model>, Error> {
+    let relationships = coaching_relationships::Entity::find()
+        .filter(
+            Condition::all()
+                .add(
+                    Condition::any()
+                        .add(coaching_relationships::Column::CoachId.eq(user_id))
+                        .add(coaching_relationships::Column::CoacheeId.eq(user_id)),
+                )
+                .add(coaching_relationships::Column::OrganizationId.eq(organization_id)),
+        )
+        .all(db)
+        .await?;
+
+    Ok(relationships)
+}
+
 /// Checks if a user is a coach of another user.
 ///
 /// Returns `true` if there exists a coaching relationship where

--- a/web/src/controller/organization/coaching_relationship/actions_controller.rs
+++ b/web/src/controller/organization/coaching_relationship/actions_controller.rs
@@ -55,11 +55,8 @@ fn check_assignee_visibility(
     }
 }
 
-/// GET actions for a coaching relationship. Coachees see only self-assigned
-/// or unassigned actions; the coach's actions are never returned to a
-/// coachee. `assignee=X` is strict-contains (excludes unassigned); omit for
-/// the broad view. Coachee scoping to coach/other-user → 403
-/// `forbidden_assignee_scope`. See `BatchCoacheeActions` v5 contract.
+/// GET actions for a coaching relationship. See `BatchCoacheeActions` v5
+/// for visibility rules and the `assignee` strict-contains semantic.
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships/{relationship_id}/actions",
@@ -71,7 +68,7 @@ fn check_assignee_visibility(
     responses(
         (status = 200, description = "Successfully retrieved actions for the coaching relationship"),
         (status = 401, description = "Unauthorized"),
-        (status = 403, description = "Forbidden — coachee attempted to scope to coach or another user"),
+        (status = 403, description = "Coachee scoped `assignee` to coach or another user"),
         (status = 503, description = "Service temporarily unavailable")
     ),
     security(
@@ -115,12 +112,9 @@ pub async fn read(
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), actions)))
 }
 
-/// GET actions across all coaching relationships the caller participates in,
-/// grouped by coachee user id. `assignee=X` resolves per-relationship and is
-/// strict-contains. Mixed-role users get per-relationship visibility (full
-/// for coach side, narrowed for coachee side). Coachee-only callers scoping
-/// to non-self → 403; coach-anywhere callers bypass that guard. See
-/// `BatchCoacheeActions` v5 contract.
+/// GET actions across all participant relationships, grouped by coachee
+/// user id. See `BatchCoacheeActions` v5 for visibility rules and the
+/// `assignee` strict-contains semantic.
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships/actions",
@@ -131,7 +125,7 @@ pub async fn read(
     responses(
         (status = 200, description = "Successfully retrieved batch actions"),
         (status = 401, description = "Unauthorized"),
-        (status = 403, description = "Forbidden — coachee attempted to scope to coach or another user"),
+        (status = 403, description = "Coachee scoped `assignee` to coach or another user"),
         (status = 503, description = "Service temporarily unavailable")
     ),
     security(

--- a/web/src/controller/organization/coaching_relationship/actions_controller.rs
+++ b/web/src/controller/organization/coaching_relationship/actions_controller.rs
@@ -92,7 +92,11 @@ pub async fn read(
     );
 
     let assignee_scope = params.assignee_scope();
-    let caller_visibility = ActionApi::CallerVisibility::for_relationship(user.id, &relationship);
+    // `CoachingRelationshipAccess` has already verified membership, so this
+    // `ok_or` should be unreachable. Fail closed to 401 if the invariant is
+    // ever violated rather than silently inheriting a permissive default.
+    let caller_visibility = ActionApi::CallerVisibility::for_relationship(user.id, &relationship)
+        .ok_or(Error::Web(WebErrorKind::Auth))?;
     check_assignee_visibility(user.id, &caller_visibility, assignee_scope.as_ref())?;
 
     let mut query_params = params.into_query_params();

--- a/web/src/controller/organization/coaching_relationship/actions_controller.rs
+++ b/web/src/controller/organization/coaching_relationship/actions_controller.rs
@@ -55,8 +55,11 @@ fn check_assignee_visibility(
     }
 }
 
-/// GET actions for a coaching relationship. See `BatchCoacheeActions` v5
-/// for visibility rules and the `assignee` strict-contains semantic.
+/// GET actions for a coaching relationship.
+///
+/// Coachees see only actions assigned to themselves or unassigned.
+/// `assignee=X` filters strictly to actions whose assignees contain X
+/// (excludes unassigned); omit it for the broad view.
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships/{relationship_id}/actions",
@@ -113,8 +116,8 @@ pub async fn read(
 }
 
 /// GET actions across all participant relationships, grouped by coachee
-/// user id. See `BatchCoacheeActions` v5 for visibility rules and the
-/// `assignee` strict-contains semantic.
+/// user id. Visibility narrows per-relationship by the caller's role
+/// (full for coach side, self-or-unassigned for coachee side).
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships/actions",

--- a/web/src/controller/organization/coaching_relationship/actions_controller.rs
+++ b/web/src/controller/organization/coaching_relationship/actions_controller.rs
@@ -11,15 +11,23 @@ use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use domain::{action as ActionApi, coaching_relationship as CoachingRelationshipApi, Id};
+use domain::{
+    action as ActionApi, coaching_relationship as CoachingRelationshipApi, coaching_relationships,
+    Id,
+};
 use service::config::ApiVersion;
 
 use log::*;
 
-/// Returns an error response if the caller is not permitted to scope the
-/// returned action set to the requested `assignee`. Coachees may only ask
-/// for their own actions (`assignee=coachee` or `assignee=<self.id>`);
-/// anything else is a 403.
+/// Used by the batch handler to gate the HTTP-layer `assignee` scope check:
+/// coach-anywhere callers bypass it; coachee-only callers go through it.
+fn caller_is_coach_in_any(relationships: &[coaching_relationships::Model], user_id: Id) -> bool {
+    relationships
+        .iter()
+        .any(|relationship| relationship.coach_id == user_id)
+}
+
+/// 403s a coachee caller that scopes `assignee` to anyone other than self.
 fn check_assignee_visibility(
     caller_id: Id,
     caller_visibility: &ActionApi::CallerVisibility,
@@ -47,27 +55,11 @@ fn check_assignee_visibility(
     }
 }
 
-/// GET actions for a specific coaching relationship.
-///
-/// The `CoachingRelationshipAccess` extractor verifies that the authenticated
-/// user is a participant (coach or coachee) in the relationship.
-///
-/// Supports an optional `assignee` query parameter with **strict-contains**
-/// semantics — i.e., the action's assignees must contain the resolved user id.
-/// Unassigned actions are *excluded* whenever `assignee` is present:
-/// - `?assignee=coach` — actions assigned to the coach of this relationship
-/// - `?assignee=coachee` — actions assigned to the coachee of this relationship
-/// - `?assignee={user_id}` — actions assigned to a specific user
-/// - omit the param to get the broad view (no scope filter); the
-///   `caller_visibility` predicate alone narrows the result. **For a coachee
-///   caller wanting their own broad view (self-assigned ∪ unassigned), omit
-///   `assignee` rather than sending `assignee=coachee`** — the strict-contains
-///   semantic would otherwise exclude unassigned actions.
-///
-/// Coachee callers are limited to actions assigned to themselves or
-/// unassigned; the coach's assigned actions are never returned to a coachee.
-/// Requesting `assignee=coach` (or any user other than self) as a coachee
-/// returns 403 with `error: "forbidden_assignee_scope"`.
+/// GET actions for a coaching relationship. Coachees see only self-assigned
+/// or unassigned actions; the coach's actions are never returned to a
+/// coachee. `assignee=X` is strict-contains (excludes unassigned); omit for
+/// the broad view. Coachee scoping to coach/other-user → 403
+/// `forbidden_assignee_scope`. See `BatchCoacheeActions` v5 contract.
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships/{relationship_id}/actions",
@@ -123,37 +115,12 @@ pub async fn read(
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), actions)))
 }
 
-/// GET actions across all coaching relationships where the authenticated user
-/// is a participant (coach or coachee), grouped by coachee user ID.
-///
-/// Supports an optional `assignee` query parameter with **strict-contains**
-/// semantics — the action's assignees must contain the resolved user id, so
-/// unassigned actions are excluded whenever `assignee` is present. The
-/// resolution is per-relationship (the `coach`/`coachee` role strings resolve
-/// to that specific relationship's `coach_id`/`coachee_id`):
-/// - `?assignee=coach` — actions assigned to the coach in each relationship
-/// - `?assignee=coachee` — actions assigned to the coachee in each relationship
-/// - `?assignee={user_id}` — actions assigned to a specific user (UUID form;
-///   supported for completeness but not invoked by the FE today)
-/// - omit the param to get the broad view (no scope filter); the
-///   `caller_visibility` predicate alone narrows the result.
-///
-/// **FE guidance — when to omit `assignee`:** for the coach's "All" tab and
-/// for any coachee caller's broad view, omit the param. Sending
-/// `assignee=coachee` from a coachee resolves to their own user id and the
-/// strict-contains semantic then excludes unassigned actions — by design, but
-/// usually not what a coachee broad view wants. For coach role-toggle tabs
-/// ("Coach Actions" / "Coachee Actions") that want a strict-scoped slice,
-/// include the param as usual.
-///
-/// Coachee callers are limited to actions assigned to themselves or unassigned
-/// in each relationship; the coach's assigned actions are never returned.
-/// Coachees may only pass `assignee=coachee` or `assignee=<self.id>` —
-/// requesting any other assignee scope returns 403 with
-/// `error: "forbidden_assignee_scope"`. For users who are coach in some
-/// relationships and coachee in others within the same organization,
-/// visibility is determined per-relationship based on the caller's role in
-/// each one.
+/// GET actions across all coaching relationships the caller participates in,
+/// grouped by coachee user id. `assignee=X` resolves per-relationship and is
+/// strict-contains. Mixed-role users get per-relationship visibility (full
+/// for coach side, narrowed for coachee side). Coachee-only callers scoping
+/// to non-self → 403; coach-anywhere callers bypass that guard. See
+/// `BatchCoacheeActions` v5 contract.
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships/actions",
@@ -197,16 +164,12 @@ pub async fn index(
     // relationships. If the caller is *only* a coachee across the returned
     // relationships, an `assignee=coach` request is forbidden. If they are a
     // coach in at least one relationship, the assignee scope is permitted.
-    let caller_is_coach_anywhere = relationships
-        .iter()
-        .any(|relationship| relationship.coach_id == user.id);
-
-    if !caller_is_coach_anywhere {
+    if !caller_is_coach_in_any(&relationships, user.id) {
         let coachee_visibility = ActionApi::CallerVisibility::CoacheeSelf { user_id: user.id };
         check_assignee_visibility(user.id, &coachee_visibility, assignee_scope.as_ref())?;
     }
 
-    let coachee_actions = ActionApi::find_by_coach_relationships(
+    let coachee_actions = ActionApi::find_by_user_relationships(
         app_state.db_conn_ref(),
         &relationships,
         query_params,
@@ -230,6 +193,68 @@ mod tests {
             Err(Error::Web(WebErrorKind::ForbiddenAssigneeScope)) => {}
             other => panic!("expected ForbiddenAssigneeScope, got: {other:?}"),
         }
+    }
+
+    fn make_relationship(coach_id: Id, coachee_id: Id) -> coaching_relationships::Model {
+        let now = chrono::Utc::now().fixed_offset();
+        coaching_relationships::Model {
+            id: Id::new_v4(),
+            organization_id: Id::new_v4(),
+            coach_id,
+            coachee_id,
+            slug: "test".to_string(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    // ─── caller_is_coach_in_any tests ─────────────────────────────────
+
+    #[test]
+    fn caller_is_coach_in_any_empty_relationships_is_false() {
+        let user_id = Id::new_v4();
+        assert!(!caller_is_coach_in_any(&[], user_id));
+    }
+
+    #[test]
+    fn caller_is_coach_in_any_only_coachee_is_false() {
+        let user_id = Id::new_v4();
+        let other = Id::new_v4();
+        let rels = vec![
+            make_relationship(other, user_id),
+            make_relationship(other, user_id),
+        ];
+        assert!(!caller_is_coach_in_any(&rels, user_id));
+    }
+
+    #[test]
+    fn caller_is_coach_in_any_coach_in_at_least_one_is_true() {
+        let user_id = Id::new_v4();
+        let other = Id::new_v4();
+        let rels = vec![
+            make_relationship(other, user_id), // coachee here
+            make_relationship(user_id, other), // coach here
+        ];
+        assert!(caller_is_coach_in_any(&rels, user_id));
+    }
+
+    #[test]
+    fn caller_is_coach_in_any_coach_in_all_is_true() {
+        let user_id = Id::new_v4();
+        let rels = vec![
+            make_relationship(user_id, Id::new_v4()),
+            make_relationship(user_id, Id::new_v4()),
+        ];
+        assert!(caller_is_coach_in_any(&rels, user_id));
+    }
+
+    #[test]
+    fn caller_is_coach_in_any_unrelated_user_is_false() {
+        let user_id = Id::new_v4();
+        let other_coach = Id::new_v4();
+        let other_coachee = Id::new_v4();
+        let rels = vec![make_relationship(other_coach, other_coachee)];
+        assert!(!caller_is_coach_in_any(&rels, user_id));
     }
 
     #[test]

--- a/web/src/controller/organization/coaching_relationship/actions_controller.rs
+++ b/web/src/controller/organization/coaching_relationship/actions_controller.rs
@@ -115,9 +115,10 @@ pub async fn read(
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), actions)))
 }
 
-/// GET actions across all participant relationships, grouped by coachee
-/// user id. Visibility narrows per-relationship by the caller's role
-/// (full for coach side, self-or-unassigned for coachee side).
+/// GET actions across all participant relationships, grouped by coachee user id.
+///
+/// Visibility narrows per-relationship by the caller's role (full for coach
+/// side, self-or-unassigned for coachee side).
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships/actions",

--- a/web/src/controller/organization/coaching_relationship/actions_controller.rs
+++ b/web/src/controller/organization/coaching_relationship/actions_controller.rs
@@ -1,4 +1,5 @@
 use crate::controller::ApiResponse;
+use crate::error::{Error as WebError, WebErrorKind};
 use crate::extractors::coaching_relationship_access::CoachingRelationshipAccess;
 use crate::extractors::organization_member_access::OrganizationMemberAccess;
 use crate::extractors::{
@@ -10,15 +11,63 @@ use axum::extract::{Query, State};
 use axum::http::StatusCode;
 use axum::response::IntoResponse;
 use axum::Json;
-use domain::{action as ActionApi, coaching_relationship as CoachingRelationshipApi};
+use domain::{action as ActionApi, coaching_relationship as CoachingRelationshipApi, Id};
 use service::config::ApiVersion;
 
 use log::*;
+
+/// Returns an error response if the caller is not permitted to scope the
+/// returned action set to the requested `assignee`. Coachees may only ask
+/// for their own actions (`assignee=coachee` or `assignee=<self.id>`);
+/// anything else is a 403.
+fn check_assignee_visibility(
+    caller_id: Id,
+    caller_visibility: &ActionApi::CallerVisibility,
+    assignee_scope: Option<&ActionApi::AssigneeScope>,
+) -> Result<(), Error> {
+    let coachee_self_id = match caller_visibility {
+        ActionApi::CallerVisibility::Unrestricted => return Ok(()),
+        ActionApi::CallerVisibility::CoacheeSelf { user_id } => *user_id,
+    };
+
+    let permitted = match assignee_scope {
+        None => true,
+        Some(ActionApi::AssigneeScope::Coachee) => true,
+        Some(ActionApi::AssigneeScope::User(id)) => *id == coachee_self_id,
+        Some(ActionApi::AssigneeScope::Coach) => false,
+    };
+
+    if permitted {
+        Ok(())
+    } else {
+        warn!(
+            "Coachee caller {caller_id} attempted to scope assignee outside their visibility: {assignee_scope:?}"
+        );
+        Err(WebError::Web(WebErrorKind::ForbiddenAssigneeScope))
+    }
+}
 
 /// GET actions for a specific coaching relationship.
 ///
 /// The `CoachingRelationshipAccess` extractor verifies that the authenticated
 /// user is a participant (coach or coachee) in the relationship.
+///
+/// Supports an optional `assignee` query parameter with **strict-contains**
+/// semantics — i.e., the action's assignees must contain the resolved user id.
+/// Unassigned actions are *excluded* whenever `assignee` is present:
+/// - `?assignee=coach` — actions assigned to the coach of this relationship
+/// - `?assignee=coachee` — actions assigned to the coachee of this relationship
+/// - `?assignee={user_id}` — actions assigned to a specific user
+/// - omit the param to get the broad view (no scope filter); the
+///   `caller_visibility` predicate alone narrows the result. **For a coachee
+///   caller wanting their own broad view (self-assigned ∪ unassigned), omit
+///   `assignee` rather than sending `assignee=coachee`** — the strict-contains
+///   semantic would otherwise exclude unassigned actions.
+///
+/// Coachee callers are limited to actions assigned to themselves or
+/// unassigned; the coach's assigned actions are never returned to a coachee.
+/// Requesting `assignee=coach` (or any user other than self) as a coachee
+/// returns 403 with `error: "forbidden_assignee_scope"`.
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships/{relationship_id}/actions",
@@ -30,6 +79,7 @@ use log::*;
     responses(
         (status = 200, description = "Successfully retrieved actions for the coaching relationship"),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden — coachee attempted to scope to coach or another user"),
         (status = 503, description = "Service temporarily unavailable")
     ),
     security(
@@ -38,15 +88,23 @@ use log::*;
 )]
 pub async fn read(
     CompareApiVersion(_v): CompareApiVersion,
+    AuthenticatedUser(user): AuthenticatedUser,
     OrganizationMemberAccess(_organization_id): OrganizationMemberAccess,
     CoachingRelationshipAccess(relationship): CoachingRelationshipAccess,
     State(app_state): State<AppState>,
     Query(params): Query<IndexParams>,
 ) -> Result<impl IntoResponse, Error> {
-    debug!("GET actions for coaching relationship: {}", relationship.id);
+    debug!(
+        "GET actions for coaching relationship {} (caller {})",
+        relationship.id, user.id
+    );
 
     let assignee_scope = params.assignee_scope();
+    let caller_visibility = ActionApi::CallerVisibility::for_relationship(user.id, &relationship);
+    check_assignee_visibility(user.id, &caller_visibility, assignee_scope.as_ref())?;
+
     let mut query_params = params.into_query_params();
+    query_params.caller_visibility = caller_visibility;
 
     // Resolve role-based assignee scope to a concrete user ID
     query_params.assignee_user_id = assignee_scope.map(|scope| match scope {
@@ -66,13 +124,36 @@ pub async fn read(
 }
 
 /// GET actions across all coaching relationships where the authenticated user
-/// is the coach, grouped by coachee user ID.
+/// is a participant (coach or coachee), grouped by coachee user ID.
 ///
-/// Supports an optional `assignee` query parameter to filter by who the actions
-/// are assigned to:
+/// Supports an optional `assignee` query parameter with **strict-contains**
+/// semantics — the action's assignees must contain the resolved user id, so
+/// unassigned actions are excluded whenever `assignee` is present. The
+/// resolution is per-relationship (the `coach`/`coachee` role strings resolve
+/// to that specific relationship's `coach_id`/`coachee_id`):
 /// - `?assignee=coach` — actions assigned to the coach in each relationship
 /// - `?assignee=coachee` — actions assigned to the coachee in each relationship
-/// - `?assignee={user_id}` — actions assigned to a specific user
+/// - `?assignee={user_id}` — actions assigned to a specific user (UUID form;
+///   supported for completeness but not invoked by the FE today)
+/// - omit the param to get the broad view (no scope filter); the
+///   `caller_visibility` predicate alone narrows the result.
+///
+/// **FE guidance — when to omit `assignee`:** for the coach's "All" tab and
+/// for any coachee caller's broad view, omit the param. Sending
+/// `assignee=coachee` from a coachee resolves to their own user id and the
+/// strict-contains semantic then excludes unassigned actions — by design, but
+/// usually not what a coachee broad view wants. For coach role-toggle tabs
+/// ("Coach Actions" / "Coachee Actions") that want a strict-scoped slice,
+/// include the param as usual.
+///
+/// Coachee callers are limited to actions assigned to themselves or unassigned
+/// in each relationship; the coach's assigned actions are never returned.
+/// Coachees may only pass `assignee=coachee` or `assignee=<self.id>` —
+/// requesting any other assignee scope returns 403 with
+/// `error: "forbidden_assignee_scope"`. For users who are coach in some
+/// relationships and coachee in others within the same organization,
+/// visibility is determined per-relationship based on the caller's role in
+/// each one.
 #[utoipa::path(
     get,
     path = "/organizations/{organization_id}/coaching_relationships/actions",
@@ -83,6 +164,7 @@ pub async fn read(
     responses(
         (status = 200, description = "Successfully retrieved batch actions"),
         (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Forbidden — coachee attempted to scope to coach or another user"),
         (status = 503, description = "Service temporarily unavailable")
     ),
     security(
@@ -97,25 +179,39 @@ pub async fn index(
     Query(params): Query<IndexParams>,
 ) -> Result<impl IntoResponse, Error> {
     debug!(
-        "GET batch actions for coach {} in organization {}",
+        "GET batch actions for user {} in organization {}",
         user.id, organization_id
     );
 
     let assignee_scope = params.assignee_scope();
     let query_params = params.into_query_params();
 
-    let relationships = CoachingRelationshipApi::find_by_coach_and_organization(
+    let relationships = CoachingRelationshipApi::find_by_user_and_organization(
         app_state.db_conn_ref(),
         user.id,
         organization_id,
     )
     .await?;
 
+    // Authorize the assignee scope against the caller's role in any of their
+    // relationships. If the caller is *only* a coachee across the returned
+    // relationships, an `assignee=coach` request is forbidden. If they are a
+    // coach in at least one relationship, the assignee scope is permitted.
+    let caller_is_coach_anywhere = relationships
+        .iter()
+        .any(|relationship| relationship.coach_id == user.id);
+
+    if !caller_is_coach_anywhere {
+        let coachee_visibility = ActionApi::CallerVisibility::CoacheeSelf { user_id: user.id };
+        check_assignee_visibility(user.id, &coachee_visibility, assignee_scope.as_ref())?;
+    }
+
     let coachee_actions = ActionApi::find_by_coach_relationships(
         app_state.db_conn_ref(),
         &relationships,
         query_params,
         assignee_scope,
+        user.id,
     )
     .await?;
 
@@ -123,4 +219,88 @@ pub async fn index(
         StatusCode::OK.into(),
         serde_json::json!({ "coachee_actions": coachee_actions }),
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assert_forbidden(result: Result<(), Error>) {
+        match result {
+            Err(Error::Web(WebErrorKind::ForbiddenAssigneeScope)) => {}
+            other => panic!("expected ForbiddenAssigneeScope, got: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unrestricted_caller_allowed_with_any_assignee_scope() {
+        let caller = Id::new_v4();
+        let vis = ActionApi::CallerVisibility::Unrestricted;
+        assert!(check_assignee_visibility(caller, &vis, None).is_ok());
+        assert!(
+            check_assignee_visibility(caller, &vis, Some(&ActionApi::AssigneeScope::Coach)).is_ok()
+        );
+        assert!(
+            check_assignee_visibility(caller, &vis, Some(&ActionApi::AssigneeScope::Coachee))
+                .is_ok()
+        );
+        assert!(check_assignee_visibility(
+            caller,
+            &vis,
+            Some(&ActionApi::AssigneeScope::User(Id::new_v4()))
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn coachee_self_allowed_when_assignee_omitted() {
+        let caller = Id::new_v4();
+        let vis = ActionApi::CallerVisibility::CoacheeSelf { user_id: caller };
+        assert!(check_assignee_visibility(caller, &vis, None).is_ok());
+    }
+
+    #[test]
+    fn coachee_self_allowed_with_coachee_scope() {
+        let caller = Id::new_v4();
+        let vis = ActionApi::CallerVisibility::CoacheeSelf { user_id: caller };
+        assert!(
+            check_assignee_visibility(caller, &vis, Some(&ActionApi::AssigneeScope::Coachee))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn coachee_self_allowed_with_own_uuid_scope() {
+        let caller = Id::new_v4();
+        let vis = ActionApi::CallerVisibility::CoacheeSelf { user_id: caller };
+        assert!(check_assignee_visibility(
+            caller,
+            &vis,
+            Some(&ActionApi::AssigneeScope::User(caller))
+        )
+        .is_ok());
+    }
+
+    #[test]
+    fn coachee_self_forbidden_with_coach_scope() {
+        let caller = Id::new_v4();
+        let vis = ActionApi::CallerVisibility::CoacheeSelf { user_id: caller };
+        assert_forbidden(check_assignee_visibility(
+            caller,
+            &vis,
+            Some(&ActionApi::AssigneeScope::Coach),
+        ));
+    }
+
+    #[test]
+    fn coachee_self_forbidden_with_other_user_uuid_scope() {
+        let caller = Id::new_v4();
+        let other = Id::new_v4();
+        let vis = ActionApi::CallerVisibility::CoacheeSelf { user_id: caller };
+        assert_forbidden(check_assignee_visibility(
+            caller,
+            &vis,
+            Some(&ActionApi::AssigneeScope::User(other)),
+        ));
+    }
 }

--- a/web/src/error.rs
+++ b/web/src/error.rs
@@ -25,6 +25,11 @@ pub enum Error {
 pub enum WebErrorKind {
     Input,
     Auth,
+    /// Caller (typically a coachee) attempted to scope `assignee` to a value
+    /// outside their visibility (e.g. `assignee=coach`, or `assignee=<uuid>`
+    /// for any user other than themselves). 403 Forbidden with a specific
+    /// discriminator so the FE can branch deterministically.
+    ForbiddenAssigneeScope,
     Other,
 }
 
@@ -204,6 +209,17 @@ impl Error {
             WebErrorKind::Auth => {
                 warn!("WebErrorKind::Auth: Responding with 401 Unauthorized. Error: {self:?}");
                 (StatusCode::UNAUTHORIZED, "UNAUTHORIZED").into_response()
+            }
+            WebErrorKind::ForbiddenAssigneeScope => {
+                warn!(
+                    "WebErrorKind::ForbiddenAssigneeScope: Responding with 403 Forbidden. Error: {self:?}"
+                );
+                let body = serde_json::json!({
+                    "status_code": 403,
+                    "error": "forbidden_assignee_scope",
+                    "message": "Caller is not permitted to scope actions to that assignee.",
+                });
+                (StatusCode::FORBIDDEN, Json(body)).into_response()
             }
             WebErrorKind::Other => {
                 warn!(

--- a/web/src/params/coaching_relationship/action.rs
+++ b/web/src/params/coaching_relationship/action.rs
@@ -82,8 +82,7 @@ pub(crate) struct IndexParams {
     /// PascalCase status: `NotStarted`, `InProgress`, `Completed`, `OnHold`, `WontDo`.
     pub(crate) status: Option<Status>,
     /// Strict-contains scope: `coach`, `coachee`, or a user UUID. Excludes
-    /// unassigned when present. Omit for the broad view (see
-    /// `BatchCoacheeActions` v5).
+    /// unassigned when present. Omit for the broad view.
     pub(crate) assignee: Option<AssigneeScope>,
     /// Defaults to `due_by` when any sort param is provided.
     pub(crate) sort_by: Option<SortField>,

--- a/web/src/params/coaching_relationship/action.rs
+++ b/web/src/params/coaching_relationship/action.rs
@@ -73,36 +73,21 @@ pub(crate) enum SortField {
     UpdatedAt,
 }
 
-/// Query parameters shared by coaching relationship action endpoints:
-/// - `GET /organizations/{org_id}/coaching_relationships/{rel_id}/actions`
-/// - `GET /organizations/{org_id}/coaching_relationships/actions`
+/// Shared query parameters for both coaching relationship action endpoints.
 #[derive(Debug, Deserialize, IntoParams)]
 pub(crate) struct IndexParams {
-    /// Optional: filter by assignment status. `all` (default) returns
-    /// everything visible to the caller; `assigned` returns only actions
-    /// with ≥1 assignee; `unassigned` returns only actions with 0 assignees.
-    /// Orthogonal to `assignee` (which scopes to a specific party).
+    /// `all` (default), `assigned`, or `unassigned`. Orthogonal to `assignee`.
     #[serde(default)]
     pub(crate) assignee_filter: AssigneeFilter,
-    /// Optional: filter by action lifecycle status (PascalCase: `NotStarted`,
-    /// `InProgress`, `Completed`, `OnHold`, `WontDo`).
+    /// PascalCase status: `NotStarted`, `InProgress`, `Completed`, `OnHold`, `WontDo`.
     pub(crate) status: Option<Status>,
-    /// Optional: filter actions by assignee with **strict-contains** semantics
-    /// (the action's assignees must contain the resolved user id; unassigned
-    /// actions are excluded whenever this param is present). Accepts three
-    /// forms: `coach` / `coachee` (case-insensitive role strings that resolve
-    /// per-relationship to the relationship's `coach_id`/`coachee_id`), or a
-    /// UUID string for a specific user. **Omit this param for the broad view**
-    /// — visibility narrowing alone determines what each caller can see, and
-    /// omitting is the correct shape for the coach's "All" tab and for any
-    /// coachee caller's own page. Coachee callers may only pass `coachee` or
-    /// their own UUID; other values return 403 `forbidden_assignee_scope`.
+    /// Strict-contains scope: `coach`, `coachee`, or a user UUID. Excludes
+    /// unassigned when present. Omit for the broad view (see
+    /// `BatchCoacheeActions` v5).
     pub(crate) assignee: Option<AssigneeScope>,
-    /// Optional: field to sort by. Defaults to `due_by` when any sort param
-    /// is provided.
+    /// Defaults to `due_by` when any sort param is provided.
     pub(crate) sort_by: Option<SortField>,
-    /// Optional: sort direction (`asc` / `desc`). Defaults to `asc` when any
-    /// sort param is provided.
+    /// Defaults to `asc` when any sort param is provided.
     pub(crate) sort_order: Option<SortOrder>,
 }
 

--- a/web/src/params/coaching_relationship/action.rs
+++ b/web/src/params/coaching_relationship/action.rs
@@ -78,16 +78,31 @@ pub(crate) enum SortField {
 /// - `GET /organizations/{org_id}/coaching_relationships/actions`
 #[derive(Debug, Deserialize, IntoParams)]
 pub(crate) struct IndexParams {
-    /// Optional: filter by assignee status (all, assigned, unassigned)
+    /// Optional: filter by assignment status. `all` (default) returns
+    /// everything visible to the caller; `assigned` returns only actions
+    /// with ≥1 assignee; `unassigned` returns only actions with 0 assignees.
+    /// Orthogonal to `assignee` (which scopes to a specific party).
     #[serde(default)]
     pub(crate) assignee_filter: AssigneeFilter,
-    /// Optional: filter by action status
+    /// Optional: filter by action lifecycle status (PascalCase: `NotStarted`,
+    /// `InProgress`, `Completed`, `OnHold`, `WontDo`).
     pub(crate) status: Option<Status>,
-    /// Optional: filter by who actions are assigned to (coach, coachee, or user UUID)
+    /// Optional: filter actions by assignee with **strict-contains** semantics
+    /// (the action's assignees must contain the resolved user id; unassigned
+    /// actions are excluded whenever this param is present). Accepts three
+    /// forms: `coach` / `coachee` (case-insensitive role strings that resolve
+    /// per-relationship to the relationship's `coach_id`/`coachee_id`), or a
+    /// UUID string for a specific user. **Omit this param for the broad view**
+    /// — visibility narrowing alone determines what each caller can see, and
+    /// omitting is the correct shape for the coach's "All" tab and for any
+    /// coachee caller's own page. Coachee callers may only pass `coachee` or
+    /// their own UUID; other values return 403 `forbidden_assignee_scope`.
     pub(crate) assignee: Option<AssigneeScope>,
-    /// Optional: field to sort by
+    /// Optional: field to sort by. Defaults to `due_by` when any sort param
+    /// is provided.
     pub(crate) sort_by: Option<SortField>,
-    /// Optional: sort direction
+    /// Optional: sort direction (`asc` / `desc`). Defaults to `asc` when any
+    /// sort param is provided.
     pub(crate) sort_order: Option<SortOrder>,
 }
 
@@ -152,6 +167,7 @@ impl IndexParams {
             status: params.status,
             assignee_filter: params.assignee_filter.into(),
             assignee_user_id: None,
+            caller_visibility: action::CallerVisibility::default(),
             sort_column,
             sort_order,
         }


### PR DESCRIPTION
## Description

Fixes the empty `/actions` board for coachees. The batch endpoint (`GET /organizations/{org_id}/coaching_relationships/actions`) was scoped to coach-only callers via `find_by_coach_and_organization`, returning an empty `coachee_actions` map to any coachee. This PR broadens the endpoint to coach-or-coachee participants and layers in a role-aware `CallerVisibility` predicate so coachees see only self-assigned + unassigned actions — the coach's assigned actions never leak to a coachee under any filter combination. Coach behavior is bit-identical to v3.

Wire contract published as `BatchCoacheeActions` v5 on the coordinator board. FE coordinates with a companion PR (4-line change in `use-actions-fetch.ts` to drop `assignee=coachee` for the coachee broad view, per the Option B semantic alignment).

### Changes

* New `entity_api::coaching_relationship::find_by_user_and_organization` helper (coach OR coachee in an organization)
* New `entity_api::action::CallerVisibility` enum with `allows` / `for_relationship` predicate — layered on the filter chain at the same `then_some` site as `passes_filter` / `passes_scope`
* `find_by_coach_relationships` now takes `caller_user_id` and resolves visibility per-relationship inside the batch loop (correct for mixed-role users)
* New `WebErrorKind::ForbiddenAssigneeScope` → 403 with `error: "forbidden_assignee_scope"` (defense-in-depth against non-FE callers; specific-discriminator shape matches existing convention)
* Both `read` and `index` controllers: `check_assignee_visibility` guard + `caller_visibility` wiring; batch handler swaps to the new participant lookup
* utoipa annotations + `IndexParams` field docs updated to document the omit-`assignee`-for-broad-view convention and the strict-contains semantic

### Testing Strategy

* `cargo test -p entity_api --features mock action::` — 36 tests pass (10 new + 26 regression-guarded). New tests cover `CallerVisibility` units, coachee visibility filtering coach actions (security property), coach three-bucket regression guard, and mixed-role per-relationship resolution.
* `cargo test -p web actions_controller::` — 6 tests pass covering every `assignee` value × caller role combination of the 403 guard.
* `cargo fmt` and `cargo clippy --workspace --all-targets --features mock` clean on changed files.
* FE-side verification per coordinator question `playwright_e2e_coachee_actions_visibility_fix`: two canary Playwright specs in the FE companion PR, manual pass against Caleb Bourg (coachee), and `curl -i` 403 probes posted to the PR thread for the `assignee=coach` / `assignee=<other-uuid>` from a coachee cases.

### Concerns

* **Coordinated merge timing.** Per coordinator question `actions_endpoint_coachee_assignee_param_semantics` Q4, BE merges first and FE merges within ≤15 min to minimize a brief local-dev-only window where coachees on `/actions` would see only self-assigned (not self + unassigned). No production or PR-preview environment is affected — neither auto-deploys from `main`.