### PR TITLE
Readability + DRY cleanups from review

### DIFF
--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -105,18 +105,9 @@ pub fn normalize_title(title: Option<String>) -> Option<String> {
 /// Normalize an update-map `title` to NULL when empty/whitespace. Explicit
 /// null (clear) and an absent key are left unchanged.
 pub fn normalize_title_in_update_map(update_map: &mut UpdateMap) {
-    let normalized = match update_map.get_value("title") {
-        Some(Value::String(Some(s))) => {
-            let trimmed = s.trim();
-            Some(if trimmed.is_empty() {
-                None
-            } else {
-                Some(Box::new(trimmed.to_string()))
-            })
-        }
-        _ => None,
-    };
-    if let Some(value) = normalized {
+    if let Some(Value::String(Some(s))) = update_map.get_value("title") {
+        let trimmed = s.trim();
+        let value = (!trimmed.is_empty()).then(|| Box::new(trimmed.to_string()));
         update_map.insert("title".to_string(), Some(Value::String(value)));
     }
 }

--- a/entity_api/src/coaching_session_topic.rs
+++ b/entity_api/src/coaching_session_topic.rs
@@ -83,7 +83,7 @@ pub async fn update(db: &DatabaseConnection, id: Id, body: String) -> Result<Mod
     let topic = find_by_id(db, id).await?;
     let mut active: ActiveModel = topic.into();
     active.body = Set(body);
-    active.undo_snapshot = Set(None);
+    active.undo_snapshot = Set(None); // a body edit settles the undo window
     active.updated_at = Set(chrono::Utc::now().into());
     Ok(active.update(db).await?.try_into_model()?)
 }

--- a/entity_api/src/coaching_session_topic.rs
+++ b/entity_api/src/coaching_session_topic.rs
@@ -81,22 +81,10 @@ pub async fn find_including_deleted_by_id(
 
 pub async fn update(db: &DatabaseConnection, id: Id, body: String) -> Result<Model, Error> {
     let topic = find_by_id(db, id).await?;
-    let active = ActiveModel {
-        id: Unchanged(topic.id),
-        coaching_session_id: Unchanged(topic.coaching_session_id),
-        user_id: Unchanged(topic.user_id),
-        body: Set(body),
-        display_order: Unchanged(topic.display_order),
-        priority: Unchanged(topic.priority),
-        status: Unchanged(topic.status),
-        moved_from_session_id: Unchanged(topic.moved_from_session_id),
-        // A body edit is a deliberate re-commit, so it settles the undo window even on a
-        // deferred/moved topic: a subsequent undo then returns 422 rather than reverting the edit.
-        undo_snapshot: Set(None),
-        deleted_at: Unchanged(topic.deleted_at),
-        created_at: Unchanged(topic.created_at),
-        updated_at: Set(chrono::Utc::now().into()),
-    };
+    let mut active: ActiveModel = topic.into();
+    active.body = Set(body);
+    active.undo_snapshot = Set(None);
+    active.updated_at = Set(chrono::Utc::now().into());
     Ok(active.update(db).await?.try_into_model()?)
 }
 

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -491,9 +491,7 @@ mod tests {
         )
         .await;
 
-        if let Err(e) = result {
-            panic!("participant title update should succeed, got: {e:?}");
-        }
+        result.expect("participant title update should succeed");
     }
 
     // Title-only map: a value sets it, explicit null clears it, absence leaves it untouched.

--- a/web/src/extractors/coaching_session_topic_access.rs
+++ b/web/src/extractors/coaching_session_topic_access.rs
@@ -1,8 +1,6 @@
-use std::collections::HashMap;
-
 use axum::{
     async_trait,
-    extract::{FromRef, FromRequestParts, Path},
+    extract::{FromRef, FromRequestParts},
     http::{request::Parts, StatusCode},
 };
 use domain::{coaching_session, coaching_session_topic, coaching_session_topics};
@@ -10,7 +8,7 @@ use domain::{coaching_session, coaching_session_topic, coaching_session_topics};
 use crate::{
     extractors::{
         authenticated_user::AuthenticatedUser, coaching_session_access::CoachingSessionAccess,
-        parse_path_id, RejectionType,
+        not_found, parse_path_id_from_parts, RejectionType,
     },
     AppState,
 };
@@ -38,25 +36,15 @@ where
         let CoachingSessionAccess(session) =
             CoachingSessionAccess::from_request_parts(parts, state).await?;
 
-        let Path(path_params) =
-            Path::<HashMap<String, String>>::from_request_parts(parts, &app_state)
-                .await
-                .map_err(|_| {
-                    (
-                        StatusCode::BAD_REQUEST,
-                        "Invalid path parameters".to_string(),
-                    )
-                })?;
-
-        let topic_id = parse_path_id(&path_params, "topic_id")?;
+        let topic_id = parse_path_id_from_parts(parts, "topic_id").await?;
 
         // Load + verify the topic belongs to THIS session (else 404 to hide existence).
         let topic = coaching_session_topic::find_by_id(app_state.db_conn_ref(), topic_id)
             .await
-            .map_err(|_| (StatusCode::NOT_FOUND, "NOT FOUND".to_string()))?;
+            .map_err(|_| not_found())?;
 
         if topic.coaching_session_id != session.id {
-            return Err((StatusCode::NOT_FOUND, "NOT FOUND".to_string()));
+            return Err(not_found());
         }
 
         Ok(CoachingSessionTopicAccess(topic))
@@ -97,13 +85,13 @@ where
             topic.coaching_session_id,
         )
         .await
-        .map_err(|_| (StatusCode::NOT_FOUND, "NOT FOUND".to_string()))?;
+        .map_err(|_| not_found())?;
 
         if relationship.coach_id == user.id {
             return Ok(CoachingSessionTopicDeleteAccess(topic));
         }
 
-        Err((StatusCode::NOT_FOUND, "NOT FOUND".to_string()))
+        Err(not_found())
     }
 }
 
@@ -131,25 +119,15 @@ where
         let CoachingSessionAccess(session) =
             CoachingSessionAccess::from_request_parts(parts, state).await?;
 
-        let Path(path_params) =
-            Path::<HashMap<String, String>>::from_request_parts(parts, &app_state)
-                .await
-                .map_err(|_| {
-                    (
-                        StatusCode::BAD_REQUEST,
-                        "Invalid path parameters".to_string(),
-                    )
-                })?;
-
-        let topic_id = parse_path_id(&path_params, "topic_id")?;
+        let topic_id = parse_path_id_from_parts(parts, "topic_id").await?;
 
         let topic =
             coaching_session_topic::find_including_deleted_by_id(app_state.db_conn_ref(), topic_id)
                 .await
-                .map_err(|_| (StatusCode::NOT_FOUND, "NOT FOUND".to_string()))?;
+                .map_err(|_| not_found())?;
 
         if topic.coaching_session_id != session.id {
-            return Err((StatusCode::NOT_FOUND, "NOT FOUND".to_string()));
+            return Err(not_found());
         }
 
         // Undoing a delete is author-only; undoing a defer is open to either participant.
@@ -157,7 +135,7 @@ where
             let AuthenticatedUser(user) =
                 AuthenticatedUser::from_request_parts(parts, &app_state).await?;
             if topic.user_id != user.id {
-                return Err((StatusCode::NOT_FOUND, "NOT FOUND".to_string()));
+                return Err(not_found());
             }
         }
 
@@ -194,7 +172,7 @@ where
             topic.coaching_session_id,
         )
         .await
-        .map_err(|_| (StatusCode::NOT_FOUND, "NOT FOUND".to_string()))?;
+        .map_err(|_| not_found())?;
 
         if relationship.coachee_id != user.id {
             return Err((StatusCode::FORBIDDEN, "FORBIDDEN".to_string()));
@@ -206,636 +184,5 @@ where
 
 #[cfg(test)]
 #[cfg(feature = "mock")]
-mod tests {
-    use std::sync::Arc;
-
-    use crate::middleware::auth::require_auth;
-
-    use super::*;
-    use axum::{body::Body, middleware::from_fn};
-    use axum::{
-        extract::Request,
-        routing::{delete, patch, post},
-        Router,
-    };
-    use axum_login::{
-        tower_sessions::{MemoryStore, SessionManagerLayer},
-        AuthManagerLayerBuilder,
-    };
-    use chrono::Utc;
-    use domain::user::Backend;
-    use domain::users;
-    use domain::{coaching_relationships, coaching_sessions, user_roles, Id};
-    use password_auth::generate_hash;
-    use sea_orm::{DatabaseBackend, MockDatabase};
-    use service::config::Config;
-    use time::Duration;
-    use tower::ServiceExt;
-    use tower_sessions::Expiry;
-
-    fn create_test_user() -> users::Model {
-        let now = Utc::now();
-        users::Model {
-            id: Id::new_v4(),
-            email: "test@example.com".to_string(),
-            first_name: "Test".to_string(),
-            last_name: "User".to_string(),
-            display_name: Some("Test User".to_string()),
-            password: Some(generate_hash("password123")),
-            github_username: None,
-            github_profile_url: None,
-            timezone: "UTC".to_string(),
-            default_coaching_session_duration_minutes: domain::duration::Duration::default_minutes(
-            ),
-            role: users::Role::User,
-            roles: vec![],
-            invite_status: None,
-            created_at: now.into(),
-            updated_at: now.into(),
-        }
-    }
-
-    fn test_role(user_id: Id) -> user_roles::Model {
-        let now = Utc::now();
-        user_roles::Model {
-            id: Id::new_v4(),
-            role: users::Role::User,
-            organization_id: Some(Id::new_v4()),
-            user_id,
-            created_at: now.into(),
-            updated_at: now.into(),
-        }
-    }
-
-    fn test_session(session_id: Id, relationship_id: Id) -> coaching_sessions::Model {
-        let now = Utc::now();
-        coaching_sessions::Model {
-            id: session_id,
-            coaching_relationship_id: relationship_id,
-            collab_document_name: None,
-            date: now.naive_utc(),
-            duration_minutes: domain::duration::Duration::default_minutes(),
-            title: None,
-            meeting_url: None,
-            provider: None,
-            hydrated_at: None,
-            created_at: now.into(),
-            updated_at: now.into(),
-        }
-    }
-
-    fn test_relationship(relationship_id: Id, coachee_id: Id) -> coaching_relationships::Model {
-        let now = Utc::now();
-        coaching_relationships::Model {
-            id: relationship_id,
-            coach_id: Id::new_v4(),
-            coachee_id,
-            organization_id: Id::new_v4(),
-            slug: "test".to_string(),
-            created_at: now.into(),
-            updated_at: now.into(),
-        }
-    }
-
-    fn test_relationship_with_coach(
-        relationship_id: Id,
-        coach_id: Id,
-        coachee_id: Id,
-    ) -> coaching_relationships::Model {
-        let now = Utc::now();
-        coaching_relationships::Model {
-            id: relationship_id,
-            coach_id,
-            coachee_id,
-            organization_id: Id::new_v4(),
-            slug: "test".to_string(),
-            created_at: now.into(),
-            updated_at: now.into(),
-        }
-    }
-
-    fn test_topic(
-        topic_id: Id,
-        coaching_session_id: Id,
-        user_id: Id,
-    ) -> coaching_session_topics::Model {
-        let now = Utc::now();
-        coaching_session_topics::Model {
-            id: topic_id,
-            coaching_session_id,
-            body: "A topic".to_string(),
-            user_id,
-            display_order: 0,
-            priority: Some(domain::topic_priority::Priority::High),
-            status: domain::topic_status::Status::Open,
-            moved_from_session_id: None,
-            undo_snapshot: None,
-            deleted_at: None,
-            created_at: now.into(),
-            updated_at: now.into(),
-        }
-    }
-
-    // Mounts the delete extractor behind require_auth so a logged-in DELETE exercises the full
-    // composed chain (session participant -> topic-belongs-to-session -> author-or-coach).
-    async fn delete_route(
-        CoachingSessionTopicDeleteAccess(_topic): CoachingSessionTopicDeleteAccess,
-    ) -> &'static str {
-        "extracted_success"
-    }
-
-    // Mounts the coachee extractor behind require_auth so a logged-in PATCH exercises the
-    // coachee-only rating guard (coachee -> ok, coach -> 403).
-    async fn coachee_route(
-        CoachingSessionTopicCoacheeAccess(_topic): CoachingSessionTopicCoacheeAccess,
-    ) -> &'static str {
-        "extracted_success"
-    }
-
-    // Mounts the undo extractor behind require_auth so a logged-in POST exercises the
-    // state-derived undo guard (defer: any participant; delete: author only).
-    async fn undo_route(
-        CoachingSessionTopicUndoAccess(_topic): CoachingSessionTopicUndoAccess,
-    ) -> &'static str {
-        "extracted_success"
-    }
-
-    fn build_app(db: Arc<sea_orm::DatabaseConnection>) -> Router {
-        let app_state = AppState::new(
-            service::AppState::new(Config::default(), &db),
-            Arc::new(sse::Manager::default()),
-            domain::events::EventPublisher::default(),
-            None,
-            None,
-        );
-
-        let session_store = MemoryStore::default();
-        let session_layer = SessionManagerLayer::new(session_store)
-            .with_secure(false)
-            .with_expiry(Expiry::OnInactivity(Duration::days(1)))
-            .with_always_save(true);
-
-        let backend = Backend::new(&db);
-        let auth_layer = AuthManagerLayerBuilder::new(backend, session_layer).build();
-
-        Router::new()
-            .route(
-                "/login",
-                axum::routing::post(crate::controller::user_session_controller::login),
-            )
-            .merge(
-                Router::new()
-                    .route(
-                        "/coaching_sessions/:coaching_session_id/topics/:topic_id",
-                        delete(delete_route),
-                    )
-                    .route(
-                        "/coaching_sessions/:coaching_session_id/topics/:topic_id/rating",
-                        patch(coachee_route),
-                    )
-                    .route(
-                        "/coaching_sessions/:coaching_session_id/topics/:topic_id/undo",
-                        post(undo_route),
-                    )
-                    .route_layer(from_fn(require_auth)),
-            )
-            .layer(auth_layer)
-            .with_state(app_state)
-    }
-
-    async fn do_login(app: &Router) -> String {
-        let req = Request::builder()
-            .uri("/login")
-            .method("POST")
-            .header("content-type", "application/x-www-form-urlencoded")
-            .body(Body::from("email=test@example.com&password=password123"))
-            .unwrap();
-
-        let resp = app.clone().oneshot(req).await.unwrap();
-        resp.headers()
-            .get("set-cookie")
-            .and_then(|c| c.to_str().ok())
-            .expect("Login should return session cookie")
-            .to_string()
-    }
-
-    #[tokio::test]
-    async fn delete_extractor_ok_when_author() {
-        let session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let user = create_test_user();
-        let role = test_role(user.id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship(relationship_id, user.id),
-                )]])
-                .append_query_results(vec![vec![test_topic(topic_id, session_id, user.id)]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!("/coaching_sessions/{session_id}/topics/{topic_id}"))
-            .method("DELETE")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    // A coachee deleting the coach's topic: not the author, not the coach -> 404.
-    #[tokio::test]
-    async fn delete_extractor_404_when_coachee_deletes_coachs_topic() {
-        let session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let coach_id = Id::new_v4();
-        let user = create_test_user(); // caller acts as the coachee
-        let role = test_role(user.id);
-        let relationship = test_relationship_with_coach(relationship_id, coach_id, user.id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    relationship.clone(),
-                )]])
-                // Topic authored by the coach -> caller is not the author.
-                .append_query_results(vec![vec![test_topic(topic_id, session_id, coach_id)]])
-                // Coach check: caller is the coachee, not the coach -> 404.
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    relationship.clone(),
-                )]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!("/coaching_sessions/{session_id}/topics/{topic_id}"))
-            .method("DELETE")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-
-    // A coach deleting the coachee's topic: not the author, but is the coach -> allowed.
-    #[tokio::test]
-    async fn delete_extractor_ok_when_coach_deletes_coachees_topic() {
-        let session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let coachee_id = Id::new_v4();
-        let user = create_test_user(); // caller acts as the coach
-        let role = test_role(user.id);
-        let relationship = test_relationship_with_coach(relationship_id, user.id, coachee_id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    relationship.clone(),
-                )]])
-                // Topic authored by the coachee -> caller (coach) is not the author.
-                .append_query_results(vec![vec![test_topic(topic_id, session_id, coachee_id)]])
-                // Coach check: caller IS the coach of the relationship -> allowed.
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    relationship.clone(),
-                )]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!("/coaching_sessions/{session_id}/topics/{topic_id}"))
-            .method("DELETE")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn delete_extractor_404_when_topic_belongs_to_other_session() {
-        let session_id = Id::new_v4();
-        let other_session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let user = create_test_user();
-        let role = test_role(user.id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship(relationship_id, user.id),
-                )]])
-                // Topic belongs to a different session -> session-match guard fails to 404.
-                .append_query_results(vec![vec![test_topic(topic_id, other_session_id, user.id)]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!("/coaching_sessions/{session_id}/topics/{topic_id}"))
-            .method("DELETE")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-
-    #[tokio::test]
-    async fn coachee_extractor_ok_when_user_is_coachee() {
-        let session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let user = create_test_user();
-        let role = test_role(user.id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                // CoachingSessionTopicAccess: participant check (caller is the coachee) + topic load.
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship(relationship_id, user.id),
-                )]])
-                .append_query_results(vec![vec![test_topic(topic_id, session_id, user.id)]])
-                // Coachee gate: re-resolve the relationship; caller IS the coachee -> rating allowed.
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship(relationship_id, user.id),
-                )]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!(
-                "/coaching_sessions/{session_id}/topics/{topic_id}/rating"
-            ))
-            .method("PATCH")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    #[tokio::test]
-    async fn coachee_extractor_403_when_user_is_coach() {
-        let session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let coachee_id = Id::new_v4();
-        let user = create_test_user();
-        let role = test_role(user.id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                // CoachingSessionTopicAccess: caller is the coach (a participant) -> passes; topic loads.
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship_with_coach(relationship_id, user.id, coachee_id),
-                )]])
-                .append_query_results(vec![vec![test_topic(topic_id, session_id, coachee_id)]])
-                // Coachee gate: re-resolve the relationship; caller is the coach, not the coachee -> 403.
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship_with_coach(relationship_id, user.id, coachee_id),
-                )]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!(
-                "/coaching_sessions/{session_id}/topics/{topic_id}/rating"
-            ))
-            .method("PATCH")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
-    }
-
-    /// Builds a soft-deleted topic (deleted_at set) authored by `user_id`.
-    fn deleted_test_topic(
-        topic_id: Id,
-        coaching_session_id: Id,
-        user_id: Id,
-    ) -> coaching_session_topics::Model {
-        let now = Utc::now();
-        coaching_session_topics::Model {
-            deleted_at: Some(now.into()),
-            ..test_topic(topic_id, coaching_session_id, user_id)
-        }
-    }
-
-    // Undoing a defer is open to either participant: a live (not soft-deleted) topic
-    // authored by someone else is still undoable by the caller -> 200.
-    #[tokio::test]
-    async fn undo_extractor_ok_for_live_topic_by_non_author() {
-        let session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let other_user_id = Id::new_v4();
-        let user = create_test_user();
-        let role = test_role(user.id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship(relationship_id, user.id),
-                )]])
-                // Live topic authored by someone else: defer-undo needs no author check.
-                .append_query_results(vec![vec![test_topic(topic_id, session_id, other_user_id)]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!(
-                "/coaching_sessions/{session_id}/topics/{topic_id}/undo"
-            ))
-            .method("POST")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    // Undoing a delete is author-only: the soft-deleted topic's author -> 200.
-    #[tokio::test]
-    async fn undo_extractor_ok_for_deleted_topic_by_author() {
-        let session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let user = create_test_user();
-        let role = test_role(user.id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship(relationship_id, user.id),
-                )]])
-                // Soft-deleted topic authored by the caller -> author branch passes.
-                .append_query_results(vec![vec![deleted_test_topic(
-                    topic_id, session_id, user.id,
-                )]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!(
-                "/coaching_sessions/{session_id}/topics/{topic_id}/undo"
-            ))
-            .method("POST")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::OK);
-    }
-
-    // Security teeth: a soft-deleted topic authored by someone else is NOT undoable by a
-    // non-author participant -> 404. The author-only branch fires only for deleted topics.
-    #[tokio::test]
-    async fn undo_extractor_404_for_deleted_topic_by_non_author() {
-        let session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let other_user_id = Id::new_v4();
-        let user = create_test_user();
-        let role = test_role(user.id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship(relationship_id, user.id),
-                )]])
-                // Soft-deleted topic authored by someone else -> author guard fails to 404.
-                .append_query_results(vec![vec![deleted_test_topic(
-                    topic_id,
-                    session_id,
-                    other_user_id,
-                )]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!(
-                "/coaching_sessions/{session_id}/topics/{topic_id}/undo"
-            ))
-            .method("POST")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-
-    // A topic that belongs to a different session -> 404 (session-match guard).
-    #[tokio::test]
-    async fn undo_extractor_404_when_topic_belongs_to_other_session() {
-        let session_id = Id::new_v4();
-        let other_session_id = Id::new_v4();
-        let relationship_id = Id::new_v4();
-        let topic_id = Id::new_v4();
-        let user = create_test_user();
-        let role = test_role(user.id);
-
-        let db = Arc::new(
-            MockDatabase::new(DatabaseBackend::Postgres)
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results([vec![(user.clone(), role.clone())]])
-                .append_query_results(vec![vec![(
-                    test_session(session_id, relationship_id),
-                    test_relationship(relationship_id, user.id),
-                )]])
-                // Topic belongs to a different session -> session-match guard fails to 404.
-                .append_query_results(vec![vec![test_topic(topic_id, other_session_id, user.id)]])
-                .into_connection(),
-        );
-
-        let app = build_app(Arc::clone(&db));
-        let cookie = do_login(&app).await;
-
-        let req = Request::builder()
-            .uri(format!(
-                "/coaching_sessions/{session_id}/topics/{topic_id}/undo"
-            ))
-            .method("POST")
-            .header("cookie", cookie)
-            .body(Body::empty())
-            .unwrap();
-
-        let resp = app.oneshot(req).await.unwrap();
-        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
-    }
-}
+#[path = "coaching_session_topic_access_tests.rs"]
+mod tests;

--- a/web/src/extractors/coaching_session_topic_access_tests.rs
+++ b/web/src/extractors/coaching_session_topic_access_tests.rs
@@ -1,0 +1,630 @@
+use std::sync::Arc;
+
+use crate::middleware::auth::require_auth;
+
+use super::*;
+use axum::{body::Body, middleware::from_fn};
+use axum::{
+    extract::Request,
+    routing::{delete, patch, post},
+    Router,
+};
+use axum_login::{
+    tower_sessions::{MemoryStore, SessionManagerLayer},
+    AuthManagerLayerBuilder,
+};
+use chrono::Utc;
+use domain::user::Backend;
+use domain::users;
+use domain::{coaching_relationships, coaching_sessions, user_roles, Id};
+use password_auth::generate_hash;
+use sea_orm::{DatabaseBackend, MockDatabase};
+use service::config::Config;
+use time::Duration;
+use tower::ServiceExt;
+use tower_sessions::Expiry;
+
+fn create_test_user() -> users::Model {
+    let now = Utc::now();
+    users::Model {
+        id: Id::new_v4(),
+        email: "test@example.com".to_string(),
+        first_name: "Test".to_string(),
+        last_name: "User".to_string(),
+        display_name: Some("Test User".to_string()),
+        password: Some(generate_hash("password123")),
+        github_username: None,
+        github_profile_url: None,
+        timezone: "UTC".to_string(),
+        default_coaching_session_duration_minutes: domain::duration::Duration::default_minutes(),
+        role: users::Role::User,
+        roles: vec![],
+        invite_status: None,
+        created_at: now.into(),
+        updated_at: now.into(),
+    }
+}
+
+fn test_role(user_id: Id) -> user_roles::Model {
+    let now = Utc::now();
+    user_roles::Model {
+        id: Id::new_v4(),
+        role: users::Role::User,
+        organization_id: Some(Id::new_v4()),
+        user_id,
+        created_at: now.into(),
+        updated_at: now.into(),
+    }
+}
+
+fn test_session(session_id: Id, relationship_id: Id) -> coaching_sessions::Model {
+    let now = Utc::now();
+    coaching_sessions::Model {
+        id: session_id,
+        coaching_relationship_id: relationship_id,
+        title: None,
+        collab_document_name: None,
+        date: now.naive_utc(),
+        duration_minutes: domain::duration::Duration::default_minutes(),
+        meeting_url: None,
+        provider: None,
+        hydrated_at: None,
+        created_at: now.into(),
+        updated_at: now.into(),
+    }
+}
+
+fn test_relationship(relationship_id: Id, coachee_id: Id) -> coaching_relationships::Model {
+    let now = Utc::now();
+    coaching_relationships::Model {
+        id: relationship_id,
+        coach_id: Id::new_v4(),
+        coachee_id,
+        organization_id: Id::new_v4(),
+        slug: "test".to_string(),
+        created_at: now.into(),
+        updated_at: now.into(),
+    }
+}
+
+fn test_relationship_with_coach(
+    relationship_id: Id,
+    coach_id: Id,
+    coachee_id: Id,
+) -> coaching_relationships::Model {
+    let now = Utc::now();
+    coaching_relationships::Model {
+        id: relationship_id,
+        coach_id,
+        coachee_id,
+        organization_id: Id::new_v4(),
+        slug: "test".to_string(),
+        created_at: now.into(),
+        updated_at: now.into(),
+    }
+}
+
+fn test_topic(
+    topic_id: Id,
+    coaching_session_id: Id,
+    user_id: Id,
+) -> coaching_session_topics::Model {
+    let now = Utc::now();
+    coaching_session_topics::Model {
+        id: topic_id,
+        coaching_session_id,
+        body: "A topic".to_string(),
+        user_id,
+        display_order: 0,
+        priority: Some(domain::topic_priority::Priority::High),
+        status: domain::topic_status::Status::Open,
+        moved_from_session_id: None,
+        undo_snapshot: None,
+        deleted_at: None,
+        created_at: now.into(),
+        updated_at: now.into(),
+    }
+}
+
+// Mounts the delete extractor behind require_auth so a logged-in DELETE exercises the full
+// composed chain (session participant -> topic-belongs-to-session -> author-or-coach).
+async fn delete_route(
+    CoachingSessionTopicDeleteAccess(_topic): CoachingSessionTopicDeleteAccess,
+) -> &'static str {
+    "extracted_success"
+}
+
+// Mounts the coachee extractor behind require_auth so a logged-in PATCH exercises the
+// coachee-only rating guard (coachee -> ok, coach -> 403).
+async fn coachee_route(
+    CoachingSessionTopicCoacheeAccess(_topic): CoachingSessionTopicCoacheeAccess,
+) -> &'static str {
+    "extracted_success"
+}
+
+// Mounts the undo extractor behind require_auth so a logged-in POST exercises the
+// state-derived undo guard (defer: any participant; delete: author only).
+async fn undo_route(
+    CoachingSessionTopicUndoAccess(_topic): CoachingSessionTopicUndoAccess,
+) -> &'static str {
+    "extracted_success"
+}
+
+fn build_app(db: Arc<sea_orm::DatabaseConnection>) -> Router {
+    let app_state = AppState::new(
+        service::AppState::new(Config::default(), &db),
+        Arc::new(sse::Manager::default()),
+        domain::events::EventPublisher::default(),
+        None,
+        None,
+    );
+
+    let session_store = MemoryStore::default();
+    let session_layer = SessionManagerLayer::new(session_store)
+        .with_secure(false)
+        .with_expiry(Expiry::OnInactivity(Duration::days(1)))
+        .with_always_save(true);
+
+    let backend = Backend::new(&db);
+    let auth_layer = AuthManagerLayerBuilder::new(backend, session_layer).build();
+
+    Router::new()
+        .route(
+            "/login",
+            axum::routing::post(crate::controller::user_session_controller::login),
+        )
+        .merge(
+            Router::new()
+                .route(
+                    "/coaching_sessions/:coaching_session_id/topics/:topic_id",
+                    delete(delete_route),
+                )
+                .route(
+                    "/coaching_sessions/:coaching_session_id/topics/:topic_id/rating",
+                    patch(coachee_route),
+                )
+                .route(
+                    "/coaching_sessions/:coaching_session_id/topics/:topic_id/undo",
+                    post(undo_route),
+                )
+                .route_layer(from_fn(require_auth)),
+        )
+        .layer(auth_layer)
+        .with_state(app_state)
+}
+
+async fn do_login(app: &Router) -> String {
+    let req = Request::builder()
+        .uri("/login")
+        .method("POST")
+        .header("content-type", "application/x-www-form-urlencoded")
+        .body(Body::from("email=test@example.com&password=password123"))
+        .unwrap();
+
+    let resp = app.clone().oneshot(req).await.unwrap();
+    resp.headers()
+        .get("set-cookie")
+        .and_then(|c| c.to_str().ok())
+        .expect("Login should return session cookie")
+        .to_string()
+}
+
+#[tokio::test]
+async fn delete_extractor_ok_when_author() {
+    let session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let user = create_test_user();
+    let role = test_role(user.id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship(relationship_id, user.id),
+            )]])
+            .append_query_results(vec![vec![test_topic(topic_id, session_id, user.id)]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!("/coaching_sessions/{session_id}/topics/{topic_id}"))
+        .method("DELETE")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// A coachee deleting the coach's topic: not the author, not the coach -> 404.
+#[tokio::test]
+async fn delete_extractor_404_when_coachee_deletes_coachs_topic() {
+    let session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let coach_id = Id::new_v4();
+    let user = create_test_user(); // caller acts as the coachee
+    let role = test_role(user.id);
+    let relationship = test_relationship_with_coach(relationship_id, coach_id, user.id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                relationship.clone(),
+            )]])
+            // Topic authored by the coach -> caller is not the author.
+            .append_query_results(vec![vec![test_topic(topic_id, session_id, coach_id)]])
+            // Coach check: caller is the coachee, not the coach -> 404.
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                relationship.clone(),
+            )]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!("/coaching_sessions/{session_id}/topics/{topic_id}"))
+        .method("DELETE")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// A coach deleting the coachee's topic: not the author, but is the coach -> allowed.
+#[tokio::test]
+async fn delete_extractor_ok_when_coach_deletes_coachees_topic() {
+    let session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let coachee_id = Id::new_v4();
+    let user = create_test_user(); // caller acts as the coach
+    let role = test_role(user.id);
+    let relationship = test_relationship_with_coach(relationship_id, user.id, coachee_id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                relationship.clone(),
+            )]])
+            // Topic authored by the coachee -> caller (coach) is not the author.
+            .append_query_results(vec![vec![test_topic(topic_id, session_id, coachee_id)]])
+            // Coach check: caller IS the coach of the relationship -> allowed.
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                relationship.clone(),
+            )]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!("/coaching_sessions/{session_id}/topics/{topic_id}"))
+        .method("DELETE")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn delete_extractor_404_when_topic_belongs_to_other_session() {
+    let session_id = Id::new_v4();
+    let other_session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let user = create_test_user();
+    let role = test_role(user.id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship(relationship_id, user.id),
+            )]])
+            // Topic belongs to a different session -> session-match guard fails to 404.
+            .append_query_results(vec![vec![test_topic(topic_id, other_session_id, user.id)]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!("/coaching_sessions/{session_id}/topics/{topic_id}"))
+        .method("DELETE")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn coachee_extractor_ok_when_user_is_coachee() {
+    let session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let user = create_test_user();
+    let role = test_role(user.id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            // CoachingSessionTopicAccess: participant check (caller is the coachee) + topic load.
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship(relationship_id, user.id),
+            )]])
+            .append_query_results(vec![vec![test_topic(topic_id, session_id, user.id)]])
+            // Coachee gate: re-resolve the relationship; caller IS the coachee -> rating allowed.
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship(relationship_id, user.id),
+            )]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/coaching_sessions/{session_id}/topics/{topic_id}/rating"
+        ))
+        .method("PATCH")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn coachee_extractor_403_when_user_is_coach() {
+    let session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let coachee_id = Id::new_v4();
+    let user = create_test_user();
+    let role = test_role(user.id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            // CoachingSessionTopicAccess: caller is the coach (a participant) -> passes; topic loads.
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship_with_coach(relationship_id, user.id, coachee_id),
+            )]])
+            .append_query_results(vec![vec![test_topic(topic_id, session_id, coachee_id)]])
+            // Coachee gate: re-resolve the relationship; caller is the coach, not the coachee -> 403.
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship_with_coach(relationship_id, user.id, coachee_id),
+            )]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/coaching_sessions/{session_id}/topics/{topic_id}/rating"
+        ))
+        .method("PATCH")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+/// Builds a soft-deleted topic (deleted_at set) authored by `user_id`.
+fn deleted_test_topic(
+    topic_id: Id,
+    coaching_session_id: Id,
+    user_id: Id,
+) -> coaching_session_topics::Model {
+    let now = Utc::now();
+    coaching_session_topics::Model {
+        deleted_at: Some(now.into()),
+        ..test_topic(topic_id, coaching_session_id, user_id)
+    }
+}
+
+// Undoing a defer is open to either participant: a live (not soft-deleted) topic
+// authored by someone else is still undoable by the caller -> 200.
+#[tokio::test]
+async fn undo_extractor_ok_for_live_topic_by_non_author() {
+    let session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let other_user_id = Id::new_v4();
+    let user = create_test_user();
+    let role = test_role(user.id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship(relationship_id, user.id),
+            )]])
+            // Live topic authored by someone else: defer-undo needs no author check.
+            .append_query_results(vec![vec![test_topic(topic_id, session_id, other_user_id)]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/coaching_sessions/{session_id}/topics/{topic_id}/undo"
+        ))
+        .method("POST")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// Undoing a delete is author-only: the soft-deleted topic's author -> 200.
+#[tokio::test]
+async fn undo_extractor_ok_for_deleted_topic_by_author() {
+    let session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let user = create_test_user();
+    let role = test_role(user.id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship(relationship_id, user.id),
+            )]])
+            // Soft-deleted topic authored by the caller -> author branch passes.
+            .append_query_results(vec![vec![deleted_test_topic(
+                topic_id, session_id, user.id,
+            )]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/coaching_sessions/{session_id}/topics/{topic_id}/undo"
+        ))
+        .method("POST")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+// Security teeth: a soft-deleted topic authored by someone else is NOT undoable by a
+// non-author participant -> 404. The author-only branch fires only for deleted topics.
+#[tokio::test]
+async fn undo_extractor_404_for_deleted_topic_by_non_author() {
+    let session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let other_user_id = Id::new_v4();
+    let user = create_test_user();
+    let role = test_role(user.id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship(relationship_id, user.id),
+            )]])
+            // Soft-deleted topic authored by someone else -> author guard fails to 404.
+            .append_query_results(vec![vec![deleted_test_topic(
+                topic_id,
+                session_id,
+                other_user_id,
+            )]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/coaching_sessions/{session_id}/topics/{topic_id}/undo"
+        ))
+        .method("POST")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}
+
+// A topic that belongs to a different session -> 404 (session-match guard).
+#[tokio::test]
+async fn undo_extractor_404_when_topic_belongs_to_other_session() {
+    let session_id = Id::new_v4();
+    let other_session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let topic_id = Id::new_v4();
+    let user = create_test_user();
+    let role = test_role(user.id);
+
+    let db = Arc::new(
+        MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results([vec![(user.clone(), role.clone())]])
+            .append_query_results(vec![vec![(
+                test_session(session_id, relationship_id),
+                test_relationship(relationship_id, user.id),
+            )]])
+            // Topic belongs to a different session -> session-match guard fails to 404.
+            .append_query_results(vec![vec![test_topic(topic_id, other_session_id, user.id)]])
+            .into_connection(),
+    );
+
+    let app = build_app(Arc::clone(&db));
+    let cookie = do_login(&app).await;
+
+    let req = Request::builder()
+        .uri(format!(
+            "/coaching_sessions/{session_id}/topics/{topic_id}/undo"
+        ))
+        .method("POST")
+        .header("cookie", cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+}

--- a/web/src/extractors/mod.rs
+++ b/web/src/extractors/mod.rs
@@ -16,7 +16,10 @@ mod session_renewal_tests;
 #[path = "organization_user_access_tests.rs"]
 mod organization_user_access_tests;
 
-use axum::http::StatusCode;
+use axum::{
+    extract::{FromRequestParts, Path},
+    http::{request::Parts, StatusCode},
+};
 use domain::Id;
 use std::collections::HashMap;
 
@@ -33,4 +36,26 @@ pub(crate) fn parse_path_id(
         .ok_or_else(|| (StatusCode::BAD_REQUEST, format!("Missing {key} in path")))?
         .parse::<Id>()
         .map_err(|_| (StatusCode::BAD_REQUEST, format!("Invalid {key}")))
+}
+
+/// Resolves the request's `Path` map then parses `key` as a UUID, mapping any
+/// failure to a 400. `Path` reads from request extensions, so the state is unused.
+pub(crate) async fn parse_path_id_from_parts(
+    parts: &mut Parts,
+    key: &str,
+) -> Result<Id, RejectionType> {
+    let Path(path_params) = Path::<HashMap<String, String>>::from_request_parts(parts, &())
+        .await
+        .map_err(|_| {
+            (
+                StatusCode::BAD_REQUEST,
+                "Invalid path parameters".to_string(),
+            )
+        })?;
+    parse_path_id(&path_params, key)
+}
+
+/// The uniform 404 rejection: an inaccessible resource looks identical to a missing one.
+pub(crate) fn not_found() -> RejectionType {
+    (StatusCode::NOT_FOUND, "NOT FOUND".to_string())
 }

--- a/web/src/params/coaching_session/mod.rs
+++ b/web/src/params/coaching_session/mod.rs
@@ -78,6 +78,17 @@ where
     Ok(Some(Option::<String>::deserialize(deserializer)?))
 }
 
+/// Insert the clearable `title` entry when present: a value sets it, an explicit
+/// null clears it to NULL, an absent field leaves the column untouched.
+fn insert_title_update(update_map: &mut UpdateMap, title: Option<Option<String>>) {
+    if let Some(title) = title {
+        update_map.insert(
+            "title".to_string(),
+            Some(Value::String(title.map(Box::new))),
+        );
+    }
+}
+
 impl IntoUpdateMap for UpdateParams {
     fn into_update_map(self) -> UpdateMap {
         let mut update_map = UpdateMap::new();
@@ -103,12 +114,7 @@ impl IntoUpdateMap for UpdateParams {
                 Some(Value::String(Some(Box::new(provider.to_value())))),
             );
         }
-        if let Some(title) = self.title {
-            update_map.insert(
-                "title".to_string(),
-                Some(Value::String(title.map(Box::new))),
-            );
-        }
+        insert_title_update(&mut update_map, self.title);
         update_map
     }
 }
@@ -126,12 +132,7 @@ pub(crate) struct TitleUpdateParams {
 impl IntoUpdateMap for TitleUpdateParams {
     fn into_update_map(self) -> UpdateMap {
         let mut update_map = UpdateMap::new();
-        if let Some(title) = self.title {
-            update_map.insert(
-                "title".to_string(),
-                Some(Value::String(title.map(Box::new))),
-            );
-        }
+        insert_title_update(&mut update_map, self.title);
         update_map
     }
 }


### PR DESCRIPTION
## Description
Post-review readability and DRY cleanups for the coaching-session title/topics/views work that recently merged to `main`. Pure refactor, no behavior change. Surfaced by a senior-readability review pass; split out into its own PR rather than amending the already-merged feature PRs.

#### GitHub Issue: N/A (post-merge cleanup, no tracking issue)

### Changes
* `entity_api::normalize_title_in_update_map`: collapse the nested-`Option` sentinel + `match`/`if let` two-step into one `if let` with `bool::then`.
* `entity_api::coaching_session_topic::update`: use `topic.into()` + targeted `Set` like every sibling, instead of enumerating all 13 `ActiveModel` fields.
* Extractors: factor the duplicated `Path`-parse block and the repeated `(NOT_FOUND, "NOT FOUND")` literal into shared `parse_path_id_from_parts()` and `not_found()` helpers.
* `params::coaching_session`: de-dup the clearable-title update-map insert into one `insert_title_update()` helper shared by `UpdateParams` and `TitleUpdateParams`.
* Move the topic-access extractor tests into a separate `coaching_session_topic_access_tests.rs` (frozen-test convention; matches the sibling params module).
* Title controller test: `result.expect(...)` instead of `if let Err(e) { panic!(...) }`.

### Testing Strategy
No behavior change, so existing tests are the contract. Verified locally on this branch (off latest `main`):
* `cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"` — green (183 / 219 / 102 + gated suites, 0 failures), including all 12 moved topic-access extractor tests and the `normalize_*` edge-case tests.
* `cargo fmt --check` and `cargo clippy` clean.

### Concerns
* The large line counts are the test-file extraction (~681 lines moved out of the extractor, ~631 into the new `_tests.rs`); the net production change is small.
* No migration, schema, or wire-contract changes.
