### PR TITLE
feat(coaching-session-topics): real-time TopicsChanged SSE event (epic #412)

### DIFF
--- a/domain/src/coaching_session_topic.rs
+++ b/domain/src/coaching_session_topic.rs
@@ -1,3 +1,101 @@
-pub use entity_api::coaching_session_topic::{
-    create, delete, find_by_coaching_session_id, find_by_id, reorder, set_rating, update,
-};
+use crate::coaching_session;
+use crate::coaching_session_topics::Model;
+use crate::error::Error;
+use crate::events::{DomainEvent, EventPublisher};
+use crate::topic_immediacy::Immediacy;
+use crate::topic_relevance::Relevance;
+use crate::Id;
+use entity_api::coaching_session_topic as TopicApi;
+use log::*;
+use sea_orm::DatabaseConnection;
+
+// reads stay as direct re-exports
+pub use entity_api::coaching_session_topic::{find_by_coaching_session_id, find_by_id};
+
+/// Best-effort SSE notify. The DB write is the contract; a failure to resolve
+/// participants must NOT fail the mutation — log and continue (mirrors bot_status.rs).
+async fn publish_topics_changed(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    coaching_session_id: Id,
+) {
+    match coaching_session::find_participant_ids(db, coaching_session_id).await {
+        Ok(notify_user_ids) => {
+            event_publisher
+                .publish(DomainEvent::TopicsChanged {
+                    coaching_session_id,
+                    notify_user_ids,
+                })
+                .await;
+        }
+        Err(e) => error!(
+            "TopicsChanged: failed to resolve participants for session {coaching_session_id}: {e:?}"
+        ),
+    }
+}
+
+pub async fn create(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    coaching_session_id: Id,
+    body: String,
+    user_id: Id,
+    relevance: Option<Relevance>,
+    immediacy: Option<Immediacy>,
+) -> Result<Model, Error> {
+    let topic =
+        TopicApi::create(db, coaching_session_id, body, user_id, relevance, immediacy).await?;
+    publish_topics_changed(db, event_publisher, coaching_session_id).await;
+    Ok(topic)
+}
+
+pub async fn update(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    id: Id,
+    body: String,
+) -> Result<Model, Error> {
+    let topic = TopicApi::update(db, id, body).await?;
+    publish_topics_changed(db, event_publisher, topic.coaching_session_id).await;
+    Ok(topic)
+}
+
+pub async fn delete(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    id: Id,
+) -> Result<(), Error> {
+    // Capture the session id BEFORE deletion (the row is gone after).
+    let coaching_session_id = TopicApi::find_by_id(db, id).await?.coaching_session_id;
+    TopicApi::delete(db, id).await?;
+    publish_topics_changed(db, event_publisher, coaching_session_id).await;
+    Ok(())
+}
+
+pub async fn reorder(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    coaching_session_id: Id,
+    ordered_ids: Vec<Id>,
+) -> Result<Vec<Model>, Error> {
+    let topics = TopicApi::reorder(db, coaching_session_id, ordered_ids).await?;
+    publish_topics_changed(db, event_publisher, coaching_session_id).await;
+    Ok(topics)
+}
+
+pub async fn set_rating(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    id: Id,
+    relevance: Option<Relevance>,
+    immediacy: Option<Immediacy>,
+) -> Result<Model, Error> {
+    let topic = TopicApi::set_rating(db, id, relevance, immediacy).await?;
+    publish_topics_changed(db, event_publisher, topic.coaching_session_id).await;
+    Ok(topic)
+}
+
+#[cfg(test)]
+#[cfg(feature = "mock")]
+#[path = "coaching_session_topic_tests.rs"]
+mod tests;

--- a/domain/src/coaching_session_topic_tests.rs
+++ b/domain/src/coaching_session_topic_tests.rs
@@ -1,0 +1,114 @@
+use super::*;
+use crate::coaching_relationships;
+use crate::coaching_sessions;
+use crate::events::DomainEvent;
+use crate::test_support::recording_publisher;
+use entity::Id;
+use sea_orm::{DatabaseBackend, MockDatabase};
+
+fn topic_model(coaching_session_id: Id) -> Model {
+    let now = chrono::Utc::now().fixed_offset();
+    Model {
+        id: Id::new_v4(),
+        coaching_session_id,
+        body: "Topic body".to_string(),
+        user_id: Id::new_v4(),
+        display_order: 0,
+        relevance: Relevance::Neutral,
+        immediacy: Immediacy::Neutral,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn session_with_relationship(
+    coaching_session_id: Id,
+) -> (coaching_sessions::Model, coaching_relationships::Model) {
+    let now = chrono::Utc::now().fixed_offset();
+    let relationship_id = Id::new_v4();
+    let session = coaching_sessions::Model {
+        id: coaching_session_id,
+        coaching_relationship_id: relationship_id,
+        collab_document_name: None,
+        date: now.naive_utc(),
+        duration_minutes: 60,
+        meeting_url: None,
+        provider: None,
+        created_at: now,
+        updated_at: now,
+        hydrated_at: None,
+    };
+    let relationship = coaching_relationships::Model {
+        id: relationship_id,
+        organization_id: Id::new_v4(),
+        coach_id: Id::new_v4(),
+        coachee_id: Id::new_v4(),
+        slug: "test-slug".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+    (session, relationship)
+}
+
+/// Asserts the recorder captured exactly one TopicsChanged for the session.
+fn assert_topics_changed(events: &[DomainEvent], expected_session_id: Id) {
+    assert_eq!(events.len(), 1, "expected exactly one published event");
+    match &events[0] {
+        DomainEvent::TopicsChanged {
+            coaching_session_id,
+            ..
+        } => assert_eq!(*coaching_session_id, expected_session_id),
+        other => panic!("expected TopicsChanged, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn create_publishes_topics_changed() {
+    let session_id = Id::new_v4();
+    let created = topic_model(session_id);
+    let (publisher, events) = recording_publisher();
+
+    // create: existing-topics load (all) → insert (save) → participant lookup (find_also_related)
+    let db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![Vec::<Model>::new()])
+        .append_query_results(vec![vec![created.clone()]])
+        .append_query_results(vec![vec![session_with_relationship(session_id)]])
+        .into_connection();
+
+    let result = create(
+        &db,
+        &publisher,
+        session_id,
+        "Topic body".to_string(),
+        Id::new_v4(),
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.is_ok());
+    assert_topics_changed(&events.lock().unwrap(), session_id);
+}
+
+#[tokio::test]
+async fn reorder_publishes_topics_changed() {
+    let session_id = Id::new_v4();
+    let topic_a = topic_model(session_id);
+    let topic_b = topic_model(session_id);
+    let ordered = vec![topic_b.id, topic_a.id];
+    let (publisher, events) = recording_publisher();
+
+    // reorder: load current → per-id update (x2) → reload → participant lookup
+    let db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![topic_a.clone(), topic_b.clone()]])
+        .append_query_results(vec![vec![topic_b.clone()]])
+        .append_query_results(vec![vec![topic_a.clone()]])
+        .append_query_results(vec![vec![topic_b.clone(), topic_a.clone()]])
+        .append_query_results(vec![vec![session_with_relationship(session_id)]])
+        .into_connection();
+
+    let result = reorder(&db, &publisher, session_id, ordered).await;
+
+    assert!(result.is_ok());
+    assert_topics_changed(&events.lock().unwrap(), session_id);
+}

--- a/events/src/lib.rs
+++ b/events/src/lib.rs
@@ -102,6 +102,14 @@ pub enum DomainEvent {
         /// User IDs to receive SSE notifications (coach + coachee from coaching relationship).
         notify_user_ids: Vec<Id>,
     },
+    /// Emitted on ANY topic mutation (add/edit/delete/reorder/rate). Coarse: carries no
+    /// entity — participants refetch the session's topics. Triggers SSE to coach + coachee.
+    TopicsChanged {
+        /// The coaching session whose topics changed.
+        coaching_session_id: Id,
+        /// User IDs to receive SSE notifications (coach + coachee from the relationship).
+        notify_user_ids: Vec<Id>,
+    },
     /// Emitted when a transcription status changes (created, completed, or failed).
     /// Triggers SSE notifications so participants see the current transcription state without polling.
     TranscriptionUpdated {

--- a/sse/src/domain_event_handler.rs
+++ b/sse/src/domain_event_handler.rs
@@ -123,6 +123,17 @@ impl EventHandler for SseDomainEventHandler {
                 self.send_to_users(sse_event, notify_user_ids);
             }
 
+            DomainEvent::TopicsChanged {
+                coaching_session_id,
+                notify_user_ids,
+            } => {
+                let sse_event = SseEvent::TopicsChanged {
+                    coaching_session_id: coaching_session_id.to_string(),
+                };
+
+                self.send_to_users(sse_event, notify_user_ids);
+            }
+
             DomainEvent::TranscriptionUpdated {
                 coaching_session_id,
                 notify_user_ids,

--- a/sse/src/message.rs
+++ b/sse/src/message.rs
@@ -82,6 +82,10 @@ pub enum Event {
     #[serde(rename = "meeting_recording_updated")]
     MeetingRecordingUpdated { coaching_session_id: String },
 
+    // Topic events (session-scoped, coarse: refetch on receipt)
+    #[serde(rename = "topics_changed")]
+    TopicsChanged { coaching_session_id: String },
+
     // Transcription events (session-scoped)
     #[serde(rename = "transcription_updated")]
     TranscriptionUpdated { coaching_session_id: String },
@@ -103,6 +107,7 @@ impl EventType for Event {
             Event::CoachingSessionGoalDeleted { .. } => "coaching_session_goal_deleted",
             Event::ForceLogout { .. } => "force_logout",
             Event::MeetingRecordingUpdated { .. } => "meeting_recording_updated",
+            Event::TopicsChanged { .. } => "topics_changed",
             Event::TranscriptionUpdated { .. } => "transcription_updated",
         }
     }

--- a/web/src/controller/coaching_session/topic_controller.rs
+++ b/web/src/controller/coaching_session/topic_controller.rs
@@ -99,6 +99,7 @@ pub async fn create(
 
     let topic = TopicApi::create(
         app_state.db_conn_ref(),
+        app_state.event_publisher.as_ref(),
         session.id,
         params.body,
         user.id,
@@ -135,7 +136,13 @@ pub async fn update(
 ) -> Result<impl IntoResponse, Error> {
     debug!("PUT topic {}", topic.id);
 
-    let updated = TopicApi::update(app_state.db_conn_ref(), topic.id, params.body).await?;
+    let updated = TopicApi::update(
+        app_state.db_conn_ref(),
+        app_state.event_publisher.as_ref(),
+        topic.id,
+        params.body,
+    )
+    .await?;
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), updated)))
 }
@@ -165,7 +172,13 @@ pub async fn reorder(
 ) -> Result<impl IntoResponse, Error> {
     debug!("PATCH reorder topics for session {}", session.id);
 
-    let topics = TopicApi::reorder(app_state.db_conn_ref(), session.id, params.ordered_ids).await?;
+    let topics = TopicApi::reorder(
+        app_state.db_conn_ref(),
+        app_state.event_publisher.as_ref(),
+        session.id,
+        params.ordered_ids,
+    )
+    .await?;
 
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), topics)))
 }
@@ -193,7 +206,12 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, Error> {
     debug!("DELETE topic {}", topic.id);
 
-    TopicApi::delete(app_state.db_conn_ref(), topic.id).await?;
+    TopicApi::delete(
+        app_state.db_conn_ref(),
+        app_state.event_publisher.as_ref(),
+        topic.id,
+    )
+    .await?;
 
     Ok(Json(ApiResponse::new(
         StatusCode::OK.into(),
@@ -229,6 +247,7 @@ pub async fn set_rating(
 
     let updated = TopicApi::set_rating(
         app_state.db_conn_ref(),
+        app_state.event_publisher.as_ref(),
         topic.id,
         params.relevance,
         params.immediacy,


### PR DESCRIPTION
## Description

Adds real-time propagation for coaching-session **Topics**, bringing them to parity with goals: when one participant mutates a topic (add / edit / delete / reorder / rate), the other participant's UI is notified to refetch — no polling. Topics are part of the "collaborative" intent of epic refactor-group/refactor-platform-fe#412, but the rs#347/rs#348 PRs shipped without any SSE; this closes that gap.

> **Stacked on #351 (rs#348).** Branch is off `feat/348-topic-rating` because publishing on the rating mutation needs `set_rating`. Merge order: #350 → #351 → this PR (rebases onto `main` as the stack lands).

Design: a single **coarse** event, `TopicsChanged { coaching_session_id }`, carrying no entity payload — the FE refetches the (already pre-sorted) topic list. This deliberately avoids granular per-topic events, which handle whole-list **reorder** poorly and add FE cache-merge complexity. It mirrors the existing `MeetingRecordingUpdated` / `TranscriptionUpdated` events exactly.

### Changes

* **`events` crate** — new `DomainEvent::TopicsChanged { coaching_session_id, notify_user_ids }`.
* **`sse` crate** — `SseEvent::TopicsChanged { coaching_session_id }` (wire `event: topics_changed`) + the handler match arm routing to `notify_user_ids` (coach + coachee).
* **`domain`** — the 5 topic mutations (create/update/delete/reorder/set_rating) became publishing wrappers; reads unchanged. Publish is **best-effort**: a failure to resolve participants logs and does **not** fail the mutation (the DB write is the contract).
* **`web`** — the 5 topic handlers pass `event_publisher`.

### Wire (for the FE)

```
event: topics_changed
data: {"type":"topics_changed","data":{"coaching_session_id":"<uuid>"}}
```

On receipt, refetch `GET /coaching_sessions/{id}/topics`. (To be added to the `CoachingSessionTopics` contract on the coordination blackboard.)

### Testing Strategy

* `cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"` — green; new tests use a capturing event publisher to assert create and reorder each publish exactly one `TopicsChanged` with the correct `coaching_session_id`.
* `cargo clippy --all-targets` + `cargo fmt --all -- --check` — clean.
* **Live two-connection verification:** booted the binary against a real Postgres; opened an SSE stream as the coachee; the coach created a topic and then reordered — the coachee's stream received a `topics_changed` event for **each** mutation (captured verbatim).

### Concerns

* No wire/entity/migration change — topic payloads are unchanged; this only adds an out-of-band SSE event.
* **FE work required:** subscribe to the `topics_changed` event and refetch (no first-party consumer exists yet). A board note will go out so the Topics UI is built knowing live updates now exist.
* Coarse-by-design: a mutation triggers a full topic-list refetch on the other client. Topic lists are small and always returned pre-sorted, so this is cheap and avoids ordering/merge edge cases.
