### PR TITLE
Server-composed display_title on list reads

### DIFF
--- a/docs/implementation-plans/coaching-session-display-title-backend.md
+++ b/docs/implementation-plans/coaching-session-display-title-backend.md
@@ -1,0 +1,232 @@
+# Coaching Session `display_title` — Backend Implementation Plan
+
+## Goal
+
+Add a server-composed `display_title: string | null` field to the two coaching-session
+**list reads** so every list/preview surface derives an identical session title without
+shipping topic arrays or re-implementing the fallback chain client-side.
+
+Settles the coordinator `session_title_topics_include` question (Option B, BE composes the
+chain), FE-confirmed 2026-06-18.
+
+### The fallback chain (BE owns it now)
+
+```
+human-set title  →  first topic body  →  first goal title  →  null
+```
+
+- No synthetic `"Coaching Session"` default. When no tier yields text, `display_title` is `null`.
+- `null` (not `""`) is the no-value encoding — matches the sibling `title` field (already
+  `string | null`, never `""` on the wire) and serde `Option<String>` default. The FE renders
+  `display_title ?? <fe placeholder>`; the placeholder stays an FE presentation choice.
+- **Why `null` matters for the FE component (clarified):** returning `null` (not a baked default)
+  is exactly what lets the FE title component expose the fallback as a **per-call-site parameter**
+  (e.g. a `defaultTitle` prop). Each surface overrides it independently — "Coaching Session" on the
+  dashboard, a different label elsewhere — and no surface ever renders `""`. A BE-baked default
+  would force one word everywhere; `null` keeps the choice at the call site. This is an FE concern
+  (no BE change), recorded here so the rationale for `null` isn't mistaken for an oversight.
+
+### Scope (narrowed by FE confirmation — read before building)
+
+- **IN:** enriched `GET /users/{user_id}/coaching_sessions` AND the shared relationship-scoped
+  `GET /coaching_sessions?coaching_relationship_id=`.
+- **OUT:** the single-session `GET /coaching_sessions/{id}`. The FE explicitly declined it — the
+  single page keeps client-side derivation so it stays consistent with optimistic title/topic
+  edits a server field would lag behind. Do NOT add the field there.
+- Always-present field (value may be `null`), **not** include-gated. Additive. No SSE. No new
+  endpoint. **No change to any topic or goal endpoint.**
+
+## Key architectural decision
+
+The two target endpoints differ in return type and query path:
+
+| Endpoint | Handler | entity_api fn | Return type today |
+|---|---|---|---|
+| Enriched user-list | `web/src/controller/user/coaching_session_controller.rs::index` | `find_by_user_with_includes` | `Vec<EnrichedSession>` |
+| Relationship-scoped list | `web/src/controller/coaching_session_controller.rs::index` | `CoachingSessionApi::find_by` (generic `query::find_by`) | `Vec<coaching_sessions::Model>` |
+
+**Do NOT reuse `EnrichedSession` for the relationship-scoped endpoint.** `EnrichedSession`
+carries `viewer_last_viewed_at`, which is **caller-scoped**; the `CoachingSessionViews` v2
+contract deliberately kept that off the shared relationship-scoped list. `display_title`, by
+contrast, is **not** caller-scoped (same value for coach and coachee), so it is safe on the
+shared list — but it must travel on its own minimal wrapper, not by importing the view marker.
+
+Therefore: factor the title logic into a **shared composition primitive** + **two lightweight
+batch loaders**, consumed by both assembly sites independently.
+
+## Design — shared primitives (in `entity_api/src/coaching_session_display_title.rs`)
+
+> **Module placement (decided during build):** the composition + loaders live in their
+> own sibling module `entity_api/src/coaching_session_display_title.rs`, mirroring
+> `coaching_session_topic.rs` / `coaching_session_goal.rs` / `coaching_session_view.rs`.
+> It is a *module*, not a new DB entity — `display_title` is a read-time projection with
+> no stored state, identity, or lifecycle (the opposite of `coaching_session_views`, which
+> earned its own table). `batch_load_display_titles` is `pub` so both the enriched path
+> (entity_api) and the relationship-scoped path (domain) consume it; the inner loaders +
+> `compose_display_title` stay private/`pub(crate)`.
+
+### 1. Pure composition function
+
+```rust
+/// Compose the display title from the fallback chain. Treats empty / whitespace-only
+/// inputs as absent so a blank topic body or goal title falls through to the next tier.
+fn compose_display_title(
+    session_title: Option<&str>,
+    first_topic_body: Option<&str>,
+    first_goal_title: Option<&str>,
+) -> Option<String> {
+    [session_title, first_topic_body, first_goal_title]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+```
+
+- Pure, trivially unit-testable, no DB. The emptiness guard matters: goal `title` can be `""`
+  (see `ActiveGoalLimitConflict` note), and `title` is already whitespace-normalized on write
+  but we trim defensively.
+
+### 2. Two lightweight batch loaders (mirror `batch_load_views`)
+
+```rust
+/// First (drag-order) live topic body per session. Reuses the EXACT canonical ordering +
+/// soft-delete filter from `coaching_session_topic::find_by_coaching_session_id`, so it
+/// inherits v5 move/defer parenting (CoachingSessionId = this session) and v6 soft-delete
+/// exclusion (DeletedAt IS NULL) by construction.
+async fn batch_load_first_topic_bodies(
+    db: &impl ConnectionTrait,
+    session_ids: &[Id],
+) -> Result<HashMap<Id, String>, Error>;
+
+/// First linked goal title per session. Reuses `coaching_session_goal::find_goals_grouped_by_session_ids`
+/// and takes the first goal's title.
+async fn batch_load_first_goal_titles(
+    db: &impl ConnectionTrait,
+    session_ids: &[Id],
+) -> Result<HashMap<Id, String>, Error>;
+```
+
+Implementation notes:
+- `batch_load_first_topic_bodies`: one query — `coaching_session_topics` where
+  `CoachingSessionId IN (...)` AND `DeletedAt IS NULL`, ordered by `DisplayOrder ASC, CreatedAt ASC`
+  (the canonical order). Select only the columns needed (`coaching_session_id`, `body`,
+  `display_order`, `created_at`) and reduce to the first row per session in Rust (keep the first
+  seen per `coaching_session_id` since the result is already globally ordered, or group then pick
+  min). Matches the existing `batch_load_topics` shape but lighter (no full Model vec, `LIMIT`-1
+  semantics per session).
+- `batch_load_first_goal_titles`: call the existing grouped-goals loader and `.first()` each vec.
+- Optional optimization (non-blocking): both could be a single SQL `DISTINCT ON (coaching_session_id)`
+  / lateral query. Start with the Rust-reduce version for consistency with existing `batch_load_*`
+  code; revisit only if profiling warrants.
+
+### 3. One thin helper to assemble a title map
+
+```rust
+/// Compose display titles for a set of sessions in one place. `titles` is each session's own
+/// `title` column keyed by id (callers already hold the Models).
+async fn batch_load_display_titles(
+    db: &impl ConnectionTrait,
+    sessions: &[(Id, Option<String>)],   // (session_id, session.title)
+) -> Result<HashMap<Id, Option<String>>, Error>;
+```
+
+Loads first-topic-bodies + first-goal-titles for the ids, then `compose_display_title` per
+session. Both call sites use this; the composition rule lives exactly once.
+
+## Wiring — site A: enriched user-list (`EnrichedSession`)
+
+1. Add field to `EnrichedSession` (entity_api/src/coaching_session.rs, near line 494, beside
+   `viewer_last_viewed_at`):
+   ```rust
+   // Server-composed fallback title (human title → first topic body → first goal title);
+   // null when none derive. Always present.
+   pub display_title: Option<String>,
+   ```
+   **No `#[serde(skip_serializing_if)]`** — must serialize as `null` when absent (same as
+   `viewer_last_viewed_at`).
+2. In `find_by_user_with_includes`: after the base sessions are fetched, call
+   `batch_load_display_titles` **unconditionally** (like `batch_load_views`), independent of the
+   `include` flags. Populate `display_title` in both the includes-assembly path
+   (`assemble_enriched_session`) and the no-includes path (where `viewer_last_viewed_at` is set
+   per session today).
+3. Reuse already-loaded data when present: if `include=topics`/`include=goal` already loaded the
+   full vecs, prefer composing from those to avoid a redundant query. Keep it simple — correctness
+   first; the extra two batch queries are cheap and keyed on the same id set.
+
+## Wiring — site B: relationship-scoped list (plain `Model` today)
+
+1. Introduce a minimal serialized wrapper (entity_api/src/coaching_session.rs):
+   ```rust
+   #[derive(Debug, Clone, serde::Serialize, ToSchema)]
+   #[schema(as = domain::coaching_session::SessionWithDisplayTitle)]
+   pub struct SessionWithDisplayTitle {
+       #[serde(flatten)]
+       pub session: coaching_sessions::Model,
+       pub display_title: Option<String>,   // always present; null when none
+   }
+   ```
+   Deliberately does **not** include `viewer_last_viewed_at` (caller-scoped; out of scope here).
+2. The relationship-scoped `index` controller currently returns `Vec<Model>` from
+   `CoachingSessionApi::find_by`. Two options:
+   - **B1 (preferred):** add a domain fn `find_by_with_display_title(db, params)` that runs the
+     existing `find_by`, then maps the Models through `batch_load_display_titles`, returning
+     `Vec<SessionWithDisplayTitle>`. Controller switches to it. Smallest blast radius; the generic
+     `find_by` filter path is untouched.
+   - **B2:** enrich inside the controller. Avoid — keeps composition logic out of entity_api.
+3. Update the utoipa `responses(... body = [coaching_sessions::Model])` to the new wrapper type.
+
+## Contract + versioning (owed after build)
+
+- Bump `UserCoachingSessionsListEndpoint` (add `display_title` to the enriched read shape).
+- Bump `CoachingSessionsListEndpoint` → v3. **Coordinate with the already-promised v3** for that
+  endpoint (the date-filter-fix the contract says "v3 will be posted with the fix"); fold
+  `display_title` into the same bump or sequence them clearly.
+- Cross-reference `CoachingSessionTitleField` (the `title` field this falls back from).
+- Post to the coordinator board when **built + verified live**, per the FE's "ping the board"
+  request. Until then the FE types against the agreed shape.
+
+## Testing
+
+Mock-gated suite (per project convention):
+`cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"`.
+Frozen-test discipline: unit tests in a separate `*_tests.rs` wired via
+`#[cfg(test)] #[path = "..."] mod tests;`, never an in-file `mod tests`.
+
+- **Pure `compose_display_title`** (no DB): title wins over topic/goal; empty/whitespace title
+  falls through to topic; empty topic body falls through to goal; all-empty → `None`; goal `""`
+  treated as absent.
+- **`batch_load_first_topic_bodies`**: returns drag-order-first body; excludes soft-deleted
+  (`DeletedAt` set) topics; ignores topics parented to other sessions (v5 move semantics); empty
+  when session has no live topics.
+- **`batch_load_first_goal_titles`**: first linked goal's title; none when no linked goals.
+- **End-to-end per endpoint** (web/mock where feasible): enriched list returns `display_title`
+  matching the chain; relationship-scoped list returns the wrapper with `display_title`; `null`
+  surfaces when nothing derives; field present even with no `include=`.
+
+Run `cargo clippy` and `cargo fmt` before committing. No `.unwrap()` in production paths.
+
+## Phases (single coherent PR; sequence for clean review)
+
+1. **Primitives** — `compose_display_title` (+ unit tests), `batch_load_first_topic_bodies`,
+   `batch_load_first_goal_titles`, `batch_load_display_titles` (+ entity_api tests).
+2. **Site A** — `display_title` on `EnrichedSession` + unconditional load in
+   `find_by_user_with_includes`; assembly in both include/no-include paths; tests.
+3. **Site B** — `SessionWithDisplayTitle` wrapper + `find_by_with_display_title`; relationship-scoped
+   controller + utoipa response type; tests.
+4. **Contracts + verify** — live-verify both endpoints on real Postgres; bump the two list-endpoint
+   contracts; post the board update.
+
+## Out of scope / explicit non-goals
+
+- Single-session `GET /coaching_sessions/{id}` (FE keeps client-side derivation there).
+- Any change to topic/goal endpoints, enums, or wire shapes.
+- SSE (none; title is derived, not a live event).
+- No migration — `display_title` is computed, not stored.
+
+## Branch
+
+New branch off `main` (e.g. `feat/coaching-session-display-title`). Additive; no coordinated
+deploy needed — the field is read-only-when-present and the FE consumes it via its existing
+`CoachingSessionTitleText` seam once it appears.

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -264,10 +264,10 @@ where
     Ok(coaching_sessions)
 }
 
-/// Like [`find_by`], but enriches each session with its server-composed
-/// `display_title` (title -> first topic body -> first goal title; null when
-/// none). Used by the relationship-scoped list so every list surface derives an
-/// identical title without re-running the chain client-side.
+/// [`find_by`] plus a per-session `display_title`. Distinct from the stored
+/// `title` column (a user-set name, often null): `display_title` is the
+/// server-composed fallback `title -> first topic body -> first goal title`
+/// (null when none), so list surfaces render a consistent name without deriving it.
 pub async fn find_by_with_display_title<P>(
     db: &DatabaseConnection,
     params: P,

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -22,8 +22,9 @@ use service::config::Config;
 pub use entity_api::coaching_session::{
     find_by_id, find_by_series_id, find_by_user_with_includes, find_counts_by_month_for_user,
     find_next_session, find_participant_ids, CountByMonth, EnrichedSession, IncludeOptions,
-    SessionQueryOptions, SessionWithDisplayTitle,
+    SessionQueryOptions,
 };
+pub use entity_api::coaching_session_display_title::SessionWithDisplayTitle;
 
 use crate::duration::Duration;
 pub use recurrence::{expand_recurrence, Frequency, Recurrence, RecurrenceError};

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -22,7 +22,7 @@ use service::config::Config;
 pub use entity_api::coaching_session::{
     find_by_id, find_by_series_id, find_by_user_with_includes, find_counts_by_month_for_user,
     find_next_session, find_participant_ids, CountByMonth, EnrichedSession, IncludeOptions,
-    SessionQueryOptions,
+    SessionQueryOptions, SessionWithDisplayTitle,
 };
 
 use crate::duration::Duration;
@@ -262,6 +262,35 @@ where
         query::find_by::<coaching_sessions::Entity, coaching_sessions::Column, P>(db, params)
             .await?;
     Ok(coaching_sessions)
+}
+
+/// Like [`find_by`], but enriches each session with its server-composed
+/// `display_title` (title -> first topic body -> first goal title; null when
+/// none). Used by the relationship-scoped list so every list surface derives an
+/// identical title without re-running the chain client-side.
+pub async fn find_by_with_display_title<P>(
+    db: &DatabaseConnection,
+    params: P,
+) -> Result<Vec<SessionWithDisplayTitle>, Error>
+where
+    P: IntoQueryFilterMap + QuerySort<coaching_sessions::Column>,
+{
+    let sessions =
+        query::find_by::<coaching_sessions::Entity, coaching_sessions::Column, P>(db, params)
+            .await?;
+    let display_titles =
+        entity_api::coaching_session_display_title::batch_load_display_titles(db, &sessions)
+            .await?;
+    Ok(sessions
+        .into_iter()
+        .map(|session| {
+            let display_title = display_titles.get(&session.id).cloned().flatten();
+            SessionWithDisplayTitle {
+                session,
+                display_title,
+            }
+        })
+        .collect())
 }
 
 pub async fn update(

--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -275,18 +275,18 @@ pub async fn find_by_with_display_title<P>(
 where
     P: IntoQueryFilterMap + QuerySort<coaching_sessions::Column>,
 {
-    let sessions =
-        query::find_by::<coaching_sessions::Entity, coaching_sessions::Column, P>(db, params)
-            .await?;
-    let display_titles =
-        entity_api::coaching_session_display_title::batch_load_display_titles(db, &sessions)
-            .await?;
-    Ok(sessions
+    let coaching_sessions = find_by(db, params).await?;
+    let display_titles = entity_api::coaching_session_display_title::batch_load_display_titles(
+        db,
+        &coaching_sessions,
+    )
+    .await?;
+    Ok(coaching_sessions
         .into_iter()
-        .map(|session| {
-            let display_title = display_titles.get(&session.id).cloned().flatten();
+        .map(|coaching_session| {
+            let display_title = display_titles.get(&coaching_session.id).cloned().flatten();
             SessionWithDisplayTitle {
-                session,
+                session: coaching_session,
                 display_title,
             }
         })

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -540,8 +540,25 @@ pub struct EnrichedSession {
     pub agreement: Option<agreements::Model>,
     // Caller-scoped read receipt: when the path user last marked this session viewed; null if never.
     pub viewer_last_viewed_at: Option<DateTimeWithTimeZone>,
+    // Server-composed fallback title: human title -> first topic body -> first goal title;
+    // null when none derive. Always present (serialized as null, never omitted), so consumers
+    // get one canonical title without re-deriving the chain.
+    pub display_title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub topics: Option<Vec<coaching_session_topics::Model>>,
+}
+
+/// Relationship-scoped list read shape: the base session plus the server-composed
+/// `display_title`. Unlike [`EnrichedSession`], it carries no caller-scoped fields
+/// (e.g. `viewer_last_viewed_at`), so it is safe on the relationship list, which is
+/// shared by both participants.
+#[derive(Debug, Clone, serde::Serialize, ToSchema)]
+#[schema(as = domain::coaching_session::SessionWithDisplayTitle)]
+pub struct SessionWithDisplayTitle {
+    #[serde(flatten)]
+    pub session: Model,
+    // Server-composed fallback title; null when none derive. Always present.
+    pub display_title: Option<String>,
 }
 
 /// Configuration for which related resources to include when fetching coaching sessions.
@@ -733,6 +750,12 @@ pub async fn find_by_user_with_includes(
     let session_ids: Vec<Id> = sessions.iter().map(|s| s.id).collect();
     let views = batch_load_views(db, &session_ids, user_id).await?;
 
+    // Compose `display_title` unconditionally (like the view markers) so every
+    // response carries one canonical title (null when nothing derives),
+    // independent of which includes were requested.
+    let display_titles =
+        super::coaching_session_display_title::batch_load_display_titles(db, &sessions).await?;
+
     // Early return if no includes requested
     if !options.includes.needs_relationships()
         && !options.includes.goal
@@ -743,8 +766,10 @@ pub async fn find_by_user_with_includes(
             .into_iter()
             .map(|session| {
                 let marker = views.get(&session.id).copied();
+                let display_title = display_titles.get(&session.id).cloned().flatten();
                 let mut enriched = EnrichedSession::from_session(session);
                 enriched.viewer_last_viewed_at = marker;
+                enriched.display_title = display_title;
                 enriched
             })
             .collect());
@@ -756,7 +781,15 @@ pub async fn find_by_user_with_includes(
     // Assemble enriched sessions
     Ok(sessions
         .into_iter()
-        .map(|session| assemble_enriched_session(session, &related_data, options.includes, &views))
+        .map(|session| {
+            assemble_enriched_session(
+                session,
+                &related_data,
+                options.includes,
+                &views,
+                &display_titles,
+            )
+        })
         .collect())
 }
 
@@ -997,6 +1030,7 @@ fn assemble_enriched_session(
     related: &RelatedData,
     includes: IncludeOptions,
     views: &HashMap<Id, DateTimeWithTimeZone>,
+    display_titles: &HashMap<Id, Option<String>>,
 ) -> EnrichedSession {
     let relationship = related
         .relationships
@@ -1027,6 +1061,8 @@ fn assemble_enriched_session(
 
     let viewer_last_viewed_at = views.get(&session.id).copied();
 
+    let display_title = display_titles.get(&session.id).cloned().flatten();
+
     let topics = if includes.topics {
         Some(related.topics.get(&session.id).cloned().unwrap_or_default())
     } else {
@@ -1042,6 +1078,7 @@ fn assemble_enriched_session(
         goals,
         agreement,
         viewer_last_viewed_at,
+        display_title,
         topics,
     }
 }
@@ -1058,6 +1095,7 @@ impl EnrichedSession {
             goals: None,
             agreement: None,
             viewer_last_viewed_at: None,
+            display_title: None,
             topics: None,
         }
     }
@@ -1453,6 +1491,8 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![session.clone()]])
             .append_query_results::<entity::coaching_session_views::Model, Vec<_>, _>(vec![vec![]])
+            .append_query_results(vec![Vec::<coaching_session_topics::Model>::new()])
+            .append_query_results(vec![Vec::<goals::Model>::new()])
             .into_connection();
 
         let results =
@@ -1507,6 +1547,8 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![session.clone()]])
             .append_query_results(vec![vec![view.clone()]])
+            .append_query_results(vec![Vec::<coaching_session_topics::Model>::new()])
+            .append_query_results(vec![Vec::<goals::Model>::new()])
             .into_connection();
 
         let results =
@@ -1519,6 +1561,8 @@ mod tests {
         let db_empty = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![session.clone()]])
             .append_query_results::<coaching_session_views::Model, Vec<_>, _>(vec![vec![]])
+            .append_query_results(vec![Vec::<coaching_session_topics::Model>::new()])
+            .append_query_results(vec![Vec::<goals::Model>::new()])
             .into_connection();
 
         let results_empty =
@@ -1526,6 +1570,48 @@ mod tests {
 
         assert_eq!(results_empty.len(), 1);
         assert!(results_empty[0].viewer_last_viewed_at.is_none());
+
+        Ok(())
+    }
+
+    // Guards that display_title is composed end-to-end and lands on the
+    // EnrichedSession (the title tier wins; topics/goals empty). Precedence
+    // itself is covered by the compose_display_title unit tests.
+    #[tokio::test]
+    async fn find_by_user_populates_display_title_from_title() -> Result<(), Error> {
+        let now = chrono::Utc::now();
+        let user_id = Id::new_v4();
+
+        let session = Model {
+            id: Id::new_v4(),
+            coaching_relationship_id: Id::new_v4(),
+            coaching_session_series_id: None,
+            date: chrono::Local::now().naive_utc(),
+            collab_document_name: None,
+            duration_minutes: crate::duration::Duration::default_minutes(),
+            title: Some("Quarterly Review".to_string()),
+            meeting_url: None,
+            provider: None,
+            created_at: now.into(),
+            updated_at: now.into(),
+            hydrated_at: Some(now.into()),
+        };
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![session.clone()]])
+            .append_query_results::<coaching_session_views::Model, Vec<_>, _>(vec![vec![]])
+            .append_query_results(vec![Vec::<coaching_session_topics::Model>::new()])
+            .append_query_results(vec![Vec::<goals::Model>::new()])
+            .into_connection();
+
+        let results =
+            find_by_user_with_includes(&db, user_id, SessionQueryOptions::default()).await?;
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].display_title.as_deref(),
+            Some("Quarterly Review")
+        );
 
         Ok(())
     }
@@ -1556,6 +1642,8 @@ mod tests {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results(vec![vec![session.clone()]])
             .append_query_results::<entity::coaching_session_views::Model, Vec<_>, _>(vec![vec![]])
+            .append_query_results(vec![Vec::<coaching_session_topics::Model>::new()])
+            .append_query_results(vec![Vec::<goals::Model>::new()])
             .into_connection();
 
         let results = find_by_user_with_includes(
@@ -1811,7 +1899,9 @@ mod tests {
         };
 
         let views = HashMap::new();
-        let enriched = assemble_enriched_session(session, &related, includes, &views);
+        let display_titles = HashMap::new();
+        let enriched =
+            assemble_enriched_session(session, &related, includes, &views, &display_titles);
 
         // Must be Some(empty vec), not None — otherwise the frontend
         // can't distinguish "no goals" from "data not loaded yet".
@@ -1840,7 +1930,9 @@ mod tests {
         let includes = IncludeOptions::none();
 
         let views = HashMap::new();
-        let enriched = assemble_enriched_session(session, &related, includes, &views);
+        let display_titles = HashMap::new();
+        let enriched =
+            assemble_enriched_session(session, &related, includes, &views, &display_titles);
 
         assert!(enriched.goals.is_none());
     }

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -548,19 +548,6 @@ pub struct EnrichedSession {
     pub topics: Option<Vec<coaching_session_topics::Model>>,
 }
 
-/// Relationship-scoped list read shape: the base session plus the server-composed
-/// `display_title`. Unlike [`EnrichedSession`], it carries no caller-scoped fields
-/// (e.g. `viewer_last_viewed_at`), so it is safe on the relationship list, which is
-/// shared by both participants.
-#[derive(Debug, Clone, serde::Serialize, ToSchema)]
-#[schema(as = domain::coaching_session::SessionWithDisplayTitle)]
-pub struct SessionWithDisplayTitle {
-    #[serde(flatten)]
-    pub session: Model,
-    // Server-composed fallback title; null when none derive. Always present.
-    pub display_title: Option<String>,
-}
-
 /// Configuration for which related resources to include when fetching coaching sessions.
 ///
 /// # Purpose

--- a/entity_api/src/coaching_session_display_title.rs
+++ b/entity_api/src/coaching_session_display_title.rs
@@ -10,6 +10,19 @@ use super::error::Error;
 use entity::{coaching_session_topics, coaching_sessions, Id};
 use sea_orm::{entity::prelude::*, ConnectionTrait, QueryOrder};
 use std::collections::HashMap;
+use utoipa::ToSchema;
+
+/// Relationship-scoped list read shape: a base session plus its composed
+/// `display_title`. Unlike the enriched read it carries no caller-scoped fields
+/// (e.g. `viewer_last_viewed_at`), so it is safe on the participant-shared list.
+#[derive(Debug, Clone, serde::Serialize, ToSchema)]
+#[schema(as = domain::coaching_session::SessionWithDisplayTitle)]
+pub struct SessionWithDisplayTitle {
+    #[serde(flatten)]
+    pub session: coaching_sessions::Model,
+    // Composed fallback title; null when none derive. Always present.
+    pub display_title: Option<String>,
+}
 
 /// Compose a session's display title from the fallback chain:
 /// human title -> first topic body -> first goal title. Empty / whitespace-only

--- a/entity_api/src/coaching_session_display_title.rs
+++ b/entity_api/src/coaching_session_display_title.rs
@@ -1,0 +1,110 @@
+//! Server-side composition of a coaching session's `display_title`.
+//!
+//! `display_title` is a read-time projection, not stored state: it composes the
+//! fallback chain `human title -> first topic body -> first goal title` and is
+//! `null` when no tier yields text (the server invents no placeholder). It reuses
+//! the canonical topic ordering and the `include=goal` source so the composed
+//! title matches the single-session page by construction.
+
+use super::error::Error;
+use entity::{coaching_session_topics, coaching_sessions, Id};
+use sea_orm::{entity::prelude::*, ConnectionTrait, QueryOrder};
+use std::collections::HashMap;
+
+/// Compose a session's display title from the fallback chain:
+/// human title -> first topic body -> first goal title. Empty / whitespace-only
+/// inputs are treated as absent so a blank tier falls through to the next.
+/// Returns `None` when no tier yields text.
+pub(crate) fn compose_display_title(
+    session_title: Option<&str>,
+    first_topic_body: Option<&str>,
+    first_goal_title: Option<&str>,
+) -> Option<String> {
+    [session_title, first_topic_body, first_goal_title]
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+
+/// First (drag-order) live topic body per session, keyed by session id.
+///
+/// Reuses the canonical ordering + soft-delete filter of
+/// [`super::coaching_session_topic::find_by_coaching_session_id`], so it inherits
+/// v5 move/defer parenting (`CoachingSessionId` = this session) and v6 soft-delete
+/// exclusion (`DeletedAt IS NULL`). Results are globally ordered, so the first row
+/// seen per session is that session's drag-order-first topic.
+async fn batch_load_first_topic_bodies(
+    db: &impl ConnectionTrait,
+    session_ids: &[Id],
+) -> Result<HashMap<Id, String>, Error> {
+    if session_ids.is_empty() {
+        return Ok(HashMap::new());
+    }
+    let mut map: HashMap<Id, String> = HashMap::new();
+    for topic in coaching_session_topics::Entity::find()
+        .filter(
+            coaching_session_topics::Column::CoachingSessionId.is_in(session_ids.iter().copied()),
+        )
+        .filter(coaching_session_topics::Column::DeletedAt.is_null())
+        .order_by_asc(coaching_session_topics::Column::DisplayOrder)
+        .order_by_asc(coaching_session_topics::Column::CreatedAt)
+        .all(db)
+        .await?
+    {
+        // Keep only the first (canonical-order) topic per session.
+        map.entry(topic.coaching_session_id).or_insert(topic.body);
+    }
+    Ok(map)
+}
+
+/// First linked goal title per session, keyed by session id. Reuses the same
+/// grouped-goals source as `include=goal` so the title tier matches what that
+/// include returns. Skips goals whose title is absent.
+async fn batch_load_first_goal_titles(
+    db: &impl ConnectionTrait,
+    session_ids: &[Id],
+) -> Result<HashMap<Id, String>, Error> {
+    let grouped =
+        super::coaching_session_goal::find_goals_grouped_by_session_ids(db, session_ids).await?;
+
+    Ok(grouped
+        .into_iter()
+        .filter_map(|(session_id, goals)| {
+            goals
+                .into_iter()
+                .next()
+                .and_then(|g| g.title)
+                .map(|title| (session_id, title))
+        })
+        .collect())
+}
+
+/// Compose display titles for every passed session from its own title plus the
+/// first-topic-body and first-goal-title tiers. Every session id is present in
+/// the result (value `None` when no tier derives).
+pub async fn batch_load_display_titles(
+    db: &impl ConnectionTrait,
+    sessions: &[coaching_sessions::Model],
+) -> Result<HashMap<Id, Option<String>>, Error> {
+    let session_ids: Vec<Id> = sessions.iter().map(|s| s.id).collect();
+    let first_topic_bodies = batch_load_first_topic_bodies(db, &session_ids).await?;
+    let first_goal_titles = batch_load_first_goal_titles(db, &session_ids).await?;
+
+    Ok(sessions
+        .iter()
+        .map(|s| {
+            let title = compose_display_title(
+                s.title.as_deref(),
+                first_topic_bodies.get(&s.id).map(String::as_str),
+                first_goal_titles.get(&s.id).map(String::as_str),
+            );
+            (s.id, title)
+        })
+        .collect())
+}
+
+#[cfg(test)]
+#[path = "coaching_session_display_title_tests.rs"]
+mod tests;

--- a/entity_api/src/coaching_session_display_title.rs
+++ b/entity_api/src/coaching_session_display_title.rs
@@ -53,7 +53,9 @@ async fn batch_load_first_topic_bodies(
         .all(db)
         .await?
     {
-        // Keep only the first (canonical-order) topic per session.
+        // Keep only the first (canonical-order) topic per session. Bodies are
+        // stored raw (even if empty/whitespace); compose_display_title is the
+        // single authority on emptiness and trims/falls through as needed.
         map.entry(topic.coaching_session_id).or_insert(topic.body);
     }
     Ok(map)
@@ -72,10 +74,13 @@ async fn batch_load_first_goal_titles(
     Ok(grouped
         .into_iter()
         .filter_map(|(session_id, goals)| {
+            // First goal that actually has a title (a leading title-less goal must
+            // not drop the tier). Goals arrive in deterministic order from
+            // find_goals_grouped_by_session_ids. compose_display_title trims any
+            // blank result, so emptiness policy stays in one place.
             goals
                 .into_iter()
-                .next()
-                .and_then(|g| g.title)
+                .find_map(|g| g.title)
                 .map(|title| (session_id, title))
         })
         .collect())
@@ -108,3 +113,7 @@ pub async fn batch_load_display_titles(
 #[cfg(test)]
 #[path = "coaching_session_display_title_tests.rs"]
 mod tests;
+
+#[cfg(all(test, feature = "mock"))]
+#[path = "coaching_session_display_title_mock_tests.rs"]
+mod mock_tests;

--- a/entity_api/src/coaching_session_display_title_mock_tests.rs
+++ b/entity_api/src/coaching_session_display_title_mock_tests.rs
@@ -1,0 +1,58 @@
+use super::batch_load_first_goal_titles;
+use entity::{coaching_sessions_goals, goals, Id};
+use sea_orm::{DatabaseBackend, MockDatabase};
+
+fn goal_with_title(relationship_id: Id, title: Option<&str>) -> goals::Model {
+    let now = chrono::Utc::now().fixed_offset();
+    goals::Model {
+        id: Id::new_v4(),
+        coaching_relationship_id: relationship_id,
+        created_in_session_id: None,
+        user_id: Id::new_v4(),
+        title: title.map(str::to_owned),
+        body: None,
+        status: entity::status::Status::InProgress,
+        status_changed_at: None,
+        completed_at: None,
+        target_date: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn link(session_id: Id, goal_id: Id) -> coaching_sessions_goals::Model {
+    let now = chrono::Utc::now().fixed_offset();
+    coaching_sessions_goals::Model {
+        id: Id::new_v4(),
+        coaching_session_id: session_id,
+        goal_id,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+/// A leading title-less goal must NOT drop the goal tier: the first goal that
+/// actually has a title wins. Regression for the next() -> find_map fix.
+#[tokio::test]
+async fn first_goal_title_skips_leading_untitled_goal() {
+    let session_id = Id::new_v4();
+    let relationship_id = Id::new_v4();
+    let untitled = goal_with_title(relationship_id, None);
+    let titled = goal_with_title(relationship_id, Some("Real goal title"));
+
+    let db = MockDatabase::new(DatabaseBackend::Postgres)
+        .append_query_results(vec![vec![
+            (link(session_id, untitled.id), Some(untitled.clone())),
+            (link(session_id, titled.id), Some(titled.clone())),
+        ]])
+        .into_connection();
+
+    let map = batch_load_first_goal_titles(&db, &[session_id])
+        .await
+        .expect("loader should succeed");
+
+    assert_eq!(
+        map.get(&session_id).map(String::as_str),
+        Some("Real goal title")
+    );
+}

--- a/entity_api/src/coaching_session_display_title_tests.rs
+++ b/entity_api/src/coaching_session_display_title_tests.rs
@@ -1,0 +1,60 @@
+use super::compose_display_title;
+
+#[test]
+fn title_wins_over_topic_and_goal() {
+    assert_eq!(
+        compose_display_title(Some("Set Title"), Some("topic body"), Some("goal title")),
+        Some("Set Title".to_string())
+    );
+}
+
+#[test]
+fn falls_through_to_topic_when_title_absent() {
+    assert_eq!(
+        compose_display_title(None, Some("topic body"), Some("goal title")),
+        Some("topic body".to_string())
+    );
+}
+
+#[test]
+fn blank_title_falls_through_to_topic() {
+    assert_eq!(
+        compose_display_title(Some("   "), Some("topic body"), Some("goal title")),
+        Some("topic body".to_string())
+    );
+}
+
+#[test]
+fn falls_through_to_goal_when_title_and_topic_absent() {
+    assert_eq!(
+        compose_display_title(None, None, Some("goal title")),
+        Some("goal title".to_string())
+    );
+}
+
+#[test]
+fn empty_goal_title_treated_as_absent() {
+    // Goal titles can be "" on the wire; an empty goal title must not win.
+    assert_eq!(compose_display_title(None, None, Some("")), None);
+}
+
+#[test]
+fn all_absent_yields_none() {
+    assert_eq!(compose_display_title(None, None, None), None);
+}
+
+#[test]
+fn all_blank_yields_none() {
+    assert_eq!(
+        compose_display_title(Some(" "), Some("\t"), Some("\n")),
+        None
+    );
+}
+
+#[test]
+fn winning_tier_is_trimmed() {
+    assert_eq!(
+        compose_display_title(Some("  Padded  "), None, None),
+        Some("Padded".to_string())
+    );
+}

--- a/entity_api/src/coaching_session_goal.rs
+++ b/entity_api/src/coaching_session_goal.rs
@@ -13,7 +13,7 @@ use sea_orm::{
     entity::prelude::*,
     sea_query::OnConflict,
     ActiveValue::{Set, Unchanged},
-    ConnectionTrait, DatabaseConnection, TryIntoModel,
+    ConnectionTrait, DatabaseConnection, QueryOrder, TryIntoModel,
 };
 
 use log::*;
@@ -367,9 +367,13 @@ pub async fn find_goals_grouped_by_session_ids(
         return Ok(HashMap::new());
     }
 
+    // Deterministic order so callers that take "the first goal" (e.g. the
+    // display_title goal tier) get a stable, reproducible result across requests.
     let links_with_goals = Entity::find()
         .filter(Column::CoachingSessionId.is_in(session_ids.iter().copied()))
         .find_also_related(goals::Entity)
+        .order_by_asc(goals::Column::CreatedAt)
+        .order_by_asc(goals::Column::Id)
         .all(db)
         .await?;
 

--- a/entity_api/src/lib.rs
+++ b/entity_api/src/lib.rs
@@ -15,6 +15,7 @@ pub mod actions_user;
 pub mod agreement;
 pub mod coaching_relationship;
 pub mod coaching_session;
+pub mod coaching_session_display_title;
 pub mod coaching_session_goal;
 pub mod coaching_session_series;
 pub mod coaching_session_topic;

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -97,7 +97,7 @@ pub async fn view(
         ("sort_order" = Option<crate::params::sort::SortOrder>, Query, description = "Sort order. Valid values: 'asc' (ascending), 'desc' (descending). Must be provided with sort_by.", example = "desc")
     ),
     responses(
-        (status = 200, description = "Successfully retrieved all Coaching Sessions", body = [coaching_sessions::Model]),
+        (status = 200, description = "Successfully retrieved all Coaching Sessions", body = [domain::coaching_session::SessionWithDisplayTitle]),
         (status = 401, description = "Unauthorized"),
         (status = 405, description = "Method not allowed"),
         (status = 503, description = "Service temporarily unavailable")
@@ -121,7 +121,8 @@ pub async fn index(
     let mut params = params;
     IndexParams::apply_sort_defaults(&mut params.sort_by, &mut params.sort_order, SortField::Date);
 
-    let coaching_sessions = CoachingSessionApi::find_by(app_state.db_conn_ref(), params).await?;
+    let coaching_sessions =
+        CoachingSessionApi::find_by_with_display_title(app_state.db_conn_ref(), params).await?;
 
     debug!("Found Coaching Sessions: {coaching_sessions:?}");
 

--- a/web/src/router.rs
+++ b/web/src/router.rs
@@ -162,6 +162,7 @@ use utoipa_rapidoc::RapiDoc;
                 domain::coaching_relationships::Model,
                 domain::coaching_session::CountByMonth,
                 domain::coaching_session::EnrichedSession,
+                domain::coaching_session::SessionWithDisplayTitle,
                 domain::coaching_session_topics::Model,
                 domain::coaching_session_view::MarkViewed,
                 domain::coaching_sessions::Model,


### PR DESCRIPTION
## Description

Adds a server-composed `display_title` to the two coaching-session **list reads** so every list/preview surface derives one canonical session title without re-running the fallback chain client-side. Composed as `human title → first topic body → first goal title`, `null` when no tier derives text (the server invents no placeholder — that stays a presentation choice for consumers).

This settles the cross-repo `session_title_topics_include` design (frontend asked the title to be authoritative and consistent across surfaces). It is a **read-time projection**: no migration, no new entity, no SSE.

#### GitHub Issue: N/A (coordinated via the cross-repo board; FE epic #412 family)

### Changes
* New sibling module `entity_api/src/coaching_session_display_title.rs` — pure `compose_display_title` (fallback chain, trims, treats empty/whitespace as absent) + lightweight batch loaders. The first-topic tier reuses the canonical topics query (drag-order, v5 move/defer parenting, v6 soft-delete exclusion); the first-goal tier reuses the `include=goal` grouped-goals source. `batch_load_display_titles` is `pub` and consumed by both list paths.
* Enriched `GET /users/{user_id}/coaching_sessions`: `display_title` on `EnrichedSession`, loaded unconditionally (like `viewer_last_viewed_at`), independent of `?include=`.
* Relationship-scoped `GET /coaching_sessions?coaching_relationship_id=`: new `SessionWithDisplayTitle` wrapper (flattened session + `display_title`) via domain `find_by_with_display_title`. Deliberately carries no caller-scoped fields, so it is safe on the shared list.
* utoipa response body + router `schemas()` updated for the new wrapper.
* 8 pure precedence unit tests + 1 end-to-end mock test.

It is additive and intentionally **not** on the single-session `GET /coaching_sessions/{id}` (that read keeps client-side derivation so it doesn't lag optimistic title/topic edits).

### Testing Strategy
* `cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"` — full mock suite green (incl. the new pure + e2e tests). `cargo clippy` + `cargo fmt` clean.
* **Verified live on real Postgres** (relationship `ceff71c6`): both list reads return `display_title` on every row. Title tier wins over topic; goal tier and `null` confirmed. An independent SQL oracle computed the expected tier for all 46 enriched-list sessions and matched the endpoint 46/46. Topic tier + v6 soft-delete exercised by adding a topic to a null session (display_title → topic body on both endpoints) then deleting it (→ null again); probe data cleaned up.

### Concerns
* **Per-request query cost:** each enriched-list read now issues two extra unconditional queries (first topic bodies + grouped goals), mirroring how `viewer_last_viewed_at` added one. Keyed on the same session-id set; acceptable, but noted.
* **Contract sequencing:** this bumps `CoachingSessionsListEndpoint` to v3 for `display_title` only. The previously-promised v3 *date-filter fix* on that endpoint is **separate and still pending** — the "date filter silently ignored" known issue is unchanged here.