### PR TITLE
Run mock-feature tests in CI and fix mock-gated test/lint debt (#340)

### DIFF
--- a/.github/workflows/build-test-push.yml
+++ b/.github/workflows/build-test-push.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Run clippy
         run: cargo clippy --all-targets -- -D warnings
 
+      - name: Run clippy (mock feature)
+        run: cargo clippy -p entity_api -p domain -p web --all-targets --features "domain/mock,web/mock" -- -D warnings
+
       - name: Run format check
         run: cargo fmt --all -- --check
 
@@ -117,6 +120,9 @@ jobs:
 
       - name: Run tests
         run: cargo test
+
+      - name: Run mock-gated tests
+        run: cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"
 
       - name: Show sccache stats
         run: sccache --show-stats

--- a/.github/workflows/build_and_push_production_images.yml
+++ b/.github/workflows/build_and_push_production_images.yml
@@ -35,7 +35,10 @@ jobs:
         run: cargo install sea-orm-cli  # If needed for migrations / seeds
 
       - name: Run tests
-        run: cargo test --release  # Basic test step
+        run: cargo test --release
+
+      - name: Run mock-gated tests
+        run: cargo test --release -p entity_api -p domain -p web --features "domain/mock,web/mock"
 
   build_and_push_docker:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci-deploy-pr-preview.yml
+++ b/.github/workflows/ci-deploy-pr-preview.yml
@@ -394,6 +394,9 @@ jobs:
             - name: Run tests
               run: cargo test
 
+            - name: Run mock-gated tests
+              run: cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"
+
     # ===========================================================================
     # JOB 4: Frontend Build and Test
     # ===========================================================================

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -529,16 +529,10 @@ mod tests {
             duration_minutes: crate::duration::Duration::default_minutes(),
             meeting_url: Some("https://meet.google.com/existing-url".to_string()),
             provider: Some(Provider::Google),
-            created_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-                .unwrap()
-                .into(),
-            updated_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-                .unwrap()
-                .into(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z").unwrap(),
+            updated_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z").unwrap(),
             hydrated_at: Some(
-                chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-                    .unwrap()
-                    .into(),
+                chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z").unwrap(),
             ),
         };
 

--- a/domain/src/password_reset.rs
+++ b/domain/src/password_reset.rs
@@ -883,10 +883,10 @@ mod tests {
         );
     }
 
-    /// The target padding constant must stay in the "imperceptible-to-user
-    /// but generous-over-DB-jitter" range. Loosening below 100ms risks not
-    /// masking real DB-jitter variance; raising above ~500ms turns every
-    // HANDLER_TARGET_DURATION_MS bounds are guarded at compile time —
+    // The target padding constant must stay in the "imperceptible-to-user
+    // but generous-over-DB-jitter" range. Loosening below 100ms risks not
+    // masking real DB-jitter variance; raising above ~500ms turns every
+    // HANDLER_TARGET_DURATION_MS bounds are guarded at compile time,
     // see the const assertion at module scope (`_HANDLER_TARGET_DURATION_BOUNDS_CHECK`).
     // Build fails if someone loosens the value.
 

--- a/domain/src/webhook/recording_done.rs
+++ b/domain/src/webhook/recording_done.rs
@@ -142,7 +142,7 @@ mod tests {
     use entity::meeting_recording::{MeetingRecordingStatus, Model as RecordingModel};
     use entity::Id;
     use events::EventPublisher;
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+    use sea_orm::{DatabaseBackend, MockDatabase};
     use std::sync::Arc;
 
     fn recording_for_session(session_id: Id) -> RecordingModel {
@@ -167,16 +167,16 @@ mod tests {
     async fn recording_done_skips_when_try_claim_completed_returns_false() {
         let session_id = Id::new_v4();
         let recording = recording_for_session(session_id);
+        let mut already_terminal = recording.clone();
+        already_terminal.status = MeetingRecordingStatus::Completed;
 
         let db = Arc::new(
             MockDatabase::new(DatabaseBackend::Postgres)
                 // find_by_bot_id
                 .append_query_results(vec![vec![recording]])
-                // try_claim_completed — 0 rows affected means already terminal
-                .append_exec_results(vec![MockExecResult {
-                    last_insert_id: 0,
-                    rows_affected: 0,
-                }])
+                // try_claim_completed: locked re-read returns an already-terminal row,
+                // so the claim is declined (Ok(false)) without an UPDATE
+                .append_query_results(vec![vec![already_terminal]])
                 .into_connection(),
         );
 

--- a/domain/src/webhook/transcript_done.rs
+++ b/domain/src/webhook/transcript_done.rs
@@ -93,7 +93,7 @@ mod tests {
     use entity::transcription::{Model as TranscriptionModel, TranscriptionStatus};
     use entity::Id;
     use events::EventPublisher;
-    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+    use sea_orm::{DatabaseBackend, MockDatabase};
     use std::sync::Arc;
 
     fn queued_transcription() -> TranscriptionModel {
@@ -119,16 +119,16 @@ mod tests {
     #[tokio::test]
     async fn transcript_done_skips_when_try_claim_for_processing_returns_false() {
         let transcription = queued_transcription();
+        let mut already_claimed = transcription.clone();
+        already_claimed.status = TranscriptionStatus::Processing;
 
         let db = Arc::new(
             MockDatabase::new(DatabaseBackend::Postgres)
                 // find_by_external_id
                 .append_query_results(vec![vec![transcription]])
-                // try_claim_for_processing — 0 rows affected means already claimed
-                .append_exec_results(vec![MockExecResult {
-                    last_insert_id: 0,
-                    rows_affected: 0,
-                }])
+                // try_claim_for_processing: locked re-read returns a non-queued row,
+                // so the claim is declined (Ok(false)) without an UPDATE
+                .append_query_results(vec![vec![already_claimed]])
                 .into_connection(),
         );
 

--- a/entity_api/src/action.rs
+++ b/entity_api/src/action.rs
@@ -619,7 +619,7 @@ mod tests {
             .append_query_results(vec![vec![action_model.clone()]])
             .into_connection();
 
-        let action = create(&db, action_model.clone().into(), Id::new_v4()).await?;
+        let action = create(&db, action_model.clone(), Id::new_v4()).await?;
 
         assert_eq!(action.id, action_model.id);
 
@@ -704,7 +704,7 @@ mod tests {
 
         let result = update_status(&db, Id::new_v4(), Status::Completed).await;
 
-        assert_eq!(result.is_err(), true);
+        assert!(result.is_err());
 
         Ok(())
     }

--- a/entity_api/src/agreement.rs
+++ b/entity_api/src/agreement.rs
@@ -100,7 +100,7 @@ mod tests {
             .append_query_results(vec![vec![agreement_model.clone()]])
             .into_connection();
 
-        let agreement = create(&db, agreement_model.clone().into(), Id::new_v4()).await?;
+        let agreement = create(&db, agreement_model.clone(), Id::new_v4()).await?;
 
         assert_eq!(agreement.id, agreement_model.id);
 

--- a/entity_api/src/coaching_relationship.rs
+++ b/entity_api/src/coaching_relationship.rs
@@ -506,7 +506,7 @@ mod tests {
             [Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 r#"SELECT "coaching_relationships"."id", "coaching_relationships"."organization_id", "coaching_relationships"."coach_id", "coaching_relationships"."coachee_id", "coaching_relationships"."slug", "coaching_relationships"."created_at", "coaching_relationships"."updated_at" FROM "refactor_platform"."coaching_relationships" WHERE "coaching_relationships"."organization_id" IN (SELECT "organizations"."id" FROM "refactor_platform"."organizations" WHERE "organizations"."id" = $1)"#,
-                [organization_id.clone().into()]
+                [organization_id.into()]
             )]
         );
 
@@ -526,114 +526,10 @@ mod tests {
             [Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 r#"SELECT "coaching_relationships"."id", "coaching_relationships"."organization_id", "coaching_relationships"."coach_id", "coaching_relationships"."coachee_id", "coaching_relationships"."created_at", "coaching_relationships"."updated_at", coaches.first_name AS "coach_first_name", coaches.last_name AS "coach_last_name", coachees.first_name AS "coachee_first_name", coachees.last_name AS "coachee_last_name" FROM "refactor_platform"."coaching_relationships" JOIN "refactor_platform"."users" AS "coaches" ON "coaching_relationships"."coach_id" = "coaches"."id" JOIN "refactor_platform"."users" AS "coachees" ON "coaching_relationships"."coachee_id" = "coachees"."id" WHERE "coaching_relationships"."organization_id" IN (SELECT "organizations"."id" FROM "refactor_platform"."organizations" WHERE "organizations"."id" = $1)"#,
-                [organization_id.clone().into()]
+                [organization_id.into()]
             )]
         );
 
-        Ok(())
-    }
-
-    #[ignore = "Temporarily disabled due to user::find_by_id mock complexity with find_with_related queries"]
-    #[tokio::test]
-    async fn create_returns_validation_error_for_duplicate_relationship() -> Result<(), Error> {
-        use entity::coaching_relationships::Model;
-        use sea_orm::{DatabaseBackend, MockDatabase};
-
-        let organization_id = Id::new_v4();
-        let coach_id = Id::new_v4();
-        let coachee_id = Id::new_v4();
-        let coach_organization_id = Id::new_v4();
-        let coachee_organization_id = Id::new_v4();
-
-        let coach_user = entity::users::Model {
-            id: coach_id.clone(),
-            first_name: "Coach".to_string(),
-            last_name: "User".to_string(),
-            email: "coach@example.com".to_string(),
-            password: Some("hash".to_string()),
-            display_name: Some("Coach User".to_string()),
-            github_username: Some("coach_user".to_string()),
-            role: entity::users::Role::User,
-            github_profile_url: Some("https://github.com/coach_user".to_string()),
-            timezone: "UTC".to_string(),
-            default_coaching_session_duration_minutes: crate::duration::Duration::default_minutes(),
-            roles: vec![],
-            invite_status: None,
-            created_at: chrono::Utc::now().into(),
-            updated_at: chrono::Utc::now().into(),
-        };
-
-        let coachee_user = entity::users::Model {
-            id: coachee_id.clone(),
-            first_name: "Coachee".to_string(),
-            last_name: "User".to_string(),
-            email: "coachee@example.com".to_string(),
-            password: Some("hash".to_string()),
-            display_name: Some("Coachee User".to_string()),
-            github_username: Some("coachee_user".to_string()),
-            role: entity::users::Role::User,
-            roles: vec![],
-            invite_status: None,
-            github_profile_url: Some("https://github.com/coachee_user".to_string()),
-            timezone: "UTC".to_string(),
-            default_coaching_session_duration_minutes: crate::duration::Duration::default_minutes(),
-            created_at: chrono::Utc::now().into(),
-            updated_at: chrono::Utc::now().into(),
-        };
-
-        let coaching_relationships = vec![Model {
-            id: Id::new_v4(),
-            organization_id: organization_id.clone(),
-            coach_id: coach_id.clone(),
-            coachee_id: coachee_id.clone(),
-            slug: "coach-coachee".to_string(),
-            created_at: chrono::Utc::now().into(),
-            updated_at: chrono::Utc::now().into(),
-        }];
-
-        let coach_organization = entity::organizations::Model {
-            id: coach_organization_id,
-            name: "Organization".to_string(),
-            slug: "organization".to_string(),
-            logo: None,
-            created_at: chrono::Utc::now().into(),
-            updated_at: chrono::Utc::now().into(),
-        };
-
-        let coachee_organization = entity::organizations::Model {
-            id: coachee_organization_id,
-            name: "Organization".to_string(),
-            slug: "organization".to_string(),
-            logo: None,
-            created_at: chrono::Utc::now().into(),
-            updated_at: chrono::Utc::now().into(),
-        };
-
-        let db = MockDatabase::new(DatabaseBackend::Postgres)
-            .append_query_results(vec![vec![coach_user]])
-            .append_query_results(vec![vec![coachee_user]])
-            .append_query_results(vec![vec![coach_organization]])
-            .append_query_results(vec![vec![coachee_organization]])
-            .append_query_results(vec![coaching_relationships])
-            .into_connection();
-
-        let model = Model {
-            id: Id::new_v4(),
-            organization_id: organization_id.clone(),
-            coach_id: coach_id.clone(),
-            coachee_id: coachee_id.clone(),
-            slug: "coach-coachee".to_string(),
-            created_at: chrono::Utc::now().into(),
-            updated_at: chrono::Utc::now().into(),
-        };
-
-        let result = create(&db, organization_id, model).await;
-        println!("Result: {:?}", result);
-        let err = result.unwrap_err();
-        assert!(matches!(
-            err.error_kind,
-            EntityApiErrorKind::ValidationError { .. }
-        ));
         Ok(())
     }
 
@@ -649,7 +545,7 @@ mod tests {
             [Transaction::from_sql_and_values(
                 DatabaseBackend::Postgres,
                 r#"DELETE FROM "refactor_platform"."coaching_relationships" WHERE "coaching_relationships"."coach_id" = $1 OR "coaching_relationships"."coachee_id" = $2"#,
-                [user_id.clone().into(), user_id.clone().into()]
+                [user_id.into(), user_id.into()]
             )]
         );
 

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -1537,16 +1537,10 @@ mod tests {
             duration_minutes: crate::duration::Duration::default_minutes(),
             meeting_url: Some("https://meet.google.com/old-meet-url".to_string()),
             provider: Some(Provider::Google),
-            created_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-                .unwrap()
-                .into(),
-            updated_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-                .unwrap()
-                .into(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z").unwrap(),
+            updated_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z").unwrap(),
             hydrated_at: Some(
-                chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-                    .unwrap()
-                    .into(),
+                chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z").unwrap(),
             ),
         };
 
@@ -1559,16 +1553,10 @@ mod tests {
             duration_minutes: crate::duration::Duration::default_minutes(),
             meeting_url: Some("https://meet.google.com/latest-meet-url".to_string()),
             provider: Some(Provider::Google),
-            created_at: chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z")
-                .unwrap()
-                .into(),
-            updated_at: chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z")
-                .unwrap()
-                .into(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z").unwrap(),
+            updated_at: chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z").unwrap(),
             hydrated_at: Some(
-                chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z")
-                    .unwrap()
-                    .into(),
+                chrono::DateTime::parse_from_rfc3339("2025-02-01T00:00:00Z").unwrap(),
             ),
         };
 
@@ -1581,16 +1569,10 @@ mod tests {
             duration_minutes: crate::duration::Duration::default_minutes(),
             meeting_url: None,
             provider: None,
-            created_at: chrono::DateTime::parse_from_rfc3339("2025-03-01T00:00:00Z")
-                .unwrap()
-                .into(),
-            updated_at: chrono::DateTime::parse_from_rfc3339("2025-03-01T00:00:00Z")
-                .unwrap()
-                .into(),
+            created_at: chrono::DateTime::parse_from_rfc3339("2025-03-01T00:00:00Z").unwrap(),
+            updated_at: chrono::DateTime::parse_from_rfc3339("2025-03-01T00:00:00Z").unwrap(),
             hydrated_at: Some(
-                chrono::DateTime::parse_from_rfc3339("2025-03-01T00:00:00Z")
-                    .unwrap()
-                    .into(),
+                chrono::DateTime::parse_from_rfc3339("2025-03-01T00:00:00Z").unwrap(),
             ),
         };
 

--- a/entity_api/src/goal.rs
+++ b/entity_api/src/goal.rs
@@ -253,7 +253,7 @@ mod tests {
             .append_query_results(vec![vec![goal_model.clone()]])
             .into_connection();
 
-        let goal = create(&db, goal_model.clone().into(), Id::new_v4()).await?;
+        let goal = create(&db, goal_model.clone(), Id::new_v4()).await?;
 
         assert_eq!(goal.id, goal_model.id);
 
@@ -344,7 +344,7 @@ mod tests {
 
         let result = update_status(&db, Id::new_v4(), Status::Completed).await;
 
-        assert_eq!(result.is_err(), true);
+        assert!(result.is_err());
 
         Ok(())
     }

--- a/entity_api/src/note.rs
+++ b/entity_api/src/note.rs
@@ -138,7 +138,7 @@ mod tests {
             .append_query_results(vec![vec![note_model.clone()]])
             .into_connection();
 
-        let note = create(&db, note_model.clone().into(), Id::new_v4()).await?;
+        let note = create(&db, note_model.clone(), Id::new_v4()).await?;
 
         assert_eq!(note.id, note_model.id);
 

--- a/entity_api/src/oauth_connection.rs
+++ b/entity_api/src/oauth_connection.rs
@@ -256,18 +256,14 @@ mod tests {
             id: Id::new_v4(),
             user_id,
             provider: Provider::Google,
-            updated_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z")
-                .unwrap()
-                .into(),
+            updated_at: chrono::DateTime::parse_from_rfc3339("2025-01-01T00:00:00Z").unwrap(),
             ..test_model()
         };
         let newer = Model {
             id: Id::new_v4(),
             user_id,
             provider: Provider::Zoom,
-            updated_at: chrono::DateTime::parse_from_rfc3339("2026-04-01T00:00:00Z")
-                .unwrap()
-                .into(),
+            updated_at: chrono::DateTime::parse_from_rfc3339("2026-04-01T00:00:00Z").unwrap(),
             ..test_model()
         };
 

--- a/web/src/controller/coaching_session/meeting_recording_controller.rs
+++ b/web/src/controller/coaching_session/meeting_recording_controller.rs
@@ -187,7 +187,7 @@ mod tests {
             first_name: "Coach".to_string(),
             last_name: "User".to_string(),
             display_name: None,
-            password: Some(generate_hash("password123".to_string())),
+            password: Some(generate_hash("password123")),
             github_username: None,
             github_profile_url: None,
             timezone: "UTC".to_string(),

--- a/web/src/extractors/coaching_session_access.rs
+++ b/web/src/extractors/coaching_session_access.rs
@@ -125,7 +125,7 @@ mod tests {
             first_name: "Test".to_string(),
             last_name: "User".to_string(),
             display_name: Some("Test User".to_string()),
-            password: Some(generate_hash("password123".to_string())),
+            password: Some(generate_hash("password123")),
             github_username: None,
             github_profile_url: None,
             timezone: "UTC".to_string(),

--- a/web/src/extractors/organization_member_access.rs
+++ b/web/src/extractors/organization_member_access.rs
@@ -148,7 +148,7 @@ mod tests {
             first_name: "Test".to_string(),
             last_name: "User".to_string(),
             display_name: Some("Test User".to_string()),
-            password: Some(generate_hash("password123".to_string())),
+            password: Some(generate_hash("password123")),
             github_username: None,
             github_profile_url: None,
             timezone: "UTC".to_string(),

--- a/web/src/extractors/session_renewal_tests.rs
+++ b/web/src/extractors/session_renewal_tests.rs
@@ -26,7 +26,7 @@ mod session_renewal_integration_tests {
             first_name: "Test".to_string(),
             last_name: "User".to_string(),
             display_name: Some("Test User".to_string()),
-            password: Some(generate_hash("password123".to_string())),
+            password: Some(generate_hash("password123")),
             github_username: None,
             github_profile_url: None,
             timezone: "UTC".to_string(),


### PR DESCRIPTION
## Description
CI ran plain `cargo test`, which compiles out every `#[cfg(feature = "mock")]` test in `entity_api`, `domain`, and `web` — the whole MockDatabase suite only ran locally. This enables it in CI, fixes the tests that had rotted, and closes the matching clippy gap.

#### GitHub Issue: Closes #340

### Changes
* Add a `Run mock-gated tests` step (`cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"`) to all three CI workflows, alongside the existing `cargo test`.
* Fix two mock tests broken by `072b66b`'s switch to a transactional claim (`recording_done`, `transcript_done`).
* Delete the perpetually-ignored, brittle `create_returns_validation_error_for_duplicate_relationship` test; the invariant is enforced by a DB unique constraint.
* Fix 40 clippy errors in mock-gated code and add a mock-feature clippy step to the lint job.

### Testing Strategy
* Mock suite green: `cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"`.
* `cargo test`, both clippy passes, and `cargo fmt --check` all clean.

### Concerns
* Can't enable mock workspace-wide: `--workspace --features mock` pulls `sea-orm/mock`, which drops `DatabaseConnection: Clone` (sea-orm #830) and breaks the binary build — hence the crate-targeted second step.
