### PR TITLE
feat(coaching-session-topics): coachee-set relevance + immediacy rating (rs#348)

### DIFF
--- a/docs/implementation-plans/coaching-session-topics-backend.md
+++ b/docs/implementation-plans/coaching-session-topics-backend.md
@@ -199,7 +199,29 @@ from CRUD/reorder logic, and a focused migration commit is trivial to review and
   the guard. Gates reproduced: 173/194/83 (no new tests — mirrors untested sibling loaders). 4
   `IncludeOptions` test literals got the new field. Scope: 3 files, no out-of-scope.
 - **✅ Epic Phase 1 (P1–P5) COMPLETE** — Title (rs#346, PR #349) + Topics CRUD/reorder/authz/include
-  (rs#347). P6–P7 (rating, rs#348, epic Phase 2) not started.
+  (rs#347, PR #350).
+- **P6 — Rating schema + enums — ✅ APPROVED** (overseer-reviewed 2026-06-07). Branch
+  `feat/348-topic-rating` (off feat/347; stacked), commit `c30a9bd`. Migration
+  `m20260607_000002_add_topic_rating_enums`: `CREATE TYPE topic_relevance`/`topic_immediacy` (each
+  `+ OWNER TO refactor`), columns `NOT NULL DEFAULT 'neutral'`, `down` drops cols then types. Entity
+  enums `Relevance` (neutral/peripheral/worth_exploring/central) + `Immediacy`
+  (neutral/can_wait/soon/pressing), serde = PascalCase variant on the wire (like `status`). `update`
+  preserves rating via `Unchanged`; `create`/`reorder` unchanged (DB default applies). Frozen test
+  re-frozen: asserts relevance+immediacy serialized, display_order not, ORDER BY unchanged; SQL now
+  has `CAST(... AS "text")` enum cols. Enums re-exported `entity_api`→`domain` (VERIFIED correct:
+  web has no `entity` dep; `domain::<enum>::Type` is the established pattern, mirrors provider/status;
+  utoipa `body = entity::...` annotations are macro schema-name refs, not a real entity dep). Gates
+  173/194/83. **Pre-merge:** run migration up/down on live PG (PG enum + OWNER TO).
+- **P7 — Rating endpoint + coachee authz — ✅ APPROVED** (overseer-reviewed 2026-06-07). Branch
+  `feat/348-topic-rating`, commit `d57cc03`. `entity_api::set_rating` (via `topic.into()` + `Set`,
+  stamps `updated_at`); domain re-export; route `PATCH /coaching_sessions/:id/topics/:topic_id/rating`;
+  new `CoachingSessionTopicCoacheeAccess` extractor — **coachee-only (403 for a coach), topic-in-session
+  (404)**. 2 HTTP integration tests (coachee→200, coach→403). Gates reproduced: clippy/fmt clean, web
+  **85** (+2). **Coachee guard MUTATION-TESTED:** defeating it fails the 403 test — real teeth. Scope:
+  5 files, no migration/enum/entity change. **Pre-merge:** live-PG migration check (P6 enums).
+- **✅✅ ENTIRE BUILD COMPLETE (P1–P7).** Title (rs#346, PR #349) · Topics CRUD/reorder/authz/include
+  (rs#347, PR #350) · rating (rs#348, PR pending). Every phase independently reviewed; reorder guard,
+  both topic authz guards, and the coachee guard all mutation-tested.
 
 ---
 

--- a/domain/src/coaching_session_topic.rs
+++ b/domain/src/coaching_session_topic.rs
@@ -1,3 +1,3 @@
 pub use entity_api::coaching_session_topic::{
-    create, delete, find_by_coaching_session_id, find_by_id, reorder, update,
+    create, delete, find_by_coaching_session_id, find_by_id, reorder, set_rating, update,
 };

--- a/domain/src/lib.rs
+++ b/domain/src/lib.rs
@@ -14,7 +14,7 @@ pub use entity_api::{
     actions, agreements, coachees, coaches, coaching_relationships, coaching_session_topics,
     coaching_sessions, coaching_sessions_goals, duration, goals, jwts, magic_link_tokens, notes,
     oauth_connections, organizations, password_reset_attempts, provider, query::QuerySort, status,
-    token_purpose, user_roles, users, Id,
+    token_purpose, topic_immediacy, topic_relevance, user_roles, users, Id,
 };
 
 pub mod action;

--- a/entity/src/coaching_session_topics.rs
+++ b/entity/src/coaching_session_topics.rs
@@ -1,5 +1,7 @@
 //! `SeaORM` Entity.
 
+use crate::topic_immediacy::Immediacy;
+use crate::topic_relevance::Relevance;
 use crate::Id;
 use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -22,6 +24,9 @@ pub struct Model {
     // Backend-internal ordering index. Never crosses the wire in either direction.
     #[serde(skip)]
     pub display_order: i32,
+    // Coachee-set rating axes. Default to Neutral (untriaged).
+    pub relevance: Relevance,
+    pub immediacy: Immediacy,
     #[serde(skip_deserializing)]
     pub created_at: DateTimeWithTimeZone,
     #[serde(skip_deserializing)]

--- a/entity/src/lib.rs
+++ b/entity/src/lib.rs
@@ -26,6 +26,8 @@ pub mod provider;
 pub mod roles;
 pub mod status;
 pub mod token_purpose;
+pub mod topic_immediacy;
+pub mod topic_relevance;
 pub mod transcript_segment;
 pub mod transcription;
 pub mod user_invite_status;

--- a/entity/src/topic_immediacy.rs
+++ b/entity/src/topic_immediacy.rs
@@ -1,0 +1,29 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    EnumIter,
+    Deserialize,
+    Serialize,
+    DeriveActiveEnum,
+    Default,
+    ToSchema,
+)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "topic_immediacy")]
+#[schema(as = entity::topic_immediacy::Immediacy)]
+pub enum Immediacy {
+    #[sea_orm(string_value = "neutral")]
+    #[default]
+    Neutral,
+    #[sea_orm(string_value = "can_wait")]
+    CanWait,
+    #[sea_orm(string_value = "soon")]
+    Soon,
+    #[sea_orm(string_value = "pressing")]
+    Pressing,
+}

--- a/entity/src/topic_relevance.rs
+++ b/entity/src/topic_relevance.rs
@@ -1,0 +1,29 @@
+use sea_orm::entity::prelude::*;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+
+#[derive(
+    Debug,
+    Clone,
+    Eq,
+    PartialEq,
+    EnumIter,
+    Deserialize,
+    Serialize,
+    DeriveActiveEnum,
+    Default,
+    ToSchema,
+)]
+#[sea_orm(rs_type = "String", db_type = "Enum", enum_name = "topic_relevance")]
+#[schema(as = entity::topic_relevance::Relevance)]
+pub enum Relevance {
+    #[sea_orm(string_value = "neutral")]
+    #[default]
+    Neutral,
+    #[sea_orm(string_value = "peripheral")]
+    Peripheral,
+    #[sea_orm(string_value = "worth_exploring")]
+    WorthExploring,
+    #[sea_orm(string_value = "central")]
+    Central,
+}

--- a/entity_api/src/coaching_session_topic.rs
+++ b/entity_api/src/coaching_session_topic.rs
@@ -5,7 +5,7 @@ use entity::topic_relevance::Relevance;
 use entity::Id;
 use sea_orm::{
     entity::prelude::*,
-    ActiveValue::{Set, Unchanged},
+    ActiveValue::{NotSet, Set, Unchanged},
     DatabaseConnection, QueryOrder, TryIntoModel,
 };
 use std::collections::HashSet;
@@ -35,6 +35,8 @@ pub async fn create(
     coaching_session_id: Id,
     body: String,
     user_id: Id,
+    relevance: Option<Relevance>,
+    immediacy: Option<Immediacy>,
 ) -> Result<Model, Error> {
     let existing = Entity::find()
         .filter(coaching_session_topics::Column::CoachingSessionId.eq(coaching_session_id))
@@ -46,6 +48,8 @@ pub async fn create(
         user_id: Set(user_id),
         body: Set(body),
         display_order: Set(next_display_order(&existing)),
+        relevance: relevance.map_or(NotSet, Set),
+        immediacy: immediacy.map_or(NotSet, Set),
         created_at: Set(now.into()),
         updated_at: Set(now.into()),
         ..Default::default()

--- a/entity_api/src/coaching_session_topic.rs
+++ b/entity_api/src/coaching_session_topic.rs
@@ -66,6 +66,8 @@ pub async fn update(db: &DatabaseConnection, id: Id, body: String) -> Result<Mod
         user_id: Unchanged(topic.user_id),
         body: Set(body),
         display_order: Unchanged(topic.display_order),
+        relevance: Unchanged(topic.relevance),
+        immediacy: Unchanged(topic.immediacy),
         created_at: Unchanged(topic.created_at),
         updated_at: Set(chrono::Utc::now().into()),
     };

--- a/entity_api/src/coaching_session_topic.rs
+++ b/entity_api/src/coaching_session_topic.rs
@@ -1,5 +1,7 @@
 use super::error::{EntityApiErrorKind, Error};
 use entity::coaching_session_topics::{self, ActiveModel, Entity, Model};
+use entity::topic_immediacy::Immediacy;
+use entity::topic_relevance::Relevance;
 use entity::Id;
 use sea_orm::{
     entity::prelude::*,
@@ -71,6 +73,25 @@ pub async fn update(db: &DatabaseConnection, id: Id, body: String) -> Result<Mod
         created_at: Unchanged(topic.created_at),
         updated_at: Set(chrono::Utc::now().into()),
     };
+    Ok(active.update(db).await?.try_into_model()?)
+}
+
+/// Coachee-set rating. Sets whichever axis is provided; stamps updated_at.
+pub async fn set_rating(
+    db: &DatabaseConnection,
+    id: Id,
+    relevance: Option<Relevance>,
+    immediacy: Option<Immediacy>,
+) -> Result<Model, Error> {
+    let topic = find_by_id(db, id).await?;
+    let mut active: ActiveModel = topic.into();
+    if let Some(relevance) = relevance {
+        active.relevance = Set(relevance);
+    }
+    if let Some(immediacy) = immediacy {
+        active.immediacy = Set(immediacy);
+    }
+    active.updated_at = Set(chrono::Utc::now().into());
     Ok(active.update(db).await?.try_into_model()?)
 }
 

--- a/entity_api/src/coaching_session_topic_tests.rs
+++ b/entity_api/src/coaching_session_topic_tests.rs
@@ -10,6 +10,8 @@ fn topic(session_id: Id, id: Id, order: i32) -> Model {
         body: "topic body".to_owned(),
         user_id: Id::new_v4(),
         display_order: order,
+        relevance: entity::topic_relevance::Relevance::Neutral,
+        immediacy: entity::topic_immediacy::Immediacy::Neutral,
         created_at: now.into(),
         updated_at: now.into(),
     }
@@ -82,6 +84,9 @@ fn display_order_is_never_serialized() {
     assert!(value.get("id").is_some());
     assert!(value.get("coaching_session_id").is_some());
     assert!(value.get("user_id").is_some());
+    // Rating axes ARE on the wire.
+    assert!(value.get("relevance").is_some());
+    assert!(value.get("immediacy").is_some());
 }
 
 #[tokio::test]
@@ -97,7 +102,7 @@ async fn find_by_coaching_session_id_orders_by_display_order_then_created_at() {
         db.into_transaction_log(),
         [Transaction::from_sql_and_values(
             DatabaseBackend::Postgres,
-            r#"SELECT "coaching_session_topics"."id", "coaching_session_topics"."coaching_session_id", "coaching_session_topics"."body", "coaching_session_topics"."user_id", "coaching_session_topics"."display_order", "coaching_session_topics"."created_at", "coaching_session_topics"."updated_at" FROM "refactor_platform"."coaching_session_topics" WHERE "coaching_session_topics"."coaching_session_id" = $1 ORDER BY "coaching_session_topics"."display_order" ASC, "coaching_session_topics"."created_at" ASC"#,
+            r#"SELECT "coaching_session_topics"."id", "coaching_session_topics"."coaching_session_id", "coaching_session_topics"."body", "coaching_session_topics"."user_id", "coaching_session_topics"."display_order", CAST("coaching_session_topics"."relevance" AS "text"), CAST("coaching_session_topics"."immediacy" AS "text"), "coaching_session_topics"."created_at", "coaching_session_topics"."updated_at" FROM "refactor_platform"."coaching_session_topics" WHERE "coaching_session_topics"."coaching_session_id" = $1 ORDER BY "coaching_session_topics"."display_order" ASC, "coaching_session_topics"."created_at" ASC"#,
             [session_id.into()]
         )]
     );

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -6,7 +6,8 @@ pub use entity::{
     actions, actions_users, agreements, coachees, coaches, coaching_relationships,
     coaching_session_topics, coaching_sessions, coaching_sessions_goals, duration, goals, jwts,
     magic_link_tokens, notes, oauth_connections, organizations, password_reset_attempts, provider,
-    status, token_purpose, user_invite_status, user_roles, users, users::Role, Id,
+    status, token_purpose, topic_immediacy, topic_relevance, user_invite_status, user_roles, users,
+    users::Role, Id,
 };
 
 pub mod action;

--- a/migration/src/lib.rs
+++ b/migration/src/lib.rs
@@ -32,6 +32,7 @@ mod m20260514_000000_add_password_reset_attempts;
 mod m20260515_000000_add_duration_minutes_to_coaching_sessions;
 mod m20260515_000001_add_default_coaching_session_duration_minutes_to_users;
 mod m20260607_000001_create_coaching_session_topics;
+mod m20260607_000002_add_topic_rating_enums;
 
 pub struct Migrator;
 
@@ -73,6 +74,7 @@ impl MigratorTrait for Migrator {
                 m20260515_000001_add_default_coaching_session_duration_minutes_to_users::Migration,
             ),
             Box::new(m20260607_000001_create_coaching_session_topics::Migration),
+            Box::new(m20260607_000002_add_topic_rating_enums::Migration),
         ]
     }
 }

--- a/migration/src/m20260607_000002_add_topic_rating_enums.rs
+++ b/migration/src/m20260607_000002_add_topic_rating_enums.rs
@@ -1,0 +1,69 @@
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Coachee-set rating axes. Both default to 'neutral' (untriaged).
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE TYPE refactor_platform.topic_relevance AS ENUM \
+                 ('neutral', 'peripheral', 'worth_exploring', 'central')",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("ALTER TYPE refactor_platform.topic_relevance OWNER TO refactor")
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE TYPE refactor_platform.topic_immediacy AS ENUM \
+                 ('neutral', 'can_wait', 'soon', 'pressing')",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("ALTER TYPE refactor_platform.topic_immediacy OWNER TO refactor")
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "ALTER TABLE refactor_platform.coaching_session_topics \
+                 ADD COLUMN relevance refactor_platform.topic_relevance NOT NULL DEFAULT 'neutral', \
+                 ADD COLUMN immediacy refactor_platform.topic_immediacy NOT NULL DEFAULT 'neutral'",
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "ALTER TABLE refactor_platform.coaching_session_topics \
+                 DROP COLUMN immediacy, DROP COLUMN relevance",
+            )
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TYPE IF EXISTS refactor_platform.topic_immediacy")
+            .await?;
+
+        manager
+            .get_connection()
+            .execute_unprepared("DROP TYPE IF EXISTS refactor_platform.topic_relevance")
+            .await?;
+
+        Ok(())
+    }
+}

--- a/web/src/controller/coaching_session/topic_controller.rs
+++ b/web/src/controller/coaching_session/topic_controller.rs
@@ -23,6 +23,10 @@ use utoipa::ToSchema;
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct CreateParams {
     pub body: String,
+    /// Optional initial rating, used by topic-restore to preserve a deleted
+    /// topic's ratings. Omit for new topics; both default to Neutral.
+    pub relevance: Option<domain::topic_relevance::Relevance>,
+    pub immediacy: Option<domain::topic_immediacy::Immediacy>,
 }
 
 #[derive(Debug, Deserialize, ToSchema)]
@@ -93,7 +97,15 @@ pub async fn create(
 ) -> Result<impl IntoResponse, Error> {
     debug!("POST topic for session {}", session.id);
 
-    let topic = TopicApi::create(app_state.db_conn_ref(), session.id, params.body, user.id).await?;
+    let topic = TopicApi::create(
+        app_state.db_conn_ref(),
+        session.id,
+        params.body,
+        user.id,
+        params.relevance,
+        params.immediacy,
+    )
+    .await?;
 
     Ok(Json(ApiResponse::new(StatusCode::CREATED.into(), topic)))
 }

--- a/web/src/controller/coaching_session/topic_controller.rs
+++ b/web/src/controller/coaching_session/topic_controller.rs
@@ -2,7 +2,10 @@ use crate::controller::ApiResponse;
 use crate::extractors::{
     authenticated_user::AuthenticatedUser,
     coaching_session_access::CoachingSessionAccess,
-    coaching_session_topic_access::{CoachingSessionTopicAccess, CoachingSessionTopicAuthorAccess},
+    coaching_session_topic_access::{
+        CoachingSessionTopicAccess, CoachingSessionTopicAuthorAccess,
+        CoachingSessionTopicCoacheeAccess,
+    },
     compare_api_version::CompareApiVersion,
 };
 use crate::{AppState, Error};
@@ -30,6 +33,12 @@ pub struct UpdateParams {
 #[derive(Debug, Deserialize, ToSchema)]
 pub struct ReorderParams {
     pub ordered_ids: Vec<Id>,
+}
+
+#[derive(Debug, Deserialize, ToSchema)]
+pub struct RatingParams {
+    pub relevance: Option<domain::topic_relevance::Relevance>,
+    pub immediacy: Option<domain::topic_immediacy::Immediacy>,
 }
 
 /// GET all topics for a coaching session, in canonical order
@@ -178,4 +187,41 @@ pub async fn delete(
         StatusCode::OK.into(),
         serde_json::json!({ "id": topic.id }),
     )))
+}
+
+/// PATCH set a topic's relevance/immediacy rating (coachee only)
+#[utoipa::path(
+    patch,
+    path = "/coaching_sessions/{coaching_session_id}/topics/{topic_id}/rating",
+    params(
+        ApiVersion,
+        ("coaching_session_id" = Id, Path, description = "Coaching session id"),
+        ("topic_id" = Id, Path, description = "Topic id"),
+    ),
+    request_body = RatingParams,
+    responses(
+        (status = 200, description = "Topic rating updated", body = domain::coaching_session_topics::Model),
+        (status = 401, description = "Unauthorized"),
+        (status = 403, description = "Only the coachee may rate a topic"),
+        (status = 404, description = "Topic not found in this session"),
+    ),
+    security(("cookie_auth" = []))
+)]
+pub async fn set_rating(
+    CompareApiVersion(_v): CompareApiVersion,
+    CoachingSessionTopicCoacheeAccess(topic): CoachingSessionTopicCoacheeAccess,
+    State(app_state): State<AppState>,
+    Json(params): Json<RatingParams>,
+) -> Result<impl IntoResponse, Error> {
+    debug!("PATCH rating for topic {}", topic.id);
+
+    let updated = TopicApi::set_rating(
+        app_state.db_conn_ref(),
+        topic.id,
+        params.relevance,
+        params.immediacy,
+    )
+    .await?;
+
+    Ok(Json(ApiResponse::new(StatusCode::OK.into(), updated)))
 }

--- a/web/src/extractors/coaching_session_topic_access.rs
+++ b/web/src/extractors/coaching_session_topic_access.rs
@@ -5,7 +5,7 @@ use axum::{
     extract::{FromRef, FromRequestParts, Path},
     http::{request::Parts, StatusCode},
 };
-use domain::{coaching_session_topic, coaching_session_topics, Id};
+use domain::{coaching_session, coaching_session_topic, coaching_session_topics, Id};
 
 use crate::{
     extractors::{
@@ -99,6 +99,81 @@ where
     }
 }
 
+/// Rating writes are coachee-only. Verifies the caller is the coachee of the path session's
+/// relationship (else 403), and that the `:topic_id` topic belongs to that session (else 404).
+pub(crate) struct CoachingSessionTopicCoacheeAccess(pub coaching_session_topics::Model);
+
+#[async_trait]
+impl<S> FromRequestParts<S> for CoachingSessionTopicCoacheeAccess
+where
+    AppState: FromRef<S>,
+    S: Send + Sync,
+{
+    type Rejection = RejectionType;
+
+    async fn from_request_parts(parts: &mut Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let app_state = AppState::from_ref(state);
+
+        let AuthenticatedUser(user) =
+            AuthenticatedUser::from_request_parts(parts, &app_state).await?;
+
+        let Path(path_params) =
+            Path::<HashMap<String, String>>::from_request_parts(parts, &app_state)
+                .await
+                .map_err(|_| {
+                    (
+                        StatusCode::BAD_REQUEST,
+                        "Invalid path parameters".to_string(),
+                    )
+                })?;
+
+        let coaching_session_id: Id = path_params
+            .get("coaching_session_id")
+            .ok_or((
+                StatusCode::BAD_REQUEST,
+                "Missing coaching_session_id in path".to_string(),
+            ))?
+            .parse()
+            .map_err(|_| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    "Invalid coaching session id".to_string(),
+                )
+            })?;
+
+        let topic_id: Id = path_params
+            .get("topic_id")
+            .ok_or((
+                StatusCode::BAD_REQUEST,
+                "Missing topic_id in path".to_string(),
+            ))?
+            .parse()
+            .map_err(|_| (StatusCode::BAD_REQUEST, "Invalid topic id".to_string()))?;
+
+        let (session, relationship) = coaching_session::find_by_id_with_coaching_relationship(
+            app_state.db_conn_ref(),
+            coaching_session_id,
+        )
+        .await
+        .map_err(|_| (StatusCode::NOT_FOUND, "NOT FOUND".to_string()))?;
+
+        // Coachee-only: a coach can read the topic but not rate it -> 403.
+        if relationship.coachee_id != user.id {
+            return Err((StatusCode::FORBIDDEN, "FORBIDDEN".to_string()));
+        }
+
+        let topic = coaching_session_topic::find_by_id(app_state.db_conn_ref(), topic_id)
+            .await
+            .map_err(|_| (StatusCode::NOT_FOUND, "NOT FOUND".to_string()))?;
+
+        if topic.coaching_session_id != session.id {
+            return Err((StatusCode::NOT_FOUND, "NOT FOUND".to_string()));
+        }
+
+        Ok(CoachingSessionTopicCoacheeAccess(topic))
+    }
+}
+
 #[cfg(test)]
 #[cfg(feature = "mock")]
 mod tests {
@@ -108,7 +183,11 @@ mod tests {
 
     use super::*;
     use axum::{body::Body, middleware::from_fn};
-    use axum::{extract::Request, routing::delete, Router};
+    use axum::{
+        extract::Request,
+        routing::{delete, patch},
+        Router,
+    };
     use axum_login::{
         tower_sessions::{MemoryStore, SessionManagerLayer},
         AuthManagerLayerBuilder,
@@ -187,6 +266,23 @@ mod tests {
         }
     }
 
+    fn test_relationship_with_coach(
+        relationship_id: Id,
+        coach_id: Id,
+        coachee_id: Id,
+    ) -> coaching_relationships::Model {
+        let now = Utc::now();
+        coaching_relationships::Model {
+            id: relationship_id,
+            coach_id,
+            coachee_id,
+            organization_id: Id::new_v4(),
+            slug: "test".to_string(),
+            created_at: now.into(),
+            updated_at: now.into(),
+        }
+    }
+
     fn test_topic(
         topic_id: Id,
         coaching_session_id: Id,
@@ -210,6 +306,14 @@ mod tests {
     // full composed chain (session participant -> topic-belongs-to-session -> author).
     async fn author_route(
         CoachingSessionTopicAuthorAccess(_topic): CoachingSessionTopicAuthorAccess,
+    ) -> &'static str {
+        "extracted_success"
+    }
+
+    // Mounts the coachee extractor behind require_auth so a logged-in PATCH exercises the
+    // coachee-only rating guard (coachee -> ok, coach -> 403).
+    async fn coachee_route(
+        CoachingSessionTopicCoacheeAccess(_topic): CoachingSessionTopicCoacheeAccess,
     ) -> &'static str {
         "extracted_success"
     }
@@ -242,6 +346,10 @@ mod tests {
                     .route(
                         "/coaching_sessions/:coaching_session_id/topics/:topic_id",
                         delete(author_route),
+                    )
+                    .route(
+                        "/coaching_sessions/:coaching_session_id/topics/:topic_id/rating",
+                        patch(coachee_route),
                     )
                     .route_layer(from_fn(require_auth)),
             )
@@ -371,5 +479,80 @@ mod tests {
 
         let resp = app.oneshot(req).await.unwrap();
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn coachee_extractor_ok_when_user_is_coachee() {
+        let session_id = Id::new_v4();
+        let relationship_id = Id::new_v4();
+        let topic_id = Id::new_v4();
+        let user = create_test_user();
+        let role = test_role(user.id);
+
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![(user.clone(), role.clone())]])
+                .append_query_results([vec![(user.clone(), role.clone())]])
+                // Caller is the coachee of the relationship -> rating allowed.
+                .append_query_results(vec![vec![(
+                    test_session(session_id, relationship_id),
+                    test_relationship(relationship_id, user.id),
+                )]])
+                .append_query_results(vec![vec![test_topic(topic_id, session_id, user.id)]])
+                .append_query_results([vec![(user.clone(), role.clone())]])
+                .into_connection(),
+        );
+
+        let app = build_app(Arc::clone(&db));
+        let cookie = do_login(&app).await;
+
+        let req = Request::builder()
+            .uri(format!(
+                "/coaching_sessions/{session_id}/topics/{topic_id}/rating"
+            ))
+            .method("PATCH")
+            .header("cookie", cookie)
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn coachee_extractor_403_when_user_is_coach() {
+        let session_id = Id::new_v4();
+        let relationship_id = Id::new_v4();
+        let topic_id = Id::new_v4();
+        let coachee_id = Id::new_v4();
+        let user = create_test_user();
+        let role = test_role(user.id);
+
+        let db = Arc::new(
+            MockDatabase::new(DatabaseBackend::Postgres)
+                .append_query_results([vec![(user.clone(), role.clone())]])
+                .append_query_results([vec![(user.clone(), role.clone())]])
+                // Caller is the coach (a participant) but not the coachee -> 403.
+                .append_query_results(vec![vec![(
+                    test_session(session_id, relationship_id),
+                    test_relationship_with_coach(relationship_id, user.id, coachee_id),
+                )]])
+                .into_connection(),
+        );
+
+        let app = build_app(Arc::clone(&db));
+        let cookie = do_login(&app).await;
+
+        let req = Request::builder()
+            .uri(format!(
+                "/coaching_sessions/{session_id}/topics/{topic_id}/rating"
+            ))
+            .method("PATCH")
+            .header("cookie", cookie)
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 }

--- a/web/src/extractors/coaching_session_topic_access.rs
+++ b/web/src/extractors/coaching_session_topic_access.rs
@@ -199,6 +199,8 @@ mod tests {
             body: "A topic".to_string(),
             user_id,
             display_order: 0,
+            relevance: domain::topic_relevance::Relevance::Neutral,
+            immediacy: domain::topic_immediacy::Immediacy::Neutral,
             created_at: now.into(),
             updated_at: now.into(),
         }

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -58,6 +58,7 @@ use utoipa_rapidoc::RapiDoc;
             coaching_session::topic_controller::update,
             coaching_session::topic_controller::reorder,
             coaching_session::topic_controller::delete,
+            coaching_session::topic_controller::set_rating,
             coaching_session::transcription_controller::read,
             coaching_session::transcription_segment_controller::index,
             health_check_controller::health_check,
@@ -125,6 +126,7 @@ use utoipa_rapidoc::RapiDoc;
                 crate::controller::coaching_session::topic_controller::CreateParams,
                 crate::controller::coaching_session::topic_controller::UpdateParams,
                 crate::controller::coaching_session::topic_controller::ReorderParams,
+                crate::controller::coaching_session::topic_controller::RatingParams,
                 crate::controller::oauth_controller::ConnectionResponse,
                 crate::controller::password_reset_controller::ValidateParams,
                 crate::controller::password_reset_controller::ValidateResponse,
@@ -783,6 +785,10 @@ fn coaching_session_topic_routes(app_state: AppState) -> Router {
             "/coaching_sessions/:coaching_session_id/topics/:topic_id",
             put(coaching_session::topic_controller::update)
                 .delete(coaching_session::topic_controller::delete),
+        )
+        .route(
+            "/coaching_sessions/:coaching_session_id/topics/:topic_id/rating",
+            patch(coaching_session::topic_controller::set_rating),
         )
         .route_layer(from_fn(require_auth))
         .with_state(app_state)


### PR DESCRIPTION
## Description

Adds the **coachee-set rating** on coaching-session topics: two enum axes, `relevance` and `immediacy`, plus an endpoint that lets the **coachee** triage topics. This is epic Phase 2 of refactor-group/refactor-platform-fe#412 (the Title + Topics feature); it builds on the Topics entity from rs#347.

> **Stacked on #350 (rs#347).** This branch targets `feat/347-coaching-session-topics` because the rating columns attach to the `coaching_session_topics` table created there. Once #350 merges, this will be rebased onto `main`.

#### GitHub Issue: Closes #348

### Changes

* **Migration** `m20260607_000002_add_topic_rating_enums` — `CREATE TYPE topic_relevance` (`neutral`/`peripheral`/`worth_exploring`/`central`) and `topic_immediacy` (`neutral`/`can_wait`/`soon`/`pressing`), each with `OWNER TO refactor`; adds `relevance` + `immediacy` columns to `coaching_session_topics`, **NOT NULL DEFAULT `'neutral'`** (so existing/new topics are untriaged by default).
* **Entity enums** `Relevance` + `Immediacy` (modeled on `status`); serialized by variant name (PascalCase) on the wire, like the existing goal `status`.
* **Rating write** — `entity_api::set_rating` sets whichever axis is provided and stamps `updated_at`; a body edit preserves the rating (the `update` path leaves the enum columns `Unchanged`).
* **Endpoint** `PATCH /coaching_sessions/{id}/topics/{topic_id}/rating` — gated by a new `CoachingSessionTopicCoacheeAccess` extractor: **coachee-only** (a coach is a participant who can read the topic but not rate it → **403**), and the topic must belong to the path session (→ **404**).

### Testing Strategy

* `cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"` — green. The frozen topic data-layer tests were updated to reflect the new columns (relevance/immediacy serialized; `display_order` still not; ordering unchanged), and two full login→cookie→HTTP integration tests cover the coachee gate (coachee→200, coach→403).
* `cargo clippy --all-targets` and `cargo fmt --all -- --check` — clean.
* Manual: as the coachee, `PATCH .../rating` with `{ "relevance": "Central" }` and confirm it persists and is returned on reads; as the coach, confirm the same request → 403; new topics default to `Neutral` on both axes.

### Concerns

* **Migration:** creates two PG enum types (each `OWNER TO refactor`) and adds two NOT NULL columns with a `'neutral'` default — no backfill needed. `down` drops the columns then the types. Should be smoke-tested up/down against a real Postgres before merge (PG enum ownership).
* The non-coachee response is **403** (not 404) deliberately — a coach can already see the topic via `GET`, so there's nothing to hide; they're simply forbidden from rating.
* Enum wire values are PascalCase (`Neutral`, `WorthExploring`, …), consistent with the existing `status` enum; the snake_case `string_value`s are the DB representation only. This will be pinned in the Topics wire contract for FE story refactor-group/refactor-platform-fe#415.
