### PR TITLE
Add tz query param to GET /users/{user_id}/coaching_sessions

### DIFF
--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -465,62 +465,59 @@ pub async fn find_by_user_with_includes(
     // Validate include options
     options.includes.validate()?;
 
-    // Build query for sessions filtered by user
-    let mut query = Entity::find()
+    // Build the optional date-bound filters up-front so the query chain can
+    // stay a single fluent `apply_if` pipeline. When `tz` is supplied, each
+    // bound is wrapped in an `AT TIME ZONE` shift, mirroring the expression
+    // used by `find_counts_by_month_for_user`; otherwise the legacy
+    // `Column::Date.gte/.lt` form is preserved so unchanged callers behave
+    // byte-identically.
+    let tz = options.tz.as_deref();
+    let lower_bound_filter = options.from_date.map(|from| match tz {
+        Some(tz_name) => Expr::cust_with_values(
+            r#""coaching_sessions"."date" >= ($1::timestamp AT TIME ZONE $2::text) AT TIME ZONE 'UTC'"#,
+            [
+                sea_orm::Value::from(from),
+                sea_orm::Value::from(tz_name.to_string()),
+            ],
+        ),
+        None => coaching_sessions::Column::Date.gte(from),
+    });
+    let upper_bound_filter = options.to_date.map(|to| {
+        let end_of_day = to.succ_opt().unwrap_or(to);
+        match tz {
+            Some(tz_name) => Expr::cust_with_values(
+                r#""coaching_sessions"."date" < ($1::timestamp AT TIME ZONE $2::text) AT TIME ZONE 'UTC'"#,
+                [
+                    sea_orm::Value::from(end_of_day),
+                    sea_orm::Value::from(tz_name.to_string()),
+                ],
+            ),
+            None => coaching_sessions::Column::Date.lt(end_of_day),
+        }
+    });
+
+    // Single fluent builder chain. Each optional knob lands as an `apply_if`
+    // so the "is the knob present" branch never escapes into the surrounding
+    // function body.
+    let query = Entity::find()
         .join(JoinType::InnerJoin, Relation::CoachingRelationships.def())
         .filter(
             coaching_relationships::Column::CoachId
                 .eq(user_id)
                 .or(coaching_relationships::Column::CoacheeId.eq(user_id)),
+        )
+        .apply_if(
+            options.coaching_relationship_id,
+            |q: Select<Entity>, rel_id| {
+                q.filter(coaching_sessions::Column::CoachingRelationshipId.eq(rel_id))
+            },
+        )
+        .apply_if(lower_bound_filter, |q: Select<Entity>, expr| q.filter(expr))
+        .apply_if(upper_bound_filter, |q: Select<Entity>, expr| q.filter(expr))
+        .apply_if(
+            options.sort_column.zip(options.sort_order),
+            |q: Select<Entity>, (col, ord)| q.order_by(col, ord),
         );
-
-    // Apply coaching relationship filter
-    if let Some(relationship_id) = options.coaching_relationship_id {
-        query = query.filter(coaching_sessions::Column::CoachingRelationshipId.eq(relationship_id));
-    }
-
-    // Apply date filtering. When `tz` is supplied, evaluate the bounds as
-    // calendar-day boundaries in that zone via `AT TIME ZONE`, mirroring the
-    // expression used by `find_counts_by_month_for_user`. When omitted,
-    // preserve the legacy UTC-naive comparison so unchanged callers behave
-    // identically.
-    match options.tz.as_deref() {
-        Some(tz_name) => {
-            if let Some(from) = options.from_date {
-                query = query.filter(Expr::cust_with_values(
-                    r#""coaching_sessions"."date" >= ($1::timestamp AT TIME ZONE $2::text) AT TIME ZONE 'UTC'"#,
-                    [
-                        sea_orm::Value::from(from),
-                        sea_orm::Value::from(tz_name.to_string()),
-                    ],
-                ));
-            }
-            if let Some(to) = options.to_date {
-                let end_of_day = to.succ_opt().unwrap_or(to);
-                query = query.filter(Expr::cust_with_values(
-                    r#""coaching_sessions"."date" < ($1::timestamp AT TIME ZONE $2::text) AT TIME ZONE 'UTC'"#,
-                    [
-                        sea_orm::Value::from(end_of_day),
-                        sea_orm::Value::from(tz_name.to_string()),
-                    ],
-                ));
-            }
-        }
-        None => {
-            if let Some(from) = options.from_date {
-                query = query.filter(coaching_sessions::Column::Date.gte(from));
-            }
-            if let Some(to) = options.to_date {
-                let end_of_day = to.succ_opt().unwrap_or(to);
-                query = query.filter(coaching_sessions::Column::Date.lt(end_of_day));
-            }
-        }
-    }
-
-    // Apply sorting if both column and order are provided
-    if let (Some(column), Some(order)) = (options.sort_column, options.sort_order) {
-        query = query.order_by(column, order);
-    }
 
     // Execute query to load base sessions
     let sessions = query.all(db).await?;

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -1267,6 +1267,51 @@ mod tests {
         Ok(())
     }
 
+    // Mirror of the lower-bound-only test: only `to_date` supplied, `tz`
+    // present. Guards against future regressions that would accidentally
+    // couple lower-bound emission to upper-bound presence (e.g. an
+    // `if let (Some(from), Some(to)) = ...` rewrite that silently drops the
+    // upper-only case while leaving both-bounds and lower-only green).
+    #[tokio::test]
+    async fn find_by_user_with_includes_with_tz_and_only_to_date_shifts_upper_bound(
+    ) -> Result<(), Error> {
+        let user_id = Id::new_v4();
+        let to_date = chrono::NaiveDate::from_ymd_opt(2026, 5, 24).unwrap();
+        let to_exclusive = chrono::NaiveDate::from_ymd_opt(2026, 5, 25).unwrap();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<Model, Vec<Model>, _>(vec![vec![]])
+            .into_connection();
+
+        let _ = find_by_user_with_includes(
+            &db,
+            user_id,
+            SessionQueryOptions {
+                from_date: None,
+                to_date: Some(to_date),
+                tz: Some("Europe/Berlin".to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "coaching_sessions"."id", "coaching_sessions"."coaching_relationship_id", "coaching_sessions"."collab_document_name", "coaching_sessions"."date", "coaching_sessions"."meeting_url", CAST("coaching_sessions"."provider" AS "text"), "coaching_sessions"."created_at", "coaching_sessions"."updated_at", "coaching_sessions"."hydrated_at" FROM "refactor_platform"."coaching_sessions" INNER JOIN "refactor_platform"."coaching_relationships" ON "coaching_sessions"."coaching_relationship_id" = "coaching_relationships"."id" WHERE ("coaching_relationships"."coach_id" = $1 OR "coaching_relationships"."coachee_id" = $2) AND ("coaching_sessions"."date" < ($3::timestamp AT TIME ZONE $4::text) AT TIME ZONE 'UTC')"#,
+                [
+                    user_id.into(),
+                    user_id.into(),
+                    to_exclusive.into(),
+                    "Europe/Berlin".into(),
+                ]
+            )]
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn include_options_needs_relationships_truth_table() {
         // organization || relationship → true; everything else → false.

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -438,10 +438,16 @@ impl IncludeOptions {
 pub struct SessionQueryOptions {
     /// Filter sessions to only those in this coaching relationship
     pub coaching_relationship_id: Option<Id>,
-    /// Filter sessions starting from this date (inclusive)
+    /// Filter sessions starting from this date (inclusive). Interpreted in
+    /// `tz` when present; otherwise UTC.
     pub from_date: Option<chrono::NaiveDate>,
-    /// Filter sessions up to this date (inclusive)
+    /// Filter sessions up to this date (inclusive at calendar-day precision).
+    /// Interpreted in `tz` when present; otherwise UTC.
     pub to_date: Option<chrono::NaiveDate>,
+    /// Optional canonical IANA timezone name for evaluating `from_date` and
+    /// `to_date` as calendar-day boundaries in that zone. `None` = UTC-naive.
+    /// Validate upstream (web layer); this layer trusts the value.
+    pub tz: Option<String>,
     /// Column to sort results by
     pub sort_column: Option<coaching_sessions::Column>,
     /// Sort direction (ascending or descending)
@@ -473,15 +479,42 @@ pub async fn find_by_user_with_includes(
         query = query.filter(coaching_sessions::Column::CoachingRelationshipId.eq(relationship_id));
     }
 
-    // Apply date filtering
-    if let Some(from) = options.from_date {
-        query = query.filter(coaching_sessions::Column::Date.gte(from));
-    }
-
-    if let Some(to) = options.to_date {
-        // Use next day with less-than for inclusive end date
-        let end_of_day = to.succ_opt().unwrap_or(to);
-        query = query.filter(coaching_sessions::Column::Date.lt(end_of_day));
+    // Apply date filtering. When `tz` is supplied, evaluate the bounds as
+    // calendar-day boundaries in that zone via `AT TIME ZONE`, mirroring the
+    // expression used by `find_counts_by_month_for_user`. When omitted,
+    // preserve the legacy UTC-naive comparison so unchanged callers behave
+    // identically.
+    match options.tz.as_deref() {
+        Some(tz_name) => {
+            if let Some(from) = options.from_date {
+                query = query.filter(Expr::cust_with_values(
+                    r#""coaching_sessions"."date" >= ($1::timestamp AT TIME ZONE $2::text) AT TIME ZONE 'UTC'"#,
+                    [
+                        sea_orm::Value::from(from),
+                        sea_orm::Value::from(tz_name.to_string()),
+                    ],
+                ));
+            }
+            if let Some(to) = options.to_date {
+                let end_of_day = to.succ_opt().unwrap_or(to);
+                query = query.filter(Expr::cust_with_values(
+                    r#""coaching_sessions"."date" < ($1::timestamp AT TIME ZONE $2::text) AT TIME ZONE 'UTC'"#,
+                    [
+                        sea_orm::Value::from(end_of_day),
+                        sea_orm::Value::from(tz_name.to_string()),
+                    ],
+                ));
+            }
+        }
+        None => {
+            if let Some(from) = options.from_date {
+                query = query.filter(coaching_sessions::Column::Date.gte(from));
+            }
+            if let Some(to) = options.to_date {
+                let end_of_day = to.succ_opt().unwrap_or(to);
+                query = query.filter(coaching_sessions::Column::Date.lt(end_of_day));
+            }
+        }
     }
 
     // Apply sorting if both column and order are provided
@@ -1100,6 +1133,139 @@ mod tests {
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].session.id, session.id);
         assert_eq!(results[0].session.date, from_date.into());
+
+        Ok(())
+    }
+
+    // Locks down the SQL emitted when `tz` is supplied: both date bounds are
+    // shifted via `AT TIME ZONE`, matching the expression form used by
+    // `find_counts_by_month_for_user`. Catches drift in bind positions, the
+    // `to_date.succ_opt()` half-open conversion, and the tz-bind ordering.
+    #[tokio::test]
+    async fn find_by_user_with_includes_with_tz_emits_shifted_boundaries() -> Result<(), Error> {
+        let user_id = Id::new_v4();
+        let from_date = chrono::NaiveDate::from_ymd_opt(2026, 5, 24).unwrap();
+        let to_date = chrono::NaiveDate::from_ymd_opt(2026, 5, 24).unwrap();
+        let to_exclusive = chrono::NaiveDate::from_ymd_opt(2026, 5, 25).unwrap();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<Model, Vec<Model>, _>(vec![vec![]])
+            .into_connection();
+
+        let _ = find_by_user_with_includes(
+            &db,
+            user_id,
+            SessionQueryOptions {
+                from_date: Some(from_date),
+                to_date: Some(to_date),
+                tz: Some("America/Los_Angeles".to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "coaching_sessions"."id", "coaching_sessions"."coaching_relationship_id", "coaching_sessions"."collab_document_name", "coaching_sessions"."date", "coaching_sessions"."meeting_url", CAST("coaching_sessions"."provider" AS "text"), "coaching_sessions"."created_at", "coaching_sessions"."updated_at", "coaching_sessions"."hydrated_at" FROM "refactor_platform"."coaching_sessions" INNER JOIN "refactor_platform"."coaching_relationships" ON "coaching_sessions"."coaching_relationship_id" = "coaching_relationships"."id" WHERE ("coaching_relationships"."coach_id" = $1 OR "coaching_relationships"."coachee_id" = $2) AND ("coaching_sessions"."date" >= ($3::timestamp AT TIME ZONE $4::text) AT TIME ZONE 'UTC') AND ("coaching_sessions"."date" < ($5::timestamp AT TIME ZONE $6::text) AT TIME ZONE 'UTC')"#,
+                [
+                    user_id.into(),
+                    user_id.into(),
+                    from_date.into(),
+                    "America/Los_Angeles".into(),
+                    to_exclusive.into(),
+                    "America/Los_Angeles".into(),
+                ]
+            )]
+        );
+
+        Ok(())
+    }
+
+    // Regression guard for the legacy UTC-naive path. When `tz` is omitted,
+    // the boundaries must be plain `Column::Date.gte/.lt`, not the
+    // tz-shifted expression. Asserting the absence of `AT TIME ZONE` here
+    // prevents an accidental "always shift" rewrite from silently breaking
+    // existing callers who rely on UTC interpretation.
+    #[tokio::test]
+    async fn find_by_user_with_includes_without_tz_emits_utc_naive_boundaries() -> Result<(), Error>
+    {
+        let user_id = Id::new_v4();
+        let from_date = chrono::NaiveDate::from_ymd_opt(2026, 5, 24).unwrap();
+        let to_date = chrono::NaiveDate::from_ymd_opt(2026, 5, 24).unwrap();
+        let to_exclusive = chrono::NaiveDate::from_ymd_opt(2026, 5, 25).unwrap();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<Model, Vec<Model>, _>(vec![vec![]])
+            .into_connection();
+
+        let _ = find_by_user_with_includes(
+            &db,
+            user_id,
+            SessionQueryOptions {
+                from_date: Some(from_date),
+                to_date: Some(to_date),
+                tz: None,
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "coaching_sessions"."id", "coaching_sessions"."coaching_relationship_id", "coaching_sessions"."collab_document_name", "coaching_sessions"."date", "coaching_sessions"."meeting_url", CAST("coaching_sessions"."provider" AS "text"), "coaching_sessions"."created_at", "coaching_sessions"."updated_at", "coaching_sessions"."hydrated_at" FROM "refactor_platform"."coaching_sessions" INNER JOIN "refactor_platform"."coaching_relationships" ON "coaching_sessions"."coaching_relationship_id" = "coaching_relationships"."id" WHERE ("coaching_relationships"."coach_id" = $1 OR "coaching_relationships"."coachee_id" = $2) AND "coaching_sessions"."date" >= $3 AND "coaching_sessions"."date" < $4"#,
+                [
+                    user_id.into(),
+                    user_id.into(),
+                    from_date.into(),
+                    to_exclusive.into(),
+                ]
+            )]
+        );
+
+        Ok(())
+    }
+
+    // Mixed-presence: only `from_date` supplied, `tz` present. The shift
+    // applies to the present bound only; no upper-bound filter is emitted.
+    #[tokio::test]
+    async fn find_by_user_with_includes_with_tz_and_only_from_date_shifts_lower_bound(
+    ) -> Result<(), Error> {
+        let user_id = Id::new_v4();
+        let from_date = chrono::NaiveDate::from_ymd_opt(2026, 5, 24).unwrap();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<Model, Vec<Model>, _>(vec![vec![]])
+            .into_connection();
+
+        let _ = find_by_user_with_includes(
+            &db,
+            user_id,
+            SessionQueryOptions {
+                from_date: Some(from_date),
+                to_date: None,
+                tz: Some("Europe/Berlin".to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+
+        assert_eq!(
+            db.into_transaction_log(),
+            [Transaction::from_sql_and_values(
+                DatabaseBackend::Postgres,
+                r#"SELECT "coaching_sessions"."id", "coaching_sessions"."coaching_relationship_id", "coaching_sessions"."collab_document_name", "coaching_sessions"."date", "coaching_sessions"."meeting_url", CAST("coaching_sessions"."provider" AS "text"), "coaching_sessions"."created_at", "coaching_sessions"."updated_at", "coaching_sessions"."hydrated_at" FROM "refactor_platform"."coaching_sessions" INNER JOIN "refactor_platform"."coaching_relationships" ON "coaching_sessions"."coaching_relationship_id" = "coaching_relationships"."id" WHERE ("coaching_relationships"."coach_id" = $1 OR "coaching_relationships"."coachee_id" = $2) AND ("coaching_sessions"."date" >= ($3::timestamp AT TIME ZONE $4::text) AT TIME ZONE 'UTC')"#,
+                [
+                    user_id.into(),
+                    user_id.into(),
+                    from_date.into(),
+                    "Europe/Berlin".into(),
+                ]
+            )]
+        );
 
         Ok(())
     }

--- a/web/src/controller/user/coaching_session_controller.rs
+++ b/web/src/controller/user/coaching_session_controller.rs
@@ -20,7 +20,12 @@ use serde::Serialize;
 use service::config::ApiVersion;
 use utoipa::ToSchema;
 
-/// GET all coaching sessions for a specific user with optional related data
+/// GET all coaching sessions for a specific user with optional related data.
+///
+/// When `tz` is supplied, `from_date` and `to_date` are evaluated as
+/// calendar-day boundaries in that IANA zone. Omitting `tz` preserves the
+/// legacy UTC-naive interpretation. Invalid `tz` values surface a structured
+/// `invalid_timezone` 400 (see `WebErrorKind::InvalidTimezone`).
 #[utoipa::path(
     get,
     path = "/users/{user_id}/coaching_sessions",
@@ -28,15 +33,16 @@ use utoipa::ToSchema;
         ApiVersion,
         ("user_id" = Id, Path, description = "User ID to retrieve coaching sessions for"),
         ("coaching_relationship_id" = Option<Id>, Query, description = "Filter sessions to only those in this coaching relationship"),
-        ("from_date" = Option<chrono::NaiveDate>, Query, description = "Filter by from_date (inclusive, UTC)"),
-        ("to_date" = Option<chrono::NaiveDate>, Query, description = "Filter by to_date (inclusive, UTC)"),
+        ("from_date" = Option<chrono::NaiveDate>, Query, description = "Filter by from_date (inclusive). Evaluated in `tz` if supplied; otherwise UTC."),
+        ("to_date" = Option<chrono::NaiveDate>, Query, description = "Filter by to_date (inclusive at calendar-day precision). Evaluated in `tz` if supplied; otherwise UTC."),
+        ("tz" = Option<String>, Query, description = "Optional IANA timezone identifier (e.g. 'America/Los_Angeles'). Interprets `from_date`/`to_date` as local-day boundaries in that zone. Invalid value → 400 invalid_timezone."),
         ("include" = Option<String>, Query, description = "Comma-separated list of related resources to include. Valid values: 'relationship', 'organization', 'goal', 'agreements'. Example: 'relationship,organization,goal'"),
         ("sort_by" = Option<crate::params::coaching_session::SortField>, Query, description = "Sort by field. Valid values: 'date', 'created_at', 'updated_at'. Must be provided with sort_order.", example = "date"),
         ("sort_order" = Option<crate::params::sort::SortOrder>, Query, description = "Sort order. Valid values: 'asc' (ascending), 'desc' (descending). Must be provided with sort_by.", example = "desc")
     ),
     responses(
         (status = 200, description = "Successfully retrieved coaching sessions for user", body = [domain::coaching_session::EnrichedSession]),
-        (status = 400, description = "Bad Request - Invalid include parameter"),
+        (status = 400, description = "Bad Request (e.g. invalid include parameter, invalid timezone, malformed query)"),
         (status = 401, description = "Unauthorized"),
         (status = 403, description = "Forbidden"),
         (status = 404, description = "User not found"),
@@ -60,6 +66,20 @@ pub async fn index(
     // Set user_id from path parameter and apply defaults
     let params = params.with_user_id(user_id).apply_defaults();
 
+    // Validate the optional IANA timezone identifier before touching the DB.
+    // Mirrors the counts handler: on failure surface a structured 400 with
+    // `error: "invalid_timezone"`. Normalize to the canonical IANA name via
+    // `tz.name()` so deprecated aliases are accepted but a single canonical
+    // string is propagated downstream.
+    let tz_name = match params.tz.as_deref() {
+        Some(raw) => {
+            let tz = Tz::from_str(raw)
+                .map_err(|_| Error::Web(WebErrorKind::InvalidTimezone(raw.to_string())))?;
+            Some(tz.name().to_string())
+        }
+        None => None,
+    };
+
     // Build include options from parameters
     let includes = CoachingSessionApi::IncludeOptions {
         relationship: params.include.contains(&IncludeParam::Relationship),
@@ -78,6 +98,7 @@ pub async fn index(
             coaching_relationship_id: params.coaching_relationship_id,
             from_date: params.from_date,
             to_date: params.to_date,
+            tz: tz_name,
             sort_column,
             sort_order,
             includes,

--- a/web/src/params/user/coaching_session.rs
+++ b/web/src/params/user/coaching_session.rs
@@ -38,10 +38,21 @@ pub(crate) struct IndexParams {
     pub(crate) user_id: Id,
     /// Optional: filter sessions to only those in this coaching relationship
     pub(crate) coaching_relationship_id: Option<Id>,
-    /// Optional: filter sessions starting from this date (inclusive)
+    /// Optional: filter sessions starting from this date (inclusive).
+    ///
+    /// Interpreted in `tz` when present; otherwise UTC.
     pub(crate) from_date: Option<NaiveDate>,
-    /// Optional: filter sessions up to this date (inclusive)
+    /// Optional: filter sessions up to this date (inclusive at calendar-day precision).
+    ///
+    /// Interpreted in `tz` when present; otherwise UTC.
     pub(crate) to_date: Option<NaiveDate>,
+    /// Optional: IANA timezone for evaluating `from_date`/`to_date` as
+    /// calendar-day boundaries in that zone. Omitted = UTC-naive boundaries.
+    ///
+    /// Validated in the handler via `chrono_tz::Tz::from_str`; invalid → 400
+    /// `invalid_timezone`. Kept as `String` so the offending value is
+    /// preserved for the structured discriminator response.
+    pub(crate) tz: Option<String>,
     /// Optional: field to sort by (e.g., "date", "created_at")
     pub(crate) sort_by: Option<SortField>,
     /// Optional: sort direction (asc/desc)


### PR DESCRIPTION
## Description

Adds an optional `tz` query parameter to `GET /users/{user_id}/coaching_sessions` so `from_date` and `to_date` are evaluated as calendar-day boundaries in the supplied IANA zone. Mirrors the same semantics already shipping on the counts sibling endpoint.

Coordinated with the frontend to fix a dashboard bug where a session scheduled for 9 PM local on Sunday would appear in "This Week" but disappear from "Today" because the 1-day UTC filter saw the session's date as the next UTC calendar day. With `tz` supplied, the day-boundary shift is exact and the symptom disappears.

The change is purely additive at the wire level: omitting `tz` preserves the legacy UTC-naive interpretation byte-identically, so no existing caller breaks. Backed by the `UserCoachingSessionsListEndpoint` v1 contract posted on the coordinator blackboard.

### Changes

* `web/src/params/user/coaching_session.rs`: added `tz: Option<String>` to `IndexParams`; updated `from_date`/`to_date` doc comments to note TZ interpretation.
* `entity_api/src/coaching_session.rs`: added `tz: Option<String>` to `SessionQueryOptions`. `find_by_user_with_includes` branches on `tz.as_deref()` to apply TZ-aware boundaries via `Expr::cust_with_values` when supplied, falling back to the legacy `Column::Date.gte/.lt` form otherwise.
* `web/src/controller/user/coaching_session_controller.rs`: validates `tz` with `chrono_tz::Tz::from_str`, normalizes to canonical IANA name via `tz.name()`, and propagates to `SessionQueryOptions`. utoipa annotation gains the `tz` param, reworded `from_date`/`to_date` descriptions, and a broadened 400 description covering `invalid_timezone`.

### Testing Strategy

Three new SQL-emission tests in `entity_api/src/coaching_session.rs` lock down the wire-level SQL emitted by `find_by_user_with_includes`:
- `find_by_user_with_includes_with_tz_emits_shifted_boundaries`: both bounds present with tz, asserts both filters use `AT TIME ZONE` form.
- `find_by_user_with_includes_without_tz_emits_utc_naive_boundaries`: regression guard ensuring the legacy `Column::Date.gte/.lt` form is preserved when tz is omitted. Prevents an accidental "always shift" rewrite from breaking existing callers.
- `find_by_user_with_includes_with_tz_and_only_from_date_shifts_lower_bound`: mixed-presence case verifying the upper bound is omitted when `to_date` is None.

Verification:
- `cargo check --all-targets`: clean
- `cargo test --package entity_api --features mock --lib`: 177 passed, 0 failed
- `cargo clippy --all-targets --features entity_api/mock`: no new warnings on changed files
- `cargo fmt`: applied

### Concerns

None blocking.

The MockDatabase tests assert the SQL string sea_query emits, not Postgres-acceptance of it. The `AT TIME ZONE` expression form here is structurally identical to what `find_counts_by_month_for_user` already produces and ships against production, so syntactic acceptance is established by precedent.

This needs coordinated rollout with the frontend so the dashboard Today-section starts sending the `tz` query param once this lands. Either merge order is safe: until BE ships, FE keeps current behavior; once BE ships and FE catches up, the symptom disappears.