### PR TITLE
Fix PG enum cast in atomic claims, clean up webhook error logging

### DIFF
--- a/domain/src/error.rs
+++ b/domain/src/error.rs
@@ -72,7 +72,11 @@ pub enum ExternalErrorKind {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Domain Error: {self:?}")
+        write!(f, "{:?}", self.error_kind)?;
+        if let Some(ref src) = self.source {
+            write!(f, ": {src}")?;
+        }
+        Ok(())
     }
 }
 

--- a/entity_api/src/error.rs
+++ b/entity_api/src/error.rs
@@ -45,7 +45,11 @@ pub enum EntityApiErrorKind {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "Entity API Error: {self:?}")
+        write!(f, "{:?}", self.error_kind)?;
+        if let Some(ref src) = self.source {
+            write!(f, ": {src}")?;
+        }
+        Ok(())
     }
 }
 

--- a/entity_api/src/meeting_recording.rs
+++ b/entity_api/src/meeting_recording.rs
@@ -5,8 +5,15 @@ use log::debug;
 use sea_orm::{
     entity::prelude::*,
     ActiveValue::{Set, Unchanged},
-    DatabaseConnection, Order, QueryOrder, TryIntoModel,
+    DatabaseConnection, IntoActiveModel, Order, QueryOrder, QuerySelect, TransactionError,
+    TransactionTrait, TryIntoModel,
 };
+
+const TERMINAL_RECORDING_STATUSES: &[MeetingRecordingStatus] = &[
+    MeetingRecordingStatus::Completed,
+    MeetingRecordingStatus::Failed,
+    MeetingRecordingStatus::Cancelled,
+];
 
 /// Creates a new meeting recording record
 pub async fn create(db: &DatabaseConnection, model: Model) -> Result<Model, Error> {
@@ -57,27 +64,36 @@ pub async fn find_by_bot_id(db: &DatabaseConnection, bot_id: &str) -> Result<Opt
 
 /// Atomically transitions a recording to `Completed`, but only if it is not already
 /// in a terminal state (`completed`, `failed`, or `cancelled`). Returns `true` if the
-/// transition succeeded — the caller won the race and should proceed with transcription.
+/// transition succeeded; the caller won the race and should proceed with transcription.
 /// Returns `false` if the recording was already terminal and the caller should skip.
 pub async fn try_claim_completed(db: &DatabaseConnection, id: Id) -> Result<bool, Error> {
-    let result = Entity::update_many()
-        .col_expr(
-            Column::Status,
-            Expr::value(MeetingRecordingStatus::Completed),
-        )
-        .col_expr(
-            Column::UpdatedAt,
-            Expr::value(chrono::Utc::now().fixed_offset()),
-        )
-        .filter(Column::Id.eq(id))
-        .filter(Column::Status.is_not_in([
-            MeetingRecordingStatus::Completed,
-            MeetingRecordingStatus::Failed,
-            MeetingRecordingStatus::Cancelled,
-        ]))
-        .exec(db)
-        .await?;
-    Ok(result.rows_affected > 0)
+    db.transaction::<_, bool, Error>(|txn| {
+        Box::pin(async move {
+            let Some(model) = Entity::find_by_id(id)
+                .lock_exclusive()
+                .one(txn)
+                .await?
+                .filter(|m| !TERMINAL_RECORDING_STATUSES.contains(&m.status))
+            else {
+                return Ok(false);
+            };
+
+            ActiveModel {
+                status: Set(MeetingRecordingStatus::Completed),
+                updated_at: Set(chrono::Utc::now().into()),
+                ..model.into_active_model()
+            }
+            .update(txn)
+            .await?;
+
+            Ok(true)
+        })
+    })
+    .await
+    .map_err(|e| match e {
+        TransactionError::Connection(db_err) => db_err.into(),
+        TransactionError::Transaction(err) => err,
+    })
 }
 
 /// Optional artifact fields to set when updating a recording's status.
@@ -130,7 +146,7 @@ pub async fn update_status(
 #[cfg(feature = "mock")]
 mod tests {
     use super::*;
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+    use sea_orm::{DatabaseBackend, MockDatabase};
 
     fn test_model() -> Model {
         let now = chrono::Utc::now();
@@ -257,27 +273,47 @@ mod tests {
         assert!(result.is_err());
     }
 
+    fn test_model_with_status(status: MeetingRecordingStatus) -> Model {
+        let mut m = test_model();
+        m.status = status;
+        m
+    }
+
     #[tokio::test]
-    async fn try_claim_completed_returns_true_when_rows_affected() -> Result<(), Error> {
+    async fn try_claim_completed_returns_true_when_non_terminal() -> Result<(), Error> {
+        let existing = test_model_with_status(MeetingRecordingStatus::Processing);
+        let id = existing.id;
+        let mut after_update = existing.clone();
+        after_update.status = MeetingRecordingStatus::Completed;
+
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_exec_results(vec![MockExecResult {
-                last_insert_id: 0,
-                rows_affected: 1,
-            }])
+            .append_query_results(vec![vec![existing]])
+            .append_query_results(vec![vec![after_update]])
             .into_connection();
 
-        let result = try_claim_completed(&db, Id::new_v4()).await?;
+        let result = try_claim_completed(&db, id).await?;
         assert!(result);
         Ok(())
     }
 
     #[tokio::test]
-    async fn try_claim_completed_returns_false_when_no_rows_affected() -> Result<(), Error> {
+    async fn try_claim_completed_returns_false_when_already_terminal() -> Result<(), Error> {
+        let existing = test_model_with_status(MeetingRecordingStatus::Completed);
+        let id = existing.id;
+
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_exec_results(vec![MockExecResult {
-                last_insert_id: 0,
-                rows_affected: 0,
-            }])
+            .append_query_results(vec![vec![existing]])
+            .into_connection();
+
+        let result = try_claim_completed(&db, id).await?;
+        assert!(!result);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn try_claim_completed_returns_false_when_not_found() -> Result<(), Error> {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<Model, Vec<Model>, _>(vec![vec![]])
             .into_connection();
 
         let result = try_claim_completed(&db, Id::new_v4()).await?;

--- a/entity_api/src/transcription.rs
+++ b/entity_api/src/transcription.rs
@@ -5,7 +5,8 @@ use log::debug;
 use sea_orm::{
     entity::prelude::*,
     ActiveValue::{Set, Unchanged},
-    DatabaseConnection, Order, QueryOrder, TryIntoModel,
+    DatabaseConnection, IntoActiveModel, Order, QueryOrder, QuerySelect, TransactionError,
+    TransactionTrait, TryIntoModel,
 };
 
 /// Creates a new transcription record
@@ -53,17 +54,33 @@ pub async fn find_by_coaching_session(
 /// to `Processing`. Returns `true` if the claim succeeded (only one concurrent caller
 /// will win), `false` if the transcription was already claimed or completed.
 pub async fn try_claim_for_processing(db: &DatabaseConnection, id: Id) -> Result<bool, Error> {
-    let result = Entity::update_many()
-        .col_expr(Column::Status, Expr::value(TranscriptionStatus::Processing))
-        .col_expr(
-            Column::UpdatedAt,
-            Expr::value(chrono::Utc::now().fixed_offset()),
-        )
-        .filter(Column::Id.eq(id))
-        .filter(Column::Status.eq(TranscriptionStatus::Queued))
-        .exec(db)
-        .await?;
-    Ok(result.rows_affected > 0)
+    db.transaction::<_, bool, Error>(|txn| {
+        Box::pin(async move {
+            let Some(model) = Entity::find_by_id(id)
+                .lock_exclusive()
+                .one(txn)
+                .await?
+                .filter(|m| m.status == TranscriptionStatus::Queued)
+            else {
+                return Ok(false);
+            };
+
+            ActiveModel {
+                status: Set(TranscriptionStatus::Processing),
+                updated_at: Set(chrono::Utc::now().into()),
+                ..model.into_active_model()
+            }
+            .update(txn)
+            .await?;
+
+            Ok(true)
+        })
+    })
+    .await
+    .map_err(|e| match e {
+        TransactionError::Connection(db_err) => db_err.into(),
+        TransactionError::Transaction(err) => err,
+    })
 }
 
 /// Finds a transcription by its primary key
@@ -126,7 +143,7 @@ pub async fn update_status(
 #[cfg(feature = "mock")]
 mod tests {
     use super::*;
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+    use sea_orm::{DatabaseBackend, MockDatabase};
 
     fn test_model() -> Model {
         let now = chrono::Utc::now();
@@ -264,26 +281,41 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn try_claim_for_processing_returns_true_when_rows_affected() -> Result<(), Error> {
+    async fn try_claim_for_processing_returns_true_when_queued() -> Result<(), Error> {
+        let existing = test_model();
+        let id = existing.id;
+        let mut after_update = existing.clone();
+        after_update.status = TranscriptionStatus::Processing;
+
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_exec_results(vec![MockExecResult {
-                last_insert_id: 0,
-                rows_affected: 1,
-            }])
+            .append_query_results(vec![vec![existing]])
+            .append_query_results(vec![vec![after_update]])
             .into_connection();
 
-        let result = try_claim_for_processing(&db, Id::new_v4()).await?;
+        let result = try_claim_for_processing(&db, id).await?;
         assert!(result);
         Ok(())
     }
 
     #[tokio::test]
-    async fn try_claim_for_processing_returns_false_when_no_rows_affected() -> Result<(), Error> {
+    async fn try_claim_for_processing_returns_false_when_not_queued() -> Result<(), Error> {
+        let mut existing = test_model();
+        existing.status = TranscriptionStatus::Processing;
+        let id = existing.id;
+
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_exec_results(vec![MockExecResult {
-                last_insert_id: 0,
-                rows_affected: 0,
-            }])
+            .append_query_results(vec![vec![existing]])
+            .into_connection();
+
+        let result = try_claim_for_processing(&db, id).await?;
+        assert!(!result);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn try_claim_for_processing_returns_false_when_not_found() -> Result<(), Error> {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<Model, Vec<Model>, _>(vec![vec![]])
             .into_connection();
 
         let result = try_claim_for_processing(&db, Id::new_v4()).await?;

--- a/web/src/controller/webhook_controller.rs
+++ b/web/src/controller/webhook_controller.rs
@@ -60,7 +60,7 @@ pub async fn recall_ai(
     {
         Ok(()) => StatusCode::OK.into_response(),
         Err(e) => {
-            error!("Recall.ai webhook error: {:?}", e);
+            error!("Recall.ai webhook error: {e}");
             StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
     }


### PR DESCRIPTION
## Description
The Recall.ai `recording.done` webhook was returning HTTP 500 in local test runs. Root cause: both atomic-claim functions (`try_claim_completed` in `meeting_recording` and `try_claim_for_processing` in `transcription`) used `Entity::update_many().col_expr(Column::Status, Expr::value(enum_value))`. That `col_expr` path loses the column's PG enum type metadata at bind time, so sqlx sent the value as `text` and PostgreSQL rejected the assignment with error `42804`:

```
column "status" is of type meeting_recording_status but expression is of type text
```

The same bug existed in the transcription claim path but was latent; the failure happened earlier in the webhook flow.

Bundled with the bug fix: a small cleanup of the deeply-nested error log the webhook handler produces on failure. `domain::Error` and `entity_api::Error` `Display` impls were delegating straight to `Debug`, so `{}` and `{:?}` produced identical noise.

#### GitHub Issue: N/A

### Changes
* Rewrite `try_claim_completed` in `entity_api/src/meeting_recording.rs` to use `db.transaction(...)` with a `SELECT ... FOR UPDATE` row lock followed by `ActiveModel.update()`. The `Set(enum_variant)` path uses SeaORM's column metadata to bind the parameter as the proper PG enum type, so no `CAST` is needed in the SQL. This restores the codebase invariant that every PG enum write goes through `ActiveModel + Set()`.
* Apply the same rewrite to `try_claim_for_processing` in `entity_api/src/transcription.rs`.
* Fix `Display` on `domain::Error` in `domain/src/error.rs` to print ``{error_kind:?}: {source}`` and recurse through `source` via `Display`. Was: ``"Domain Error: {self:?}"``.
* Fix `Display` on `entity_api::Error` in `entity_api/src/error.rs` to do the same. Was: ``"Entity API Error: {self:?}"``.
* Switch `web/src/controller/webhook_controller.rs` from ``error!("...: {:?}", e)`` to ``error!("...: {e}")``.
* Update both functions' mock tests to match the SELECT-then-UPDATE shape. Each function gains an explicit "not found" test case (the previous implementation conflated "row missing" with "row already terminal"; both returned 0 rows affected. The new implementation distinguishes the two).

### Testing Strategy

#### Automated
* `cargo test --package entity_api --features mock --lib`: 174 passed, 0 failed.
* `cargo test --package domain`: 1 passed (others ignored as before).
* `cargo check --workspace`: clean.
* `cargo clippy` on the edited files: no new warnings.
* `cargo fmt --check`: clean.

#### End-to-end (already performed against a real PostgreSQL)
* Replayed a failed `recording.done` delivery from the Recall.ai dashboard against the local backend after applying the enum-cast fix.
* Confirmed HTTP 200, recording status flipped from `processing` to `completed`, and the transcription job kicked off (also exercising `try_claim_for_processing`).

#### Before / after on the webhook error log

Before (single line, fully unwrapped here for readability):
```
[ERROR] Recall.ai webhook error: Error { source: Some(Error { source: Some(Exec(SqlxError(Database(PgDatabaseError { severity: Error, code: "42804", message: "column \"status\" is of type meeting_recording_status but expression is of type text", detail: None, hint: Some("You will need to rewrite or cast the expression."), position: Some(Original(64)), where: None, schema: None, table: None, column: None, data_type: None, constraint: None, file: Some("parse_target.c"), line: Some(593), routine: Some("transformAssignedExpr") })))), error_kind: SystemError }), error_kind: Internal(Entity(ServiceUnavailable)) }
```

After:
```
[ERROR] Recall.ai webhook error: Internal(Entity(ServiceUnavailable)): SystemError: Execution Error: error returned from database: column "status" is of type meeting_recording_status but expression is of type text
```

### Concerns & Notes
* The original `update_many` form was one round-trip. The new form is two queries inside a transaction (`SELECT FOR UPDATE`, then `UPDATE ... RETURNING`). Concurrent webhook deliveries for the same row now serialize behind the row lock instead of racing at the UPDATE level. For a function called at most a handful of times per coaching session, this is the right trade. Atomicity stays correct, and the failure mode (enum cast bug) is gone.
* The `Display` change is technically a behavior change for any code that called `format!("{e}")` on a `domain::Error` or `entity_api::Error`. Grep shows no callers depend on the old `"Domain Error: ..."` or `"Entity API Error: ..."` text. Anything using `{:?}` is unaffected.