### PR TITLE
Force rustls on all reqwest clients (fixes #337)

### DIFF
--- a/.claude/coding-standards.md
+++ b/.claude/coding-standards.md
@@ -273,6 +273,29 @@ pub async fn get_user(
 }
 ```
 
+### HTTP Clients (reqwest TLS)
+
+**CRITICAL:** Every `reqwest::Client` built in production code must opt into rustls explicitly with `.use_rustls_tls()`. Never use `reqwest::Client::new()`, bare `reqwest::get(...)`, or `Client::builder().build()` without the TLS opt-in.
+
+```rust
+// ✅ Good — explicit rustls
+let client = reqwest::Client::builder()
+    .use_rustls_tls()
+    .timeout(Duration::from_secs(30))
+    .build()?;
+
+// ❌ Bad — picks up the default backend (native-tls/OpenSSL)
+let client = reqwest::Client::new();
+let response = reqwest::get(url).await?;
+let client = reqwest::Client::builder().timeout(...).build()?;
+```
+
+**Why:** Cargo features are unioned across the workspace. Several deps pull in reqwest with default features, which enables `default-tls` (native-tls/OpenSSL). When both backends are compiled in, `Client::new()` / `reqwest::get(...)` default to native-tls, which reads CA roots from the runtime container's system trust store. The production runtime image (`debian:bullseye-slim`) intentionally ships **without** `ca-certificates` — keeping it out minimizes attack surface and acts as a tripwire that fails loudly when this rule is violated. Rustls bundles its trust roots via `webpki-roots` and works regardless of the system store, so `.use_rustls_tls()` is the only safe choice. **Do not "fix" a TLS failure by installing `ca-certificates` in the runtime image** — fix the offending reqwest call to use rustls.
+
+**Pre-signed download URLs:** Do not reuse a client whose `default_headers` includes `Authorization` for downloads from pre-signed URLs (e.g. S3, Recall.ai transcript downloads). Build a second header-less rustls client and store it alongside the authenticated one. See `domain::gateway::recall_ai::Provider::{client, download_client}` for the pattern.
+
+**Review checklist:** grep for `reqwest::Client::new()`, `reqwest::get(`, and `Client::builder()` whenever touching gateway/HTTP code. The only acceptable bare-default uses are test helpers under `#[cfg(test)]` and binaries in `testing-tools/`.
+
 ### Database Transactions
 
 Use transactions when multiple database operations must succeed or fail together (e.g., delete + insert patterns, multi-table updates). This prevents partial updates that leave data inconsistent.
@@ -422,5 +445,6 @@ When reviewing or writing code, ensure:
 - [ ] Entity-derived types are accessed via `domain::<module>::<Type>` in web code (never `entity_api::...` or `entity::...`)
 - [ ] Async operations don't block the runtime
 - [ ] Public APIs have doc comments
+- [ ] Every `reqwest::Client` is built with `.use_rustls_tls()`; no `reqwest::Client::new()` or bare `reqwest::get(...)` in production code
 - [ ] Code passes `cargo clippy` without warnings
 - [ ] Code is formatted with `cargo fmt`

--- a/domain/src/gateway/oauth/zoom.rs
+++ b/domain/src/gateway/oauth/zoom.rs
@@ -15,7 +15,8 @@ use secrecy::SecretString;
 ///
 /// # Returns
 ///
-/// A configured Zoom OAuth provider ready for use.
+/// `Ok(ZoomProvider)` on success, or `Err(meeting_auth::error::Error)` if the
+/// underlying rustls HTTP client cannot be constructed.
 ///
 /// # Example
 ///
@@ -26,7 +27,8 @@ use secrecy::SecretString;
 ///     config.zoom_client_id().unwrap(),
 ///     SecretString::from(config.zoom_client_secret().unwrap()),
 ///     config.zoom_redirect_uri().unwrap(),
-/// );
+/// )
+/// .expect("failed to build Zoom OAuth provider");
 /// ```
 pub fn new_provider(
     client_id: String,

--- a/domain/src/gateway/oauth/zoom.rs
+++ b/domain/src/gateway/oauth/zoom.rs
@@ -32,6 +32,7 @@ pub fn new_provider(
     client_id: String,
     client_secret: SecretString,
     redirect_uri: String,
-) -> ZoomProvider {
+) -> Result<ZoomProvider, meeting_auth::error::Error> {
     ZoomProvider::new(client_id, client_secret, redirect_uri)
+        .map_err(meeting_auth::error::Error::from)
 }

--- a/domain/src/gateway/recall_ai/mod.rs
+++ b/domain/src/gateway/recall_ai/mod.rs
@@ -13,6 +13,9 @@ use crate::error::{DomainErrorKind, Error, ExternalErrorKind, InternalErrorKind}
 #[derive(Clone)]
 pub struct Provider {
     client: reqwest::Client,
+    /// Header-less rustls client for pre-signed transcript downloads.
+    /// Pre-signed URLs reject extra Authorization headers, so this cannot reuse `client`.
+    download_client: reqwest::Client,
     base_url: String,
 }
 
@@ -335,9 +338,19 @@ impl Provider {
             .timeout(std::time::Duration::from_secs(60))
             .build()?;
 
+        let download_client = reqwest::Client::builder()
+            .use_rustls_tls()
+            .connect_timeout(std::time::Duration::from_secs(10))
+            .timeout(std::time::Duration::from_secs(60))
+            .build()?;
+
         let base_url = format!("https://{}.recall.ai/api/v1", region);
 
-        Ok(Self { client, base_url })
+        Ok(Self {
+            client,
+            download_client,
+            base_url,
+        })
     }
 
     /// Creates a Recall.ai recording bot for the given meeting URL.
@@ -556,13 +569,18 @@ impl Provider {
     ) -> Result<Vec<ParticipantEntry>, Error> {
         debug!("Downloading transcript from pre-signed URL");
 
-        let response = reqwest::get(download_url).await.map_err(|e| {
-            warn!("Failed to download transcript: {:?}", e);
-            Error {
-                source: Some(Box::new(e)),
-                error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
-            }
-        })?;
+        let response = self
+            .download_client
+            .get(download_url)
+            .send()
+            .await
+            .map_err(|e| {
+                warn!("Failed to download transcript: {:?}", e);
+                Error {
+                    source: Some(Box::new(e)),
+                    error_kind: DomainErrorKind::External(ExternalErrorKind::Network),
+                }
+            })?;
 
         if response.status().is_success() {
             let data: Vec<ParticipantEntry> = response.json().await.map_err(|e| {
@@ -866,6 +884,7 @@ mod tests {
     fn test_provider(base_url: &str) -> Provider {
         Provider {
             client: reqwest::Client::new(),
+            download_client: reqwest::Client::new(),
             base_url: base_url.to_string(),
         }
     }

--- a/domain/src/oauth_connection.rs
+++ b/domain/src/oauth_connection.rs
@@ -262,7 +262,7 @@ fn create_zoom_provider(config: &Config) -> Result<impl Provider, Error> {
         client_id,
         client_secret,
         redirect_uri,
-    ))
+    )?)
 }
 
 fn create_oauth_connection_model(

--- a/meeting-auth/src/http/client.rs
+++ b/meeting-auth/src/http/client.rs
@@ -83,8 +83,8 @@ impl Builder {
     ///
     /// An authenticated HTTP client with middleware configured.
     pub fn build(self) -> Result<Client, reqwest::Error> {
-        // Build the base reqwest client
         let client = reqwest::Client::builder()
+            .use_rustls_tls()
             .timeout(self.config.timeout)
             .user_agent(self.config.user_agent)
             .build()?;

--- a/meeting-auth/src/oauth/providers/zoom.rs
+++ b/meeting-auth/src/oauth/providers/zoom.rs
@@ -103,13 +103,18 @@ impl Provider {
     /// * `client_id` - Zoom OAuth client ID
     /// * `client_secret` - Zoom OAuth client secret
     /// * `redirect_uri` - OAuth redirect URI
-    pub fn new(client_id: String, client_secret: SecretString, redirect_uri: String) -> Self {
-        Self {
+    pub fn new(
+        client_id: String,
+        client_secret: SecretString,
+        redirect_uri: String,
+    ) -> Result<Self, reqwest::Error> {
+        let http_client = reqwest::Client::builder().use_rustls_tls().build()?;
+        Ok(Self {
             client_id,
             client_secret,
             redirect_uri,
-            http_client: reqwest::Client::new(),
-        }
+            http_client,
+        })
     }
 }
 
@@ -356,6 +361,7 @@ mod tests {
             SecretString::from("test_client_secret".to_string()),
             "https://example.com/callback".to_string(),
         )
+        .expect("test provider construction must succeed")
     }
 
     #[test]


### PR DESCRIPTION
## Description

Transcript downloads were failing in production with `unable to get local issuer certificate` because `download_transcript` used bare `reqwest::get(...)`, which defaults to native-tls/OpenSSL. The runtime image is `debian:bullseye-slim` and intentionally ships without `ca-certificates`, so any native-tls call fails. A workspace audit found two more production paths with the same latent bug. This PR fixes all three and codifies the rule.

#### GitHub Issue: Fixes #337

### Changes
* `domain/src/gateway/recall_ai/mod.rs`: add a header-less rustls `download_client` on `Provider`; use it in `download_transcript` instead of bare `reqwest::get`. Pre-signed URLs reject extra `Authorization` headers, so this cannot reuse the authenticated `client`.
* `meeting-auth/src/oauth/providers/zoom.rs`: `Provider::new` now builds with `.use_rustls_tls()` and returns `Result<Self, reqwest::Error>`, matching the Google sibling provider.
* `domain/src/gateway/oauth/zoom.rs` and `domain/src/oauth_connection.rs`: propagate the new fallible signature.
* `meeting-auth/src/http/client.rs`: `Builder::build` adds `.use_rustls_tls()`.
* `.claude/coding-standards.md`: new "HTTP Clients (reqwest TLS)" section requiring `.use_rustls_tls()` on every production reqwest client. Documents why `ca-certificates` is intentionally absent from the runtime image (acts as a tripwire so rule violations fail loudly).

### Testing Strategy
* `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo fmt --check` all pass on this branch.
* Manual verification on PR preview: trigger a `transcript.done` webhook against a real Recall.ai async transcript. Before this PR, the download logged `unable to get local issuer certificate` from `us-west-2.recall.ai`. After this PR, the download should succeed, the transcription row should land with `Completed` status, and a non-empty `transcription_updated` SSE event should fire.
* Smoke-test the Zoom OAuth flow end-to-end (authorization code exchange) to confirm `Provider::new` still constructs correctly with the new fallible signature.

### Concerns
* The Dockerfile change initially included in this branch (installing `ca-certificates` as defense-in-depth) was reverted after review. The slim image's empty trust store is the tripwire that makes the rustls rule self-enforcing; the decision is documented in the new standards section.
* Issue #337's body still recommends installing `ca-certificates` under "Fix #3". That recommendation is now inverted; the issue body should be updated separately to match this PR's conclusion.