### PR TITLE
Decompose find_by_user_with_includes

### DIFF
--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -626,10 +626,9 @@ impl IncludeOptions {
         Ok(())
     }
 }
-/// Query options for finding coaching sessions by user.
-///
-/// Groups filtering, sorting, and include parameters into a single argument
-/// to keep the `find_by_user_with_includes` function signature clean.
+/// Filtering and sorting options for a user's coaching-session query. Excludes
+/// related-data includes, which the enriching wrapper takes as a separate argument
+/// (see [`find_by_user_with_includes`]).
 #[derive(Debug, Default)]
 pub struct SessionQueryOptions {
     /// Filter sessions to only those in this coaching relationship
@@ -648,15 +647,12 @@ pub struct SessionQueryOptions {
     pub sort_column: Option<coaching_sessions::Column>,
     /// Sort direction (ascending or descending)
     pub sort_order: Option<sea_orm::Order>,
-    /// Which related resources to include in the response
-    pub includes: IncludeOptions,
 }
 
 /// Base query for a user's coaching sessions: the optional tz-aware date window,
 /// relationship, and sort filters applied to the sessions where the user is coach
-/// or coachee. Returns plain models; `options.includes` is not consulted here. The
-/// shared base for [`find_by_user`] (no filters) and the enriching
-/// [`find_by_user_with_includes`].
+/// or coachee. Returns plain models (no enrichment). The shared base for
+/// [`find_by_user`] (no filters) and the enriching [`find_by_user_with_includes`].
 async fn find_by_user_filtered(
     db: &impl ConnectionTrait,
     user_id: Id,
@@ -727,8 +723,8 @@ pub async fn find_by_user_with_includes(
     db: &impl ConnectionTrait,
     user_id: Id,
     options: SessionQueryOptions,
+    includes: IncludeOptions,
 ) -> Result<Vec<EnrichedSession>, Error> {
-    let includes = options.includes;
     includes.validate()?;
 
     let sessions = find_by_user_filtered(db, user_id, options).await?;
@@ -1426,8 +1422,13 @@ mod tests {
             .append_query_results::<entity::coaching_session_views::Model, Vec<_>, _>(vec![vec![]])
             .into_connection();
 
-        let results =
-            find_by_user_with_includes(&db, user_id, SessionQueryOptions::default()).await?;
+        let results = find_by_user_with_includes(
+            &db,
+            user_id,
+            SessionQueryOptions::default(),
+            IncludeOptions::default(),
+        )
+        .await?;
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].session.id, session_id);
@@ -1480,8 +1481,13 @@ mod tests {
             .append_query_results(vec![vec![view.clone()]])
             .into_connection();
 
-        let results =
-            find_by_user_with_includes(&db, user_id, SessionQueryOptions::default()).await?;
+        let results = find_by_user_with_includes(
+            &db,
+            user_id,
+            SessionQueryOptions::default(),
+            IncludeOptions::default(),
+        )
+        .await?;
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].viewer_last_viewed_at, Some(viewed_at));
@@ -1492,8 +1498,13 @@ mod tests {
             .append_query_results::<coaching_session_views::Model, Vec<_>, _>(vec![vec![]])
             .into_connection();
 
-        let results_empty =
-            find_by_user_with_includes(&db_empty, user_id, SessionQueryOptions::default()).await?;
+        let results_empty = find_by_user_with_includes(
+            &db_empty,
+            user_id,
+            SessionQueryOptions::default(),
+            IncludeOptions::default(),
+        )
+        .await?;
 
         assert_eq!(results_empty.len(), 1);
         assert!(results_empty[0].viewer_last_viewed_at.is_none());
@@ -1537,6 +1548,7 @@ mod tests {
                 to_date: Some(to_date),
                 ..Default::default()
             },
+            IncludeOptions::default(),
         )
         .await?;
 
@@ -1572,6 +1584,7 @@ mod tests {
                 tz: Some("America/Los_Angeles".to_string()),
                 ..Default::default()
             },
+            IncludeOptions::default(),
         )
         .await?;
 
@@ -1620,6 +1633,7 @@ mod tests {
                 tz: None,
                 ..Default::default()
             },
+            IncludeOptions::default(),
         )
         .await?;
 
@@ -1661,6 +1675,7 @@ mod tests {
                 tz: Some("Europe/Berlin".to_string()),
                 ..Default::default()
             },
+            IncludeOptions::default(),
         )
         .await?;
 
@@ -1706,6 +1721,7 @@ mod tests {
                 tz: Some("Europe/Berlin".to_string()),
                 ..Default::default()
             },
+            IncludeOptions::default(),
         )
         .await?;
 

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -402,18 +402,10 @@ pub async fn find_meeting_url_by_relationship_and_provider(
         .and_then(|session| session.meeting_url))
 }
 
+/// All of a user's coaching sessions (coach or coachee), unfiltered and unsorted.
+/// Thin convenience over [`find_by_user_filtered`] with default options.
 pub async fn find_by_user(db: &impl ConnectionTrait, user_id: Id) -> Result<Vec<Model>, Error> {
-    let sessions = Entity::find()
-        .join(JoinType::InnerJoin, Relation::CoachingRelationships.def())
-        .filter(
-            coaching_relationships::Column::CoachId
-                .eq(user_id)
-                .or(coaching_relationships::Column::CoacheeId.eq(user_id)),
-        )
-        .all(db)
-        .await?;
-
-    Ok(sessions)
+    find_by_user_filtered(db, user_id, SessionQueryOptions::default()).await
 }
 
 /// One row of the monthly count aggregation for the user's coaching sessions.
@@ -660,15 +652,16 @@ pub struct SessionQueryOptions {
     pub includes: IncludeOptions,
 }
 
-/// Find sessions by user with optional date filtering, sorting, and related data includes
-pub async fn find_by_user_with_includes(
+/// Base query for a user's coaching sessions: the optional tz-aware date window,
+/// relationship, and sort filters applied to the sessions where the user is coach
+/// or coachee. Returns plain models; `options.includes` is not consulted here. The
+/// shared base for [`find_by_user`] (no filters) and the enriching
+/// [`find_by_user_with_includes`].
+async fn find_by_user_filtered(
     db: &impl ConnectionTrait,
     user_id: Id,
     options: SessionQueryOptions,
-) -> Result<Vec<EnrichedSession>, Error> {
-    // Validate include options
-    options.includes.validate()?;
-
+) -> Result<Vec<Model>, Error> {
     // Build the optional date-bound filters up-front so the query chain can
     // stay a single fluent `apply_if` pipeline. When `tz` is supplied, each
     // bound is wrapped in an `AT TIME ZONE` shift, mirroring the expression
@@ -723,8 +716,22 @@ pub async fn find_by_user_with_includes(
             |q: Select<Entity>, (col, ord)| q.order_by(col, ord),
         );
 
-    // Execute query to load base sessions
-    let sessions = query.all(db).await?;
+    Ok(query.all(db).await?)
+}
+
+/// Find a user's sessions, then enrich with view markers and any requested related
+/// data (relationship, organization, goals, agreements, topics). Filtering and
+/// sorting are delegated to [`find_by_user_filtered`]; this wrapper layers
+/// enrichment on top.
+pub async fn find_by_user_with_includes(
+    db: &impl ConnectionTrait,
+    user_id: Id,
+    options: SessionQueryOptions,
+) -> Result<Vec<EnrichedSession>, Error> {
+    let includes = options.includes;
+    includes.validate()?;
+
+    let sessions = find_by_user_filtered(db, user_id, options).await?;
 
     // Load the caller's view markers unconditionally so `viewer_last_viewed_at`
     // is present on every response (null when never viewed), not gated by an
@@ -734,10 +741,7 @@ pub async fn find_by_user_with_includes(
     let views = batch_load_views(db, &session_ids, user_id).await?;
 
     // Early return if no includes requested
-    if !options.includes.needs_relationships()
-        && !options.includes.goal
-        && !options.includes.agreements
-        && !options.includes.topics
+    if !includes.needs_relationships() && !includes.goal && !includes.agreements && !includes.topics
     {
         return Ok(sessions
             .into_iter()
@@ -751,12 +755,12 @@ pub async fn find_by_user_with_includes(
     }
 
     // Load all related data in efficient batches
-    let related_data = load_related_data(db, &sessions, options.includes).await?;
+    let related_data = load_related_data(db, &sessions, includes).await?;
 
     // Assemble enriched sessions
     Ok(sessions
         .into_iter()
-        .map(|session| assemble_enriched_session(session, &related_data, options.includes, &views))
+        .map(|session| assemble_enriched_session(session, &related_data, includes, &views))
         .collect())
 }
 

--- a/entity_api/src/coaching_session.rs
+++ b/entity_api/src/coaching_session.rs
@@ -733,31 +733,15 @@ pub async fn find_by_user_with_includes(
 
     let sessions = find_by_user_filtered(db, user_id, options).await?;
 
-    // Load the caller's view markers unconditionally so `viewer_last_viewed_at`
-    // is present on every response (null when never viewed), not gated by an
-    // include. The marker reflects the path user (`user_id`), who is the viewer
-    // for all first-party reads of this list.
+    // View markers load unconditionally so `viewer_last_viewed_at` is present on
+    // every response (null when never viewed); the path user is the viewer.
     let session_ids: Vec<Id> = sessions.iter().map(|s| s.id).collect();
     let views = batch_load_views(db, &session_ids, user_id).await?;
 
-    // Early return if no includes requested
-    if !includes.needs_relationships() && !includes.goal && !includes.agreements && !includes.topics
-    {
-        return Ok(sessions
-            .into_iter()
-            .map(|session| {
-                let marker = views.get(&session.id).copied();
-                let mut enriched = EnrichedSession::from_session(session);
-                enriched.viewer_last_viewed_at = marker;
-                enriched
-            })
-            .collect());
-    }
-
-    // Load all related data in efficient batches
+    // `load_related_data` runs no queries for an unset include, so one assembly
+    // pass covers both the bare and fully-included cases.
     let related_data = load_related_data(db, &sessions, includes).await?;
 
-    // Assemble enriched sessions
     Ok(sessions
         .into_iter()
         .map(|session| assemble_enriched_session(session, &related_data, includes, &views))
@@ -1047,23 +1031,6 @@ fn assemble_enriched_session(
         agreement,
         viewer_last_viewed_at,
         topics,
-    }
-}
-
-impl EnrichedSession {
-    /// Create an enriched session from just the base session model
-    fn from_session(session: Model) -> Self {
-        Self {
-            session,
-            relationship: None,
-            coach: None,
-            coachee: None,
-            organization: None,
-            goals: None,
-            agreement: None,
-            viewer_last_viewed_at: None,
-            topics: None,
-        }
     }
 }
 

--- a/web/src/controller/user/coaching_session_controller.rs
+++ b/web/src/controller/user/coaching_session_controller.rs
@@ -102,8 +102,8 @@ pub async fn index(
             tz: tz_name,
             sort_column,
             sort_order,
-            includes,
         },
+        includes,
     )
     .await?;
 


### PR DESCRIPTION
## Description

`find_by_user_with_includes` had grown to ~95 lines that interleaved two concerns: building the base query (tz-aware date window, relationship narrowing, sort) and enriching the results (view markers + requested related data). This splits the base query out so the public function reads as a short pipeline, removes a redundant branch, and aligns the input types with the split.

Pure readability/structure refactor — no behavior change, no wire change.

#### GitHub Issue: N/A (follow-up cleanup spun off from the display_title PR #359)

### Changes
* Extract `find_by_user_filtered(db, user_id, options) -> Vec<Model>` — the tz/date/relationship/sort base query — out of `find_by_user_with_includes`.
* Collapse the pre-existing unfiltered `find_by_user(db, user_id)` into a thin delegate (`find_by_user_filtered` with `SessionQueryOptions::default()`), removing a duplicated join + coach-or-coachee filter. Its public signature is unchanged.
* Drop the "no includes" early-return: `load_related_data` runs no queries for an unset include and `assemble_enriched_session` already yields the all-`None` shape, so the two paths were equivalent. The function is now a single branchless map pipeline; the now-unused `EnrichedSession::from_session` is removed.
* Pull `includes` out of `SessionQueryOptions` into a separate `IncludeOptions` parameter on `find_by_user_with_includes`. The struct now holds only filter/sort, so the base query ignores nothing — the data shape mirrors the function split. The controller already built `includes` as a standalone value, so it just passes it as a separate argument.

### Testing Strategy
* Behavior-preserving throughout: `find_by_user` with default options applies no filters/sort; the dropped branch was provably equivalent (no-includes mock tests pass unchanged).
* `cargo test -p entity_api -p domain -p web --features "domain/mock,web/mock"` — full mock suite green. `cargo clippy` clean, `cargo fmt` applied.

### Concerns
* Branched off `main`, independent of PR #359 (display_title). The two touch the same function, so whichever merges second will need a small rebase.