### PR TITLE
Emit coaching_session_goal_created SSE for auto-linked (carried-forward) goals

### DIFF
--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -2,6 +2,7 @@ pub(crate) mod recurrence;
 
 use crate::coaching_sessions::Model;
 use crate::error::{DomainErrorKind, Error, InternalErrorKind};
+use crate::events::{DomainEvent, EventPublisher};
 use crate::gateway::tiptap::TiptapDocument;
 use crate::provider::MeetingProperties;
 use crate::Id;
@@ -68,6 +69,7 @@ impl SessionDate {
 pub async fn create(
     db: &DatabaseConnection,
     config: &Config,
+    event_publisher: &EventPublisher,
     mut coaching_session_model: Model,
     requested_duration: Option<Duration>,
 ) -> Result<Model, Error> {
@@ -93,34 +95,48 @@ pub async fn create(
     // succeed or fail atomically. If the transaction fails, compensate by
     // deleting the Tiptap document we just created.
     let txn = db.begin().await.map_err(entity_api::error::Error::from)?;
-    let result: Result<Model, Error> = async {
+    let result: Result<(Model, Vec<Id>), Error> = async {
         let session =
             coaching_session::create(&txn, coaching_session_model, coach_id, requested_duration)
                 .await?;
 
-        let linked = coaching_session_goal::link_in_progress_goals_to_session(
+        let linked_goal_ids = coaching_session_goal::link_in_progress_goals_to_session(
             &txn,
             session.coaching_relationship_id,
             session.id,
         )
         .await?;
         debug!(
-            "Linked {linked} in-progress goal(s) to session {}",
+            "Linked {} in-progress goal(s) to session {}",
+            linked_goal_ids.len(),
             session.id
         );
 
         txn.commit().await.map_err(entity_api::error::Error::from)?;
-        Ok(session)
+        Ok((session, linked_goal_ids))
     }
     .await;
 
-    if result.is_err() {
-        if let Err(e) = tiptap.delete(&document_name).await {
-            warn!("Failed to clean up Tiptap document '{document_name}' after DB error: {e}");
+    // Publish after commit so subscribers never refetch against goal links
+    // that a rolled-back transaction never persisted.
+    match result {
+        Ok((session, linked_goal_ids)) => {
+            publish_goals_linked(
+                event_publisher,
+                &coaching_relationship,
+                session.id,
+                &linked_goal_ids,
+            )
+            .await;
+            Ok(session)
+        }
+        Err(e) => {
+            if let Err(cleanup_err) = tiptap.delete(&document_name).await {
+                warn!("Failed to clean up Tiptap document '{document_name}' after DB error: {cleanup_err}");
+            }
+            Err(e)
         }
     }
-
-    result
 }
 
 /// Bulk-creates a series of coaching sessions. Provider is intentionally not
@@ -160,6 +176,7 @@ pub async fn bulk_create_recurring(
 pub async fn ensure_hydrated(
     db: &DatabaseConnection,
     config: &Config,
+    event_publisher: &EventPublisher,
     session: Model,
 ) -> Result<Model, Error> {
     if session.hydrated_at.is_some() {
@@ -188,7 +205,7 @@ pub async fn ensure_hydrated(
     let tiptap = TiptapDocument::new(config).await?;
 
     let coach_id = coaching_relationship.coach_id;
-    let result: Result<Model, Error> = async {
+    let result: Result<(Model, Vec<Id>), Error> = async {
         tiptap.create(&document_name).await?;
         session.collab_document_name = Some(document_name.clone());
 
@@ -197,7 +214,7 @@ pub async fn ensure_hydrated(
             maybe_attach_meeting_url(db, config, &mut session, coach_id).await?;
         }
 
-        let linked = coaching_session_goal::link_in_progress_goals_to_session(
+        let linked_goal_ids = coaching_session_goal::link_in_progress_goals_to_session(
             &txn,
             session.coaching_relationship_id,
             session.id,
@@ -205,25 +222,71 @@ pub async fn ensure_hydrated(
         .await?;
 
         debug!(
-            "Linked {linked} in-progress goal(s) to session {}",
+            "Linked {} in-progress goal(s) to session {}",
+            linked_goal_ids.len(),
             session.id
         );
 
         let updated = coaching_session::mark_hydrated(&txn, &session).await?;
         txn.commit().await.map_err(entity_api::error::Error::from)?;
-        Ok(updated)
+        Ok((updated, linked_goal_ids))
     }
     .await;
 
-    if result.is_err() {
-        if let Err(e) = tiptap.delete(&document_name).await {
-            warn!(
-                "Failed to clean up Tiptap document '{document_name}' after hydration error: {e}"
-            );
+    // Publish after commit so subscribers never refetch against goal links
+    // that a rolled-back transaction never persisted.
+    match result {
+        Ok((updated, linked_goal_ids)) => {
+            publish_goals_linked(
+                event_publisher,
+                &coaching_relationship,
+                updated.id,
+                &linked_goal_ids,
+            )
+            .await;
+            Ok(updated)
+        }
+        Err(e) => {
+            if let Err(cleanup_err) = tiptap.delete(&document_name).await {
+                warn!(
+                    "Failed to clean up Tiptap document '{document_name}' after hydration error: {cleanup_err}"
+                );
+            }
+            Err(e)
         }
     }
+}
 
-    result
+/// Publishes a `CoachingSessionGoalCreated` event for each goal newly linked to
+/// a session during create/hydration, so connected clients refresh the session's
+/// goal list. Mirrors the manual link path's notification contract; a no-op when
+/// no new links were inserted.
+async fn publish_goals_linked(
+    event_publisher: &EventPublisher,
+    relationship: &crate::coaching_relationships::Model,
+    coaching_session_id: Id,
+    goal_ids: &[Id],
+) {
+    if goal_ids.is_empty() {
+        return;
+    }
+
+    let notify_user_ids = vec![relationship.coach_id, relationship.coachee_id];
+    for goal_id in goal_ids {
+        event_publisher
+            .publish(DomainEvent::CoachingSessionGoalCreated {
+                coaching_relationship_id: relationship.id,
+                coaching_session_id,
+                goal_id: *goal_id,
+                notify_user_ids: notify_user_ids.clone(),
+            })
+            .await;
+    }
+
+    debug!(
+        "Published {} CoachingSessionGoalCreated event(s) for session {coaching_session_id}",
+        goal_ids.len()
+    );
 }
 
 pub async fn find_by<P>(db: &DatabaseConnection, params: P) -> Result<Vec<Model>, Error>
@@ -413,9 +476,32 @@ mod tests {
         coaching_relationships, coaching_sessions, goals, oauth_connections, organizations,
         provider::Provider,
     };
+    use async_trait::async_trait;
+    use events::EventHandler;
     use mockito::Server;
     use sea_orm::{DatabaseBackend, MockDatabase};
     use service::config::Config;
+    use std::sync::{Arc, Mutex};
+
+    /// Records published events so tests can assert exactly what fired.
+    struct RecordingHandler {
+        events: Arc<Mutex<Vec<DomainEvent>>>,
+    }
+
+    #[async_trait]
+    impl EventHandler for RecordingHandler {
+        async fn handle(&self, event: &DomainEvent) {
+            self.events.lock().unwrap().push(event.clone());
+        }
+    }
+
+    fn recording_publisher() -> (EventPublisher, Arc<Mutex<Vec<DomainEvent>>>) {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let handler = Arc::new(RecordingHandler {
+            events: events.clone(),
+        });
+        (EventPublisher::new().with_handler(handler), events)
+    }
 
     fn test_organization() -> organizations::Model {
         let now = chrono::Utc::now();
@@ -469,6 +555,88 @@ mod tests {
         ])
     }
 
+    /// Creating a session links the relationship's in-progress goals and
+    /// publishes one `CoachingSessionGoalCreated` per newly-linked goal,
+    /// scoped to the coach and coachee. This is the signal the carry-forward
+    /// path previously omitted, leaving clients unaware of auto-linked goals.
+    #[tokio::test]
+    async fn create_publishes_link_event_for_each_carried_forward_goal() -> Result<(), Error> {
+        let mut server = Server::new_async().await;
+        let _tiptap_mock = server
+            .mock("POST", mockito::Matcher::Any)
+            .with_status(200)
+            .create_async()
+            .await;
+
+        let org = test_organization();
+        let coach_id = Id::new_v4();
+        let relationship = test_coaching_relationship(coach_id, org.id);
+        let session = test_session(relationship.id, None);
+
+        let now = chrono::Utc::now();
+        let goal = goals::Model {
+            id: Id::new_v4(),
+            coaching_relationship_id: relationship.id,
+            created_in_session_id: None,
+            user_id: Id::new_v4(),
+            title: Some("Carried-forward goal".to_string()),
+            body: None,
+            status: entity_api::status::Status::InProgress,
+            status_changed_at: None,
+            completed_at: None,
+            target_date: None,
+            created_at: now.into(),
+            updated_at: now.into(),
+        };
+        let link = entity_api::coaching_sessions_goals::Model {
+            id: Id::new_v4(),
+            coaching_session_id: session.id,
+            goal_id: goal.id,
+            created_at: now.into(),
+            updated_at: now.into(),
+        };
+
+        // Queries: relationship, organization, session INSERT, in-progress goals
+        // SELECT (one goal), join INSERT...RETURNING (one freshly-linked row).
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![relationship.clone()]])
+            .append_query_results(vec![vec![org.clone()]])
+            .append_query_results(vec![vec![session.clone()]])
+            .append_query_results(vec![vec![goal.clone()]])
+            .append_query_results(vec![vec![link.clone()]])
+            .into_connection();
+
+        let config = test_config(&server.url());
+        let (publisher, recorded) = recording_publisher();
+        create(
+            &db,
+            &config,
+            &publisher,
+            session.clone(),
+            Some(Duration::default()),
+        )
+        .await?;
+
+        let events = recorded.lock().unwrap();
+        assert_eq!(events.len(), 1, "expected one link event, got {events:?}");
+        match &events[0] {
+            DomainEvent::CoachingSessionGoalCreated {
+                coaching_relationship_id,
+                coaching_session_id,
+                goal_id,
+                notify_user_ids,
+            } => {
+                assert_eq!(*coaching_relationship_id, relationship.id);
+                assert_eq!(*coaching_session_id, session.id);
+                assert_eq!(*goal_id, goal.id);
+                assert_eq!(notify_user_ids, &vec![coach_id, relationship.coachee_id]);
+            }
+            other => panic!("expected CoachingSessionGoalCreated, got {other:?}"),
+        }
+
+        Ok(())
+    }
+
     /// When no provider is set, the oauth credentials lookup is skipped entirely.
     #[tokio::test]
     async fn create_without_provider_skips_oauth_lookup() -> Result<(), Error> {
@@ -496,7 +664,14 @@ mod tests {
             .into_connection();
 
         let config = test_config(&server.url());
-        let result = create(&db, &config, session.clone(), Some(Duration::default())).await?;
+        let result = create(
+            &db,
+            &config,
+            &EventPublisher::new(),
+            session.clone(),
+            Some(Duration::default()),
+        )
+        .await?;
 
         assert!(result.meeting_url.is_none());
         Ok(())
@@ -558,7 +733,14 @@ mod tests {
             .into_connection();
 
         let config = test_config(&server.url());
-        let result = create(&db, &config, session, Some(Duration::default())).await?;
+        let result = create(
+            &db,
+            &config,
+            &EventPublisher::new(),
+            session,
+            Some(Duration::default()),
+        )
+        .await?;
 
         assert_eq!(
             result.meeting_url,
@@ -603,7 +785,14 @@ mod tests {
             .into_connection();
 
         let config = test_config(&server.url());
-        let result = create(&db, &config, session.clone(), Some(Duration::default())).await?;
+        let result = create(
+            &db,
+            &config,
+            &EventPublisher::new(),
+            session.clone(),
+            Some(Duration::default()),
+        )
+        .await?;
 
         assert!(result.meeting_url.is_none());
         Ok(())
@@ -641,7 +830,7 @@ mod tests {
             .append_query_results(vec![vec![hydrated_row.clone()]])
             .into_connection();
 
-        let result = ensure_hydrated(&db, &config, input.clone()).await?;
+        let result = ensure_hydrated(&db, &config, &EventPublisher::new(), input.clone()).await?;
         assert_eq!(result.id, input.id);
         assert!(result.hydrated_at.is_some());
         Ok(())
@@ -690,7 +879,7 @@ mod tests {
             )])
             .into_connection();
 
-        let result = ensure_hydrated(&db, &config, input).await;
+        let result = ensure_hydrated(&db, &config, &EventPublisher::new(), input).await;
         assert!(
             result.is_err(),
             "expected ensure_hydrated to surface the error"
@@ -718,7 +907,7 @@ mod tests {
         let session = test_session(Id::new_v4(), None);
         assert!(session.hydrated_at.is_some());
 
-        let result = ensure_hydrated(&db, &config, session.clone()).await?;
+        let result = ensure_hydrated(&db, &config, &EventPublisher::new(), session.clone()).await?;
         assert_eq!(result.id, session.id);
         Ok(())
     }

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -1,5 +1,6 @@
 pub(crate) mod recurrence;
 
+use crate::coaching_relationships;
 use crate::coaching_sessions::Model;
 use crate::error::{DomainErrorKind, Error, InternalErrorKind};
 use crate::events::{DomainEvent, EventPublisher};
@@ -40,7 +41,7 @@ pub fn parse_duration_minutes(minutes: Option<i16>) -> Result<Option<Duration>, 
 pub async fn find_by_id_with_coaching_relationship(
     db: &DatabaseConnection,
     id: Id,
-) -> Result<(Model, crate::coaching_relationships::Model), Error> {
+) -> Result<(Model, coaching_relationships::Model), Error> {
     Ok(coaching_session::find_by_id_with_coaching_relationship(db, id).await?)
 }
 
@@ -263,7 +264,7 @@ pub async fn ensure_hydrated(
 /// no new links were inserted.
 async fn publish_goals_linked(
     event_publisher: &EventPublisher,
-    relationship: &crate::coaching_relationships::Model,
+    relationship: &coaching_relationships::Model,
     coaching_session_id: Id,
     goal_ids: &[Id],
 ) {
@@ -472,36 +473,11 @@ fn generate_document_name(organization_slug: &str, relationship_slug: &str) -> S
 #[cfg(feature = "mock")]
 mod tests {
     use super::*;
-    use crate::{
-        coaching_relationships, coaching_sessions, goals, oauth_connections, organizations,
-        provider::Provider,
-    };
-    use async_trait::async_trait;
-    use events::EventHandler;
+    use crate::test_support::recording_publisher;
+    use crate::{coaching_sessions, goals, oauth_connections, organizations, provider::Provider};
     use mockito::Server;
     use sea_orm::{DatabaseBackend, MockDatabase};
     use service::config::Config;
-    use std::sync::{Arc, Mutex};
-
-    /// Records published events so tests can assert exactly what fired.
-    struct RecordingHandler {
-        events: Arc<Mutex<Vec<DomainEvent>>>,
-    }
-
-    #[async_trait]
-    impl EventHandler for RecordingHandler {
-        async fn handle(&self, event: &DomainEvent) {
-            self.events.lock().unwrap().push(event.clone());
-        }
-    }
-
-    fn recording_publisher() -> (EventPublisher, Arc<Mutex<Vec<DomainEvent>>>) {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let handler = Arc::new(RecordingHandler {
-            events: events.clone(),
-        });
-        (EventPublisher::new().with_handler(handler), events)
-    }
 
     fn test_organization() -> organizations::Model {
         let now = chrono::Utc::now();

--- a/domain/src/coaching_session_goal.rs
+++ b/domain/src/coaching_session_goal.rs
@@ -205,35 +205,11 @@ async fn publish_session_goal_deleted(
 mod integration_tests {
     use super::*;
     use crate::error::{DomainErrorKind, EntityErrorKind, InternalErrorKind};
-    use async_trait::async_trait;
+    use crate::test_support::recording_publisher;
     use entity_api::coaching_relationships;
     use entity_api::coaching_sessions;
     use entity_api::status::Status;
-    use events::EventHandler;
     use sea_orm::{DatabaseBackend, MockDatabase};
-    use std::sync::{Arc, Mutex};
-
-    /// Recording event handler — captures every published event in order so
-    /// tests can assert exactly which events fired and in what sequence.
-    struct RecordingHandler {
-        events: Arc<Mutex<Vec<DomainEvent>>>,
-    }
-
-    #[async_trait]
-    impl EventHandler for RecordingHandler {
-        async fn handle(&self, event: &DomainEvent) {
-            self.events.lock().unwrap().push(event.clone());
-        }
-    }
-
-    fn recording_publisher() -> (EventPublisher, Arc<Mutex<Vec<DomainEvent>>>) {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let handler = Arc::new(RecordingHandler {
-            events: events.clone(),
-        });
-        let publisher = EventPublisher::new().with_handler(handler);
-        (publisher, events)
-    }
 
     fn build_goal(status: Status, relationship_id: Id) -> Model {
         let now = chrono::Utc::now().fixed_offset();

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -43,5 +43,8 @@ pub mod user;
 pub mod gateway;
 pub mod webhook;
 
+#[cfg(all(test, feature = "mock"))]
+mod test_support;
+
 // Re-export events crate as the events module to maintain existing API
 pub use events;

--- a/domain/src/test_support.rs
+++ b/domain/src/test_support.rs
@@ -1,0 +1,28 @@
+//! Shared test-only helpers for the domain crate.
+
+use crate::events::{DomainEvent, EventPublisher};
+use async_trait::async_trait;
+use events::EventHandler;
+use std::sync::{Arc, Mutex};
+
+/// Captures every published event, in order, for assertion.
+struct RecordingHandler {
+    events: Arc<Mutex<Vec<DomainEvent>>>,
+}
+
+#[async_trait]
+impl EventHandler for RecordingHandler {
+    async fn handle(&self, event: &DomainEvent) {
+        self.events.lock().unwrap().push(event.clone());
+    }
+}
+
+/// Builds an `EventPublisher` wired to a recording handler, returning the
+/// publisher plus a shared handle to the events it captures.
+pub(crate) fn recording_publisher() -> (EventPublisher, Arc<Mutex<Vec<DomainEvent>>>) {
+    let events = Arc::new(Mutex::new(Vec::new()));
+    let handler = Arc::new(RecordingHandler {
+        events: events.clone(),
+    });
+    (EventPublisher::new().with_handler(handler), events)
+}

--- a/entity_api/src/coaching_session_goal.rs
+++ b/entity_api/src/coaching_session_goal.rs
@@ -291,8 +291,9 @@ pub async fn find_in_progress_goals_by_coaching_session_id(
 /// then bulk-inserts a join row for each one. Insertion uses
 /// `ON CONFLICT (coaching_session_id, goal_id) DO NOTHING`, so repeat calls
 /// for the same session are safe — already-linked goals are silently skipped.
-/// Returns the number of rows actually inserted (zero when every goal was
-/// already linked).
+/// Returns the goal IDs of the rows actually inserted (empty when every goal
+/// was already linked), letting callers publish a link event per newly-linked
+/// goal without re-querying or risking duplicate notifications.
 ///
 /// This function does not manage its own transaction — callers are expected
 /// to wrap it in a transaction when atomicity with other operations is needed.
@@ -304,7 +305,7 @@ pub async fn link_in_progress_goals_to_session(
     db: &impl ConnectionTrait,
     coaching_relationship_id: Id,
     session_id: Id,
-) -> Result<usize, Error> {
+) -> Result<Vec<Id>, Error> {
     // Defensive cap: the write path enforces the limit, but we cap here too for safety.
     let in_progress_goals: Vec<_> =
         super::goal::find_in_progress_goals_by_coaching_relationship_id(
@@ -317,7 +318,7 @@ pub async fn link_in_progress_goals_to_session(
         .collect();
 
     if in_progress_goals.is_empty() {
-        return Ok(0);
+        return Ok(Vec::new());
     }
 
     let now = chrono::Utc::now();
@@ -341,7 +342,7 @@ pub async fn link_in_progress_goals_to_session(
         .exec_with_returning_many(db)
         .await?;
 
-    Ok(inserted.len())
+    Ok(inserted.into_iter().map(|link| link.goal_id).collect())
 }
 
 /// Finds all goal models for multiple coaching sessions at once, grouped by session ID.
@@ -762,6 +763,8 @@ mod tests {
             updated_at: now.into(),
         };
 
+        let expected_goal_ids = [join1.goal_id, join2.goal_id];
+
         // Mock sequence: 1 SELECT (in-progress goals) + 1 bulk INSERT...RETURNING
         // that returns both freshly-inserted rows (no conflicts).
         let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -769,8 +772,12 @@ mod tests {
             .append_query_results(vec![vec![join1, join2]])
             .into_connection();
 
-        let count = link_in_progress_goals_to_session(&db, relationship_id, session_id).await?;
-        assert_eq!(count, 2, "should link 2 in-progress goals");
+        let linked = link_in_progress_goals_to_session(&db, relationship_id, session_id).await?;
+        assert_eq!(linked.len(), 2, "should link 2 in-progress goals");
+        assert!(
+            expected_goal_ids.iter().all(|id| linked.contains(id)),
+            "returned goal IDs should match the inserted links"
+        );
 
         Ok(())
     }
@@ -785,8 +792,11 @@ mod tests {
             .append_query_results(vec![Vec::<goals::Model>::new()])
             .into_connection();
 
-        let count = link_in_progress_goals_to_session(&db, relationship_id, session_id).await?;
-        assert_eq!(count, 0, "should link 0 goals when none are in-progress");
+        let linked = link_in_progress_goals_to_session(&db, relationship_id, session_id).await?;
+        assert!(
+            linked.is_empty(),
+            "should link 0 goals when none are in-progress"
+        );
 
         Ok(())
     }
@@ -808,9 +818,9 @@ mod tests {
             .append_query_results(vec![Vec::<Model>::new()])
             .into_connection();
 
-        let count = link_in_progress_goals_to_session(&db, relationship_id, session_id).await?;
-        assert_eq!(
-            count, 0,
+        let linked = link_in_progress_goals_to_session(&db, relationship_id, session_id).await?;
+        assert!(
+            linked.is_empty(),
             "should report 0 new links when all goals were already linked"
         );
 

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -47,6 +47,7 @@ pub async fn read(
     let coaching_session = CoachingSessionApi::ensure_hydrated(
         app_state.db_conn_ref(),
         &app_state.config,
+        app_state.event_publisher.as_ref(),
         coaching_session,
     )
     .await?;
@@ -137,6 +138,7 @@ pub async fn create(
     let coaching_session = CoachingSessionApi::create(
         app_state.db_conn_ref(),
         &app_state.config,
+        app_state.event_publisher.as_ref(),
         coaching_session_model,
         requested_duration,
     )


### PR DESCRIPTION
## Description

Coaching goals carried forward into a session — the in-progress goals auto-linked when a session is created, and when a deferred (recurring) session is hydrated on first read — were inserted into `coaching_sessions_goals` **silently**: no SSE event was published. The frontend's goals panel fetches linked goals on mount and reacts to `coaching_session_goal_created` by revalidating its cache, but since the auto-link path never emitted that event, clients had no signal to refetch. On a freshly-opened recurring session the initial goals fetch also races hydration and usually wins (returning empty), so the panel stayed empty until some unrelated event or focus-revalidation happened to refetch.

This makes the automatic carry-forward path publish `CoachingSessionGoalCreated` per newly-linked goal, exactly like the existing manual link path already does. No frontend change is required — it already invalidates the session-goal cache on this event, so the panel self-heals within one SSE round-trip after hydration commits.

### Changes
* `entity_api::coaching_session_goal::link_in_progress_goals_to_session` now returns the goal IDs it actually inserted (`Vec<Id>`) instead of a `usize` count. The `ON CONFLICT DO NOTHING` + `exec_with_returning_many` already returns only genuinely-new rows, so callers get exactly the links to announce — no re-query, no risk of emitting for already-linked goals.
* `domain::coaching_session::{create, ensure_hydrated}` take an `&EventPublisher` and publish one `CoachingSessionGoalCreated` per newly-linked goal **after commit** (new `publish_goals_linked` helper), mirroring `link_to_coaching_session`'s contract.
* `web` coaching-session `read` and `create` handlers pass `app_state.event_publisher.as_ref()`.
* Updated the affected entity_api/domain tests; added a domain test asserting one event fires per linked goal, scoped to coach + coachee.

### Testing Strategy
* `cargo check` (default features) — clean across the workspace (confirms no other caller of the two domain functions broke).
* Mock-gated tests: `cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"` — pass, including the new `create_publishes_link_event_for_each_carried_forward_goal`.
* `cargo clippy --all-targets -- -D warnings` on both default and `domain/mock,web/mock` features — clean; `cargo fmt` applied.
* Verified against production-shaped logs: opening a deferred recurring session shows `Linked 2 in-progress goal(s)` → `Sent coaching_session_goal_created event to 2 user(s)` (x2) → `Published 2 CoachingSessionGoalCreated event(s)`, immediately followed by the client re-fetching `/coaching_sessions/{id}/goals` so the goals appear.

### Concerns
* This makes the panel **self-correct** reliably, but does not remove the brief empty first paint: the goals fetch still races hydration and usually wins. Closing that read race (and the related `generate_collab_token` 500 when `collab_document_name` is still null on an unhydrated session) was scoped as a follow-up but is being superseded by moving to self-hosted TipTap docs + synchronous session creation, which removes deferred hydration (the root cause) entirely.
* When that synchronous-creation work lands, the recurring-create path (`bulk_create_recurring`, which currently links no goals) should adopt this same link-goals + publish-event pattern.