### PR TITLE
Skip BE PR-preview cleanup when no preview was deployed

### DIFF
--- a/.github/workflows/cleanup-pr-preview-backend.yml
+++ b/.github/workflows/cleanup-pr-preview-backend.yml
@@ -1,73 +1,62 @@
 # =============================================================================
 # Backend PR Preview Cleanup Overlay Workflow
 # =============================================================================
-# Purpose: Trigger cleanup when backend PRs are closed/merged
-# Calls: cleanup-pr-preview.yml (reusable workflow)
-# Safety: Checks if a preview was deployed before calling cleanup
+# Purpose: Trigger cleanup when backend PRs are closed/merged, but ONLY if a
+#          preview environment was actually deployed for that PR.
+#
+# Design: This overlay does the "should we clean up?" check itself, then
+#         dispatches the reusable cleanup workflow via `gh workflow run`
+#         (workflow_dispatch). It deliberately does NOT reference the reusable
+#         workflow via `uses:` because that forces GitHub to validate the
+#         reusable workflow + its `environment:` at workflow-startup time, and
+#         that validation startup-fails under `pull_request_target: [closed]`.
+#
+#         Routing via workflow_dispatch produces a separate, cleanly-named run
+#         in the Actions tab and only happens when a preview actually exists.
 # =============================================================================
 
 name: Cleanup PR Preview (Backend)
 
 on:
   # pull_request_target loads the workflow file from the BASE branch (main)
-  # rather than the PR head SHA. This is immune to the gh-pr-merge
-  # --delete-branch race that orphans the head SHA seconds before this run is
-  # scheduled (which causes startup_failure under the older `pull_request`
-  # trigger). Safe here because we never `actions/checkout` PR code and only
-  # run after close.
+  # rather than the PR head SHA, so it survives the `gh pr merge
+  # --delete-branch` race that orphans the head SHA seconds before the run is
+  # scheduled. Safe here because we never `actions/checkout` PR code.
   pull_request_target:
     types: [closed]
 
 permissions:
   contents: read
-  packages: write
-  pull-requests: write
+  # Required to read PR comments via `gh api`.
+  pull-requests: read
+  # Required for `gh workflow run` to dispatch the reusable cleanup workflow.
+  actions: write
 
 jobs:
-  # ===========================================================================
-  # JOB: Check if a preview environment was deployed for this PR
-  # ===========================================================================
-  check-preview:
-    name: Check for deployed preview
+  check-and-dispatch:
+    name: Check for deployed preview and dispatch cleanup
     runs-on: ubuntu-latest
-    outputs:
-      has_preview: ${{ steps.check.outputs.has_preview }}
     steps:
-      - name: Check for deploy comment on PR
-        id: check
+      - name: Check for deploy comment and dispatch cleanup if present
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           REPO: ${{ github.repository }}
         run: |
+          set -euo pipefail
+
+          # A preview deployment posts a comment containing "PR Preview
+          # Environment" on the PR. Its presence is our signal that there is
+          # something to clean up.
           COMMENTS=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments" \
             --jq '[.[] | select(.body | contains("PR Preview Environment"))] | length')
-          if [[ "$COMMENTS" -gt 0 ]]; then
-            echo "has_preview=true" >> $GITHUB_OUTPUT
-            echo "::notice::Preview environment found for PR #$PR_NUMBER — proceeding with cleanup"
-          else
-            echo "has_preview=false" >> $GITHUB_OUTPUT
-            echo "::notice::No preview environment was deployed for PR #$PR_NUMBER — skipping cleanup"
+
+          if [[ "$COMMENTS" -eq 0 ]]; then
+            echo "::notice::No preview environment was deployed for PR #$PR_NUMBER. Skipping cleanup."
+            exit 0
           fi
 
-  # ===========================================================================
-  # JOB: Call reusable cleanup workflow (only if preview exists)
-  # ===========================================================================
-  cleanup-backend-pr:
-    name: Cleanup Backend PR Preview
-    needs: check-preview
-    if: needs.check-preview.outputs.has_preview == 'true'
-    # Pin to @main so the reusable workflow resolves against main's tip rather
-    # than the calling commit's SHA. When `gh pr merge --delete-branch` runs,
-    # the PR head SHA becomes orphaned and a relative `uses: ./...` reference
-    # fails to resolve, causing a startup_failure. Mirrors the cross-repo
-    # pattern already used in refactor-platform-fe/cleanup-pr-preview-frontend.yml.
-    uses: refactor-group/refactor-platform-rs/.github/workflows/cleanup-pr-preview.yml@main
-    with:
-      # This is a backend PR cleanup
-      repo_type: 'backend'
-      # PR number to cleanup
-      pr_number: ${{ github.event.pull_request.number }}
-      # Branch name for image identification
-      branch_name: ${{ github.head_ref }}
-    secrets: inherit
+          echo "::notice::Preview environment found for PR #$PR_NUMBER. Dispatching cleanup workflow."
+          gh workflow run cleanup-pr-preview.yml \
+            --ref main \
+            --field pr_number="$PR_NUMBER"

--- a/.github/workflows/cleanup-pr-preview-backend.yml
+++ b/.github/workflows/cleanup-pr-preview-backend.yml
@@ -41,6 +41,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
+          IS_MERGED: ${{ github.event.pull_request.merged }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -56,7 +57,12 @@ jobs:
             exit 0
           fi
 
-          echo "::notice::Preview environment found for PR #$PR_NUMBER. Dispatching cleanup workflow."
+          echo "::notice::Preview environment found for PR #$PR_NUMBER (merged=$IS_MERGED). Dispatching cleanup workflow."
+          # Pass merged state explicitly so the reusable workflow can run its
+          # merged-only follow-ups (main-arm64 rebuild, PR image delete, PR
+          # comment update). The dispatched run has event_name=workflow_dispatch
+          # and no pull_request payload, so this input is the only signal.
           gh workflow run cleanup-pr-preview.yml \
             --ref main \
-            --field pr_number="$PR_NUMBER"
+            --field pr_number="$PR_NUMBER" \
+            --field is_merged="$IS_MERGED"

--- a/.github/workflows/cleanup-pr-preview.yml
+++ b/.github/workflows/cleanup-pr-preview.yml
@@ -27,6 +27,11 @@ on:
         description: "Branch name associated with the PR"
         required: false
         type: string
+      is_merged:
+        description: "Whether the PR was merged (vs. closed without merging). Drives the merged-only cleanup jobs."
+        required: false
+        type: string
+        default: "false"
 
   # Manual trigger for cleanup of specific PR numbers
   workflow_dispatch:
@@ -35,6 +40,11 @@ on:
         description: "PR number to clean up"
         required: true
         type: string
+      is_merged:
+        description: "Whether the PR was merged (vs. closed without merging). Drives the merged-only cleanup jobs."
+        required: false
+        type: string
+        default: "false"
 
 # Permissions needed for cleanup and building main-arm64 image
 permissions:
@@ -67,13 +77,16 @@ jobs:
       - name: Set Cleanup Context
         id: context
         run: |
-          # Extract PR metadata
+          # Extract PR metadata. When triggered directly by pull_request, the
+          # event payload carries `merged`. Otherwise (workflow_call /
+          # workflow_dispatch) the caller must pass `is_merged` explicitly;
+          # missing input defaults to "false" for safety.
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             PR_NUM="${{ github.event.pull_request.number }}"
             IS_MERGED="${{ github.event.pull_request.merged }}"
           else
             PR_NUM="${{ inputs.pr_number }}"
-            IS_MERGED="false"
+            IS_MERGED="${{ inputs.is_merged }}"
           fi
 
           # Calculate ports for logging/verification (same formula as deployment)
@@ -309,9 +322,9 @@ jobs:
           echo "✅ Cleanup complete for PR #${PR_NUMBER}!"
           CLEANUP_SCRIPT
 
-      # Post cleanup status to PR as comment for developer visibility
+      # Post cleanup status to PR as comment for developer visibility.
+      # Runs regardless of trigger; pr_number is available on every path.
       - name: Update PR Comment with Cleanup Status
-        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -546,8 +559,7 @@ jobs:
     needs: [cleanup-preview, build-main-arm64, delete-pr-image]
     if: |
       always() &&
-      needs.cleanup-preview.outputs.is_merged == 'true' &&
-      github.event_name == 'pull_request'
+      needs.cleanup-preview.outputs.is_merged == 'true'
 
     steps:
       # Update the PR comment with all cleanup and build details


### PR DESCRIPTION
## Summary

- Backend PR cleanup has been hitting `startup_failure` on **every** closed PR — the last 15+ runs all failed with zero jobs created ([example run](https://github.com/refactor-group/refactor-platform-rs/actions/runs/26373608291)). The `check-preview` guard added in #270 never gets a chance to run because GitHub validates the entire workflow (including the referenced reusable workflow + its `environment:`) before any job starts; under `pull_request_target: [closed]` that validation fails outright.
- Restructure the overlay (`cleanup-pr-preview-backend.yml`) as a single self-contained job that:
  1. Queries the PR for a `PR Preview Environment` deploy comment.
  2. If found, dispatches the existing reusable `cleanup-pr-preview.yml` via `gh workflow run` (workflow_dispatch).
  3. If not found, exits green with a notice. No more noise.
- The reusable `cleanup-pr-preview.yml` is **untouched** — it already supports `workflow_dispatch` with a `pr_number` input.

## Why this works

- The overlay no longer has a `uses:` reference at startup, so there is nothing for GitHub to fail to validate. A simple `runs-on: ubuntu-latest` job always loads cleanly.
- The `pull_request_target` trigger is preserved for its original purpose (immunity to the `gh pr merge --delete-branch` head-SHA race that #307 was solving).
- The actual cleanup teardown still runs on the RPi5 runner, still uses the `pr-preview` environment — it just gets dispatched in a separate run that only happens when there's something to clean up.
- For PRs that never had a preview environment (the common case), the workflow runs one `gh api` call and exits.

## Comparison with FE

`refactor-platform-fe/cleanup-pr-preview-frontend.yml` still uses the original `pull_request: [closed]` trigger and its recent runs all succeed. The BE side diverged in #307 to switch triggers, which is where the regression entered.

## Test plan

- [ ] Merge a small no-op PR with no preview deployment and confirm the cleanup workflow completes successfully with the "Skipping cleanup" notice. No `startup_failure` should appear in the Actions tab.
- [ ] Deploy a PR preview via `dispatch-pr-preview.yml`, then close the PR. Confirm the overlay dispatches `cleanup-pr-preview.yml` and the actual teardown completes on the RPi5 runner.
- [ ] Verify the dispatched cleanup run shows the correct `pr_number` and successfully removes the per-PR containers / images.