### PR TITLE
Live title sync via coaching_session_title_updated SSE

### DIFF
--- a/domain/src/coaching_session.rs
+++ b/domain/src/coaching_session.rs
@@ -326,6 +326,45 @@ pub async fn update(
     )
 }
 
+/// Best-effort SSE notify that a session's own row changed (a title edit). The DB write is the
+/// contract; a failed participant lookup must NOT fail the mutation, so log and continue
+/// (mirrors the topics notify helper).
+async fn publish_coaching_session_title_updated(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    coaching_session_id: Id,
+) {
+    let notify_user_ids = match coaching_session::find_participant_ids(db, coaching_session_id)
+        .await
+    {
+        Ok(ids) => ids,
+        Err(e) => {
+            error!("CoachingSessionTitleUpdated: failed to resolve participants for session {coaching_session_id}: {e:?}");
+            return;
+        }
+    };
+    event_publisher
+        .publish(DomainEvent::CoachingSessionTitleUpdated {
+            coaching_session_id,
+            notify_user_ids,
+        })
+        .await;
+}
+
+/// Updates only the session title (the participant-gated title endpoint) and emits a coarse
+/// `CoachingSessionTitleUpdated` to both participants. Scheduling-field edits go through
+/// [`update`], which intentionally emits no event.
+pub async fn update_title(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    id: Id,
+    params: impl mutate::IntoUpdateMap + std::fmt::Debug,
+) -> Result<Model, Error> {
+    let coaching_session = update(db, id, params).await?;
+    publish_coaching_session_title_updated(db, event_publisher, coaching_session.id).await;
+    Ok(coaching_session)
+}
+
 pub async fn delete(db: &DatabaseConnection, config: &Config, id: Id) -> Result<(), Error> {
     let coaching_session = find_by_id(db, id).await?;
     debug!(
@@ -533,6 +572,63 @@ mod tests {
             "--tiptap-auth-key=test-auth-key",
             &format!("--tiptap-url={tiptap_url}"),
         ])
+    }
+
+    /// Editing a title via [`update_title`] publishes exactly one coarse
+    /// `CoachingSessionTitleUpdated`, scoped to the relationship's coach + coachee.
+    #[tokio::test]
+    async fn update_title_publishes_title_updated_event() -> Result<(), Error> {
+        // Test-only IntoUpdateMap wrapper (the web layer's TitleUpdateParams implements this).
+        #[derive(Debug)]
+        struct TestParams(mutate::UpdateMap);
+        impl mutate::IntoUpdateMap for TestParams {
+            fn into_update_map(self) -> mutate::UpdateMap {
+                self.0
+            }
+        }
+
+        let org = test_organization();
+        let coach_id = Id::new_v4();
+        let relationship = test_coaching_relationship(coach_id, org.id);
+        let session = test_session(relationship.id, None);
+        let updated = coaching_sessions::Model {
+            title: Some("Renamed".to_string()),
+            ..session.clone()
+        };
+
+        let (publisher, events) = recording_publisher();
+
+        // update: find_by_id → UPDATE ... RETURNING; then the participant lookup (find_also_related).
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![session.clone()]])
+            .append_query_results(vec![vec![updated.clone()]])
+            .append_query_results(vec![vec![(session.clone(), relationship.clone())]])
+            .into_connection();
+
+        let mut map = mutate::UpdateMap::new();
+        map.insert(
+            "title".into(),
+            Some(sea_orm::Value::String(Some(Box::new("Renamed".into())))),
+        );
+
+        let result = update_title(&db, &publisher, session.id, TestParams(map)).await;
+        assert!(result.is_ok());
+
+        let recorded = events.lock().unwrap();
+        assert_eq!(recorded.len(), 1, "expected exactly one published event");
+        match &recorded[0] {
+            DomainEvent::CoachingSessionTitleUpdated {
+                coaching_session_id,
+                notify_user_ids,
+            } => {
+                assert_eq!(*coaching_session_id, session.id);
+                assert_eq!(notify_user_ids.len(), 2, "coach + coachee");
+                assert!(notify_user_ids.contains(&relationship.coach_id));
+                assert!(notify_user_ids.contains(&relationship.coachee_id));
+            }
+            other => panic!("expected CoachingSessionTitleUpdated, got {other:?}"),
+        }
+        Ok(())
     }
 
     /// Creating a session links the relationship's in-progress goals and

--- a/events/src/lib.rs
+++ b/events/src/lib.rs
@@ -110,6 +110,14 @@ pub enum DomainEvent {
         /// User IDs to receive SSE notifications (coach + coachee from the relationship).
         notify_user_ids: Vec<Id>,
     },
+    /// Emitted when a coaching session's title is set/changed via the title endpoint.
+    /// Coarse: carries no entity — participants refetch the session. Triggers SSE to coach + coachee.
+    CoachingSessionTitleUpdated {
+        /// The coaching session whose title changed.
+        coaching_session_id: Id,
+        /// User IDs to receive SSE notifications (coach + coachee from the relationship).
+        notify_user_ids: Vec<Id>,
+    },
     /// Emitted when a transcription status changes (created, completed, or failed).
     /// Triggers SSE notifications so participants see the current transcription state without polling.
     TranscriptionUpdated {

--- a/sse/src/domain_event_handler.rs
+++ b/sse/src/domain_event_handler.rs
@@ -134,6 +134,17 @@ impl EventHandler for SseDomainEventHandler {
                 self.send_to_users(sse_event, notify_user_ids);
             }
 
+            DomainEvent::CoachingSessionTitleUpdated {
+                coaching_session_id,
+                notify_user_ids,
+            } => {
+                let sse_event = SseEvent::CoachingSessionTitleUpdated {
+                    coaching_session_id: coaching_session_id.to_string(),
+                };
+
+                self.send_to_users(sse_event, notify_user_ids);
+            }
+
             DomainEvent::TranscriptionUpdated {
                 coaching_session_id,
                 notify_user_ids,

--- a/sse/src/message.rs
+++ b/sse/src/message.rs
@@ -86,6 +86,10 @@ pub enum Event {
     #[serde(rename = "topics_changed")]
     TopicsChanged { coaching_session_id: String },
 
+    // Coaching session entity events (session-scoped, coarse: refetch on receipt)
+    #[serde(rename = "coaching_session_title_updated")]
+    CoachingSessionTitleUpdated { coaching_session_id: String },
+
     // Transcription events (session-scoped)
     #[serde(rename = "transcription_updated")]
     TranscriptionUpdated { coaching_session_id: String },
@@ -108,6 +112,7 @@ impl EventType for Event {
             Event::ForceLogout { .. } => "force_logout",
             Event::MeetingRecordingUpdated { .. } => "meeting_recording_updated",
             Event::TopicsChanged { .. } => "topics_changed",
+            Event::CoachingSessionTitleUpdated { .. } => "coaching_session_title_updated",
             Event::TranscriptionUpdated { .. } => "transcription_updated",
         }
     }
@@ -125,4 +130,26 @@ pub enum MessageScope {
     User { user_id: String },
     /// Send to all connected users
     Broadcast,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pins the coarse session-title event wire shape consumers depend on.
+    #[test]
+    fn coaching_session_title_updated_serializes_to_expected_wire_shape() {
+        let event = Event::CoachingSessionTitleUpdated {
+            coaching_session_id: "abc-123".to_string(),
+        };
+        let json = serde_json::to_value(&event).unwrap();
+        assert_eq!(
+            json,
+            serde_json::json!({
+                "type": "coaching_session_title_updated",
+                "data": { "coaching_session_id": "abc-123" }
+            })
+        );
+        assert_eq!(event.event_type(), "coaching_session_title_updated");
+    }
 }

--- a/testing-tools/src/api_client.rs
+++ b/testing-tools/src/api_client.rs
@@ -365,6 +365,37 @@ impl ApiClient {
         Ok(())
     }
 
+    /// PATCH the session title (either participant). Makes the backend publish a coarse
+    /// `coaching_session_title_updated` SSE event to BOTH relationship participants.
+    pub async fn update_session_title(
+        &self,
+        session_cookie: &str,
+        coaching_session_id: &str,
+        title: &str,
+    ) -> Result<Value> {
+        let url = format!(
+            "{}/coaching_sessions/{}/title",
+            self.base_url, coaching_session_id
+        );
+        let response = self
+            .client
+            .patch(&url)
+            .header("Cookie", format!("id={}", session_cookie))
+            .header("x-version", "1.0.0-beta1")
+            .json(&json!({ "title": title }))
+            .send()
+            .await
+            .context("Failed to update session title")?;
+        if !response.status().is_success() {
+            anyhow::bail!("Failed to update session title: {}", response.status());
+        }
+        let api_response: Value = response.json().await.context("Failed to parse response")?;
+        api_response["data"]
+            .as_object()
+            .context("No data object in response")
+            .map(|obj| Value::Object(obj.clone()))
+    }
+
     // --- Coaching session Topics ---
     // Every mutation below makes the backend publish a single coarse `topics_changed`
     // SSE event (data: { coaching_session_id }) to BOTH relationship participants.

--- a/testing-tools/src/bin/sse-test-client.rs
+++ b/testing-tools/src/bin/sse-test-client.rs
@@ -55,6 +55,8 @@ enum ScenarioChoice {
     TopicStatus,
     /// Test topic delete -> topics_changed (requires coaching session)
     TopicDelete,
+    /// Test session title edit -> coaching_session_title_updated (requires coaching session)
+    TitleUpdate,
     /// Run all tests including those requiring coaching data
     All,
 }
@@ -292,6 +294,22 @@ async fn main() -> Result<()> {
                 .await?,
             );
         }
+        ScenarioChoice::TitleUpdate => {
+            let env = test_env
+                .as_ref()
+                .expect("Test environment required for TitleUpdate");
+            results.push(
+                scenarios::test_title_update(
+                    &user1,
+                    &user2,
+                    env,
+                    &api_client,
+                    &mut sse1,
+                    &mut sse2,
+                )
+                .await?,
+            );
+        }
         ScenarioChoice::All => {
             results.push(scenarios::test_connection(&user1, &user2, &mut sse1, &mut sse2).await?);
             results.push(
@@ -380,6 +398,17 @@ async fn main() -> Result<()> {
             );
             results.push(
                 scenarios::test_topic_delete(
+                    &user1,
+                    &user2,
+                    env,
+                    &api_client,
+                    &mut sse1,
+                    &mut sse2,
+                )
+                .await?,
+            );
+            results.push(
+                scenarios::test_title_update(
                     &user1,
                     &user2,
                     env,

--- a/testing-tools/src/scenarios.rs
+++ b/testing-tools/src/scenarios.rs
@@ -555,3 +555,55 @@ pub async fn test_topic_delete(
 
     Ok(expect_topics_changed(sse2, &test_env.session_id, "topic_delete", start).await)
 }
+
+// --- Coaching session title (coarse, session-scoped) ---
+
+pub async fn test_title_update(
+    user1: &AuthenticatedUser,
+    _user2: &AuthenticatedUser,
+    test_env: &TestEnvironment,
+    api_client: &ApiClient,
+    _sse1: &mut Connection,
+    sse2: &mut Connection,
+) -> Result<TestResult> {
+    let start = Instant::now();
+    println!("\n{}", "=== TEST: Title Update ===".bright_cyan().bold());
+
+    println!("{} User 1 updating session title...", "→".blue());
+    api_client
+        .update_session_title(
+            &user1.session_cookie,
+            &test_env.session_id,
+            "Renamed by SSE test tool",
+        )
+        .await?;
+
+    println!(
+        "{} Waiting for User 2 to receive coaching_session_title_updated event...",
+        "→".blue()
+    );
+    match sse2
+        .wait_for_event("coaching_session_title_updated", Duration::from_secs(5))
+        .await
+    {
+        Ok(event) => {
+            print_event(&sse2.user_label, &event);
+            let got = event.data["data"]["coaching_session_id"]
+                .as_str()
+                .unwrap_or_default();
+            let passed = got == test_env.session_id;
+            Ok(TestResult {
+                scenario: "title_update".to_string(),
+                passed,
+                message: (!passed).then(|| format!("Session ID mismatch: got {}", got)),
+                duration: start.elapsed(),
+            })
+        }
+        Err(e) => Ok(TestResult {
+            scenario: "title_update".to_string(),
+            passed: false,
+            message: Some(format!("Timeout: {}", e)),
+            duration: start.elapsed(),
+        }),
+    }
+}

--- a/web/src/controller/coaching_session_controller.rs
+++ b/web/src/controller/coaching_session_controller.rs
@@ -246,8 +246,13 @@ pub async fn update_title(
     State(app_state): State<AppState>,
     Json(params): Json<TitleUpdateParams>,
 ) -> Result<impl IntoResponse, Error> {
-    let updated =
-        CoachingSessionApi::update(app_state.db_conn_ref(), coaching_session.id, params).await?;
+    let updated = CoachingSessionApi::update_title(
+        app_state.db_conn_ref(),
+        app_state.event_publisher.as_ref(),
+        coaching_session.id,
+        params,
+    )
+    .await?;
     Ok(Json(ApiResponse::new(StatusCode::OK.into(), updated)))
 }
 


### PR DESCRIPTION
## What
Emits a coarse, session-scoped SSE event `coaching_session_title_updated` when a session title is set/changed via `PATCH /coaching_sessions/{id}/title`, so the other participant's open view updates live instead of waiting for a manual refetch. Closes the "No SSE" gap noted in `CoachingSessionTitleField` v2.

## How
Standard 4-hop event pipe + a new title-specific domain wrapper:
- `events`: `DomainEvent::CoachingSessionTitleUpdated { coaching_session_id, notify_user_ids }`
- `sse`: `Event::CoachingSessionTitleUpdated` -> wire type `coaching_session_title_updated`; handler arm
- `domain`: new `coaching_session::update_title` wrapper emits after the write (best-effort participant lookup, log-and-continue). The shared `update` is left untouched, so coach-only scheduling edits (date/duration/meeting_url/provider) stay event-free by design.
- `web`: `update_title` handler routes through the new domain fn with the event publisher.

Wire: `{"type":"coaching_session_title_updated","data":{"coaching_session_id":"<uuid>"}}` (coarse — refetch the session on receipt, like `topics_changed`).

## Tests
Domain emit test (exactly one event, scoped to coach+coachee) + wire-shape serialization pin. Full mock-gated suite, clippy, fmt all green.