### PR TITLE
Emit agreement_created/updated/deleted SSE (session-scoped)

### DIFF
--- a/domain/src/agreement.rs
+++ b/domain/src/agreement.rs
@@ -7,7 +7,6 @@ use entity_api::query::{IntoQueryFilterMap, QuerySort};
 use entity_api::{agreements, query};
 use log::*;
 use sea_orm::DatabaseConnection;
-use serde_json::Value;
 
 // Mutations (create, update, delete_by_id) are wrapped below to emit SSE; reads re-export directly.
 pub use entity_api::agreement::find_by_id;
@@ -47,7 +46,13 @@ async fn publish_agreement_changed(
     let Some(notify_user_ids) = agreement_notify_user_ids(db, coaching_session_id).await else {
         return;
     };
-    let payload = serde_json::to_value(agreement).unwrap_or(Value::Null);
+    let payload = match serde_json::to_value(agreement) {
+        Ok(payload) => payload,
+        Err(e) => {
+            error!("agreement SSE: failed to serialize agreement for session {coaching_session_id}: {e:?}");
+            return;
+        }
+    };
     let event = if created {
         DomainEvent::AgreementCreated {
             coaching_session_id,

--- a/domain/src/agreement.rs
+++ b/domain/src/agreement.rs
@@ -111,6 +111,7 @@ pub async fn delete_by_id(
 }
 
 #[cfg(test)]
+#[cfg(feature = "mock")]
 mod tests {
     use super::*;
     use crate::test_support::recording_publisher;

--- a/domain/src/agreement.rs
+++ b/domain/src/agreement.rs
@@ -1,10 +1,16 @@
 use crate::agreements::Model;
+use crate::coaching_session;
 use crate::error::Error;
+use crate::events::{DomainEvent, EventPublisher};
+use crate::Id;
 use entity_api::query::{IntoQueryFilterMap, QuerySort};
 use entity_api::{agreements, query};
+use log::*;
 use sea_orm::DatabaseConnection;
+use serde_json::Value;
 
-pub use entity_api::agreement::{create, delete_by_id, find_by_id, update};
+// Mutations (create, update, delete_by_id) are wrapped below to emit SSE; reads re-export directly.
+pub use entity_api::agreement::find_by_id;
 
 pub async fn find_by<P>(db: &DatabaseConnection, params: P) -> Result<Vec<Model>, Error>
 where
@@ -13,4 +19,234 @@ where
     let agreements =
         query::find_by::<agreements::Entity, agreements::Column, P>(db, params).await?;
     Ok(agreements)
+}
+
+/// Best-effort SSE notify set for an agreement: the participants of the agreement's session. The
+/// DB write is the contract; a failed lookup must NOT fail the mutation, so log and return None.
+async fn agreement_notify_user_ids(
+    db: &DatabaseConnection,
+    coaching_session_id: Id,
+) -> Option<Vec<Id>> {
+    match coaching_session::find_participant_ids(db, coaching_session_id).await {
+        Ok(ids) => Some(ids),
+        Err(e) => {
+            error!("agreement SSE: failed to resolve participants for session {coaching_session_id}: {e:?}");
+            None
+        }
+    }
+}
+
+/// Publishes `AgreementCreated` or `AgreementUpdated` carrying the full agreement entity.
+async fn publish_agreement_changed(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    agreement: &Model,
+    created: bool,
+) {
+    let coaching_session_id = agreement.coaching_session_id;
+    let Some(notify_user_ids) = agreement_notify_user_ids(db, coaching_session_id).await else {
+        return;
+    };
+    let payload = serde_json::to_value(agreement).unwrap_or(Value::Null);
+    let event = if created {
+        DomainEvent::AgreementCreated {
+            coaching_session_id,
+            agreement: payload,
+            notify_user_ids,
+        }
+    } else {
+        DomainEvent::AgreementUpdated {
+            coaching_session_id,
+            agreement: payload,
+            notify_user_ids,
+        }
+    };
+    event_publisher.publish(event).await;
+}
+
+/// Creates an agreement and publishes `AgreementCreated` to both session participants.
+pub async fn create(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    agreement_model: Model,
+    user_id: Id,
+) -> Result<Model, Error> {
+    let agreement = entity_api::agreement::create(db, agreement_model, user_id).await?;
+    publish_agreement_changed(db, event_publisher, &agreement, true).await;
+    Ok(agreement)
+}
+
+/// Updates an agreement and publishes `AgreementUpdated`.
+pub async fn update(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    id: Id,
+    model: Model,
+) -> Result<Model, Error> {
+    let agreement = entity_api::agreement::update(db, id, model).await?;
+    publish_agreement_changed(db, event_publisher, &agreement, false).await;
+    Ok(agreement)
+}
+
+/// Deletes an agreement and publishes `AgreementDeleted`. Captures the session id before deletion.
+pub async fn delete_by_id(
+    db: &DatabaseConnection,
+    event_publisher: &EventPublisher,
+    id: Id,
+) -> Result<(), Error> {
+    let coaching_session_id = entity_api::agreement::find_by_id(db, id)
+        .await?
+        .coaching_session_id;
+    entity_api::agreement::delete_by_id(db, id).await?;
+    if let Some(notify_user_ids) = agreement_notify_user_ids(db, coaching_session_id).await {
+        event_publisher
+            .publish(DomainEvent::AgreementDeleted {
+                coaching_session_id,
+                agreement_id: id,
+                notify_user_ids,
+            })
+            .await;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_support::recording_publisher;
+    use crate::{coaching_relationships, coaching_sessions};
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+
+    fn agreement_model(coaching_session_id: Id) -> Model {
+        let now = chrono::Utc::now().fixed_offset();
+        Model {
+            id: Id::new_v4(),
+            coaching_session_id,
+            body: Some("We agree to X".to_string()),
+            user_id: Id::new_v4(),
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    fn session_with_relationship(
+        coaching_session_id: Id,
+    ) -> (coaching_sessions::Model, coaching_relationships::Model) {
+        let now = chrono::Utc::now().fixed_offset();
+        let relationship_id = Id::new_v4();
+        let session = coaching_sessions::Model {
+            id: coaching_session_id,
+            coaching_relationship_id: relationship_id,
+            coaching_session_series_id: None,
+            collab_document_name: None,
+            date: now.naive_utc(),
+            duration_minutes: 60,
+            title: None,
+            meeting_url: None,
+            provider: None,
+            created_at: now,
+            updated_at: now,
+            hydrated_at: None,
+        };
+        let relationship = coaching_relationships::Model {
+            id: relationship_id,
+            organization_id: Id::new_v4(),
+            coach_id: Id::new_v4(),
+            coachee_id: Id::new_v4(),
+            slug: "test-slug".to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+        (session, relationship)
+    }
+
+    #[tokio::test]
+    async fn create_publishes_agreement_created() {
+        let session_id = Id::new_v4();
+        let agreement = agreement_model(session_id);
+        let (publisher, events) = recording_publisher();
+
+        // create (INSERT RETURNING) → participant lookup.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![agreement.clone()]])
+            .append_query_results(vec![vec![session_with_relationship(session_id)]])
+            .into_connection();
+
+        let result = create(&db, &publisher, agreement.clone(), agreement.user_id).await;
+
+        assert!(result.is_ok());
+        let recorded = events.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        match &recorded[0] {
+            DomainEvent::AgreementCreated {
+                coaching_session_id,
+                notify_user_ids,
+                ..
+            } => {
+                assert_eq!(*coaching_session_id, session_id);
+                assert_eq!(notify_user_ids.len(), 2, "coach + coachee");
+            }
+            other => panic!("expected AgreementCreated, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn update_publishes_agreement_updated() {
+        let session_id = Id::new_v4();
+        let agreement = agreement_model(session_id);
+        let (publisher, events) = recording_publisher();
+
+        // update: find_by_id → UPDATE RETURNING → participant lookup.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![agreement.clone()]])
+            .append_query_results(vec![vec![agreement.clone()]])
+            .append_query_results(vec![vec![session_with_relationship(session_id)]])
+            .into_connection();
+
+        let result = update(&db, &publisher, agreement.id, agreement.clone()).await;
+
+        assert!(result.is_ok());
+        let recorded = events.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        assert!(matches!(
+            &recorded[0],
+            DomainEvent::AgreementUpdated { coaching_session_id, .. } if *coaching_session_id == session_id
+        ));
+    }
+
+    #[tokio::test]
+    async fn delete_by_id_publishes_agreement_deleted() {
+        let session_id = Id::new_v4();
+        let agreement = agreement_model(session_id);
+        let (publisher, events) = recording_publisher();
+
+        // delete: wrapper find_by_id → entity delete_by_id (find_by_id + DELETE) → participant lookup.
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results(vec![vec![agreement.clone()]])
+            .append_query_results(vec![vec![agreement.clone()]])
+            .append_exec_results(vec![MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .append_query_results(vec![vec![session_with_relationship(session_id)]])
+            .into_connection();
+
+        let result = delete_by_id(&db, &publisher, agreement.id).await;
+
+        assert!(result.is_ok());
+        let recorded = events.lock().unwrap();
+        assert_eq!(recorded.len(), 1);
+        match &recorded[0] {
+            DomainEvent::AgreementDeleted {
+                coaching_session_id,
+                agreement_id,
+                notify_user_ids,
+            } => {
+                assert_eq!(*coaching_session_id, session_id);
+                assert_eq!(*agreement_id, agreement.id);
+                assert_eq!(notify_user_ids.len(), 2);
+            }
+            other => panic!("expected AgreementDeleted, got {other:?}"),
+        }
+    }
 }

--- a/events/src/lib.rs
+++ b/events/src/lib.rs
@@ -94,6 +94,34 @@ pub enum DomainEvent {
         /// User IDs to receive SSE notifications (coach + coachee from relationship).
         notify_user_ids: Vec<Id>,
     },
+    /// Emitted when an agreement is created within a coaching session.
+    /// Carries the full serialized agreement entity for optimistic UI updates.
+    AgreementCreated {
+        /// The coaching session the agreement belongs to.
+        coaching_session_id: Id,
+        /// Complete serialized agreement entity for the frontend cache.
+        agreement: Value,
+        /// User IDs to receive SSE notifications (coach + coachee from the session's relationship).
+        notify_user_ids: Vec<Id>,
+    },
+    /// Emitted when an agreement is modified.
+    AgreementUpdated {
+        /// The coaching session the agreement belongs to.
+        coaching_session_id: Id,
+        /// Complete updated agreement entity for the frontend cache.
+        agreement: Value,
+        /// User IDs to receive SSE notifications (coach + coachee from the session's relationship).
+        notify_user_ids: Vec<Id>,
+    },
+    /// Emitted when an agreement is removed.
+    AgreementDeleted {
+        /// The coaching session the agreement belonged to.
+        coaching_session_id: Id,
+        /// ID of the deleted agreement (full entity not included since it no longer exists).
+        agreement_id: Id,
+        /// User IDs to receive SSE notifications (coach + coachee from the session's relationship).
+        notify_user_ids: Vec<Id>,
+    },
     /// Emitted when a meeting recording status changes (any webhook-driven transition).
     /// Triggers SSE notifications so participants see the current recording state without polling.
     MeetingRecordingUpdated {

--- a/sse/src/domain_event_handler.rs
+++ b/sse/src/domain_event_handler.rs
@@ -112,6 +112,45 @@ impl EventHandler for SseDomainEventHandler {
                 self.send_to_users(sse_event, notify_user_ids);
             }
 
+            DomainEvent::AgreementCreated {
+                coaching_session_id,
+                agreement,
+                notify_user_ids,
+            } => {
+                let sse_event = SseEvent::AgreementCreated {
+                    coaching_session_id: coaching_session_id.to_string(),
+                    agreement: agreement.clone(),
+                };
+
+                self.send_to_users(sse_event, notify_user_ids);
+            }
+
+            DomainEvent::AgreementUpdated {
+                coaching_session_id,
+                agreement,
+                notify_user_ids,
+            } => {
+                let sse_event = SseEvent::AgreementUpdated {
+                    coaching_session_id: coaching_session_id.to_string(),
+                    agreement: agreement.clone(),
+                };
+
+                self.send_to_users(sse_event, notify_user_ids);
+            }
+
+            DomainEvent::AgreementDeleted {
+                coaching_session_id,
+                agreement_id,
+                notify_user_ids,
+            } => {
+                let sse_event = SseEvent::AgreementDeleted {
+                    coaching_session_id: coaching_session_id.to_string(),
+                    agreement_id: agreement_id.to_string(),
+                };
+
+                self.send_to_users(sse_event, notify_user_ids);
+            }
+
             DomainEvent::MeetingRecordingUpdated {
                 coaching_session_id,
                 notify_user_ids,

--- a/sse/src/message.rs
+++ b/sse/src/message.rs
@@ -26,20 +26,20 @@ pub enum Event {
         action_id: String,
     },
 
-    // Agreements (relationship-scoped)
+    // Agreements (session-scoped)
     #[serde(rename = "agreement_created")]
     AgreementCreated {
-        coaching_relationship_id: String,
+        coaching_session_id: String,
         agreement: Value,
     },
     #[serde(rename = "agreement_updated")]
     AgreementUpdated {
-        coaching_relationship_id: String,
+        coaching_session_id: String,
         agreement: Value,
     },
     #[serde(rename = "agreement_deleted")]
     AgreementDeleted {
-        coaching_relationship_id: String,
+        coaching_session_id: String,
         agreement_id: String,
     },
 
@@ -125,4 +125,39 @@ pub enum MessageScope {
     User { user_id: String },
     /// Send to all connected users
     Broadcast,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Pins the agreement event wire shapes (entity-in-payload, session-scoped).
+    #[test]
+    fn agreement_events_serialize_to_expected_wire_shape() {
+        let created = Event::AgreementCreated {
+            coaching_session_id: "sess-1".to_string(),
+            agreement: serde_json::json!({ "id": "agr-1", "body": "x" }),
+        };
+        assert_eq!(
+            serde_json::to_value(&created).unwrap(),
+            serde_json::json!({
+                "type": "agreement_created",
+                "data": { "coaching_session_id": "sess-1", "agreement": { "id": "agr-1", "body": "x" } }
+            })
+        );
+
+        let deleted = Event::AgreementDeleted {
+            coaching_session_id: "sess-1".to_string(),
+            agreement_id: "agr-1".to_string(),
+        };
+        assert_eq!(
+            serde_json::to_value(&deleted).unwrap(),
+            serde_json::json!({
+                "type": "agreement_deleted",
+                "data": { "coaching_session_id": "sess-1", "agreement_id": "agr-1" }
+            })
+        );
+        assert_eq!(created.event_type(), "agreement_created");
+        assert_eq!(deleted.event_type(), "agreement_deleted");
+    }
 }

--- a/testing-tools/src/api_client.rs
+++ b/testing-tools/src/api_client.rs
@@ -398,6 +398,7 @@ impl ApiClient {
     pub async fn update_agreement(
         &self,
         session_cookie: &str,
+        coaching_session_id: &str,
         agreement_id: &str,
         body: &str,
     ) -> Result<Value> {
@@ -407,7 +408,7 @@ impl ApiClient {
             .put(&url)
             .header("Cookie", format!("id={}", session_cookie))
             .header("x-version", "1.0.0-beta1")
-            .json(&json!({ "body": body }))
+            .json(&json!({ "coaching_session_id": coaching_session_id, "body": body }))
             .send()
             .await
             .context("Failed to update agreement")?;

--- a/testing-tools/src/api_client.rs
+++ b/testing-tools/src/api_client.rs
@@ -365,6 +365,78 @@ impl ApiClient {
         Ok(())
     }
 
+    // --- Agreements (session-scoped) ---
+    // Each mutation makes the backend publish an `agreement_{created,updated,deleted}` SSE event
+    // (data: { coaching_session_id, agreement | agreement_id }) to BOTH relationship participants.
+
+    pub async fn create_agreement(
+        &self,
+        session_cookie: &str,
+        coaching_session_id: &str,
+        body: &str,
+    ) -> Result<Value> {
+        let url = format!("{}/agreements", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .header("Cookie", format!("id={}", session_cookie))
+            .header("x-version", "1.0.0-beta1")
+            .json(&json!({ "coaching_session_id": coaching_session_id, "body": body }))
+            .send()
+            .await
+            .context("Failed to create agreement")?;
+        if !response.status().is_success() {
+            anyhow::bail!("Failed to create agreement: {}", response.status());
+        }
+        let api_response: Value = response.json().await.context("Failed to parse response")?;
+        api_response["data"]
+            .as_object()
+            .context("No data object in response")
+            .map(|obj| Value::Object(obj.clone()))
+    }
+
+    pub async fn update_agreement(
+        &self,
+        session_cookie: &str,
+        agreement_id: &str,
+        body: &str,
+    ) -> Result<Value> {
+        let url = format!("{}/agreements/{}", self.base_url, agreement_id);
+        let response = self
+            .client
+            .put(&url)
+            .header("Cookie", format!("id={}", session_cookie))
+            .header("x-version", "1.0.0-beta1")
+            .json(&json!({ "body": body }))
+            .send()
+            .await
+            .context("Failed to update agreement")?;
+        if !response.status().is_success() {
+            anyhow::bail!("Failed to update agreement: {}", response.status());
+        }
+        let api_response: Value = response.json().await.context("Failed to parse response")?;
+        api_response["data"]
+            .as_object()
+            .context("No data object in response")
+            .map(|obj| Value::Object(obj.clone()))
+    }
+
+    pub async fn delete_agreement(&self, session_cookie: &str, agreement_id: &str) -> Result<()> {
+        let url = format!("{}/agreements/{}", self.base_url, agreement_id);
+        let response = self
+            .client
+            .delete(&url)
+            .header("Cookie", format!("id={}", session_cookie))
+            .header("x-version", "1.0.0-beta1")
+            .send()
+            .await
+            .context("Failed to delete agreement")?;
+        if !response.status().is_success() {
+            anyhow::bail!("Failed to delete agreement: {}", response.status());
+        }
+        Ok(())
+    }
+
     // --- Coaching session Topics ---
     // Every mutation below makes the backend publish a single coarse `topics_changed`
     // SSE event (data: { coaching_session_id }) to BOTH relationship participants.

--- a/testing-tools/src/bin/sse-test-client.rs
+++ b/testing-tools/src/bin/sse-test-client.rs
@@ -55,6 +55,12 @@ enum ScenarioChoice {
     TopicStatus,
     /// Test topic delete -> topics_changed (requires coaching session)
     TopicDelete,
+    /// Test agreement create -> agreement_created (requires coaching session)
+    AgreementCreate,
+    /// Test agreement update -> agreement_updated (requires coaching session)
+    AgreementUpdate,
+    /// Test agreement delete -> agreement_deleted (requires coaching session)
+    AgreementDelete,
     /// Run all tests including those requiring coaching data
     All,
 }
@@ -292,6 +298,54 @@ async fn main() -> Result<()> {
                 .await?,
             );
         }
+        ScenarioChoice::AgreementCreate => {
+            let env = test_env
+                .as_ref()
+                .expect("Test environment required for AgreementCreate");
+            results.push(
+                scenarios::test_agreement_create(
+                    &user1,
+                    &user2,
+                    env,
+                    &api_client,
+                    &mut sse1,
+                    &mut sse2,
+                )
+                .await?,
+            );
+        }
+        ScenarioChoice::AgreementUpdate => {
+            let env = test_env
+                .as_ref()
+                .expect("Test environment required for AgreementUpdate");
+            results.push(
+                scenarios::test_agreement_update(
+                    &user1,
+                    &user2,
+                    env,
+                    &api_client,
+                    &mut sse1,
+                    &mut sse2,
+                )
+                .await?,
+            );
+        }
+        ScenarioChoice::AgreementDelete => {
+            let env = test_env
+                .as_ref()
+                .expect("Test environment required for AgreementDelete");
+            results.push(
+                scenarios::test_agreement_delete(
+                    &user1,
+                    &user2,
+                    env,
+                    &api_client,
+                    &mut sse1,
+                    &mut sse2,
+                )
+                .await?,
+            );
+        }
         ScenarioChoice::All => {
             results.push(scenarios::test_connection(&user1, &user2, &mut sse1, &mut sse2).await?);
             results.push(
@@ -380,6 +434,39 @@ async fn main() -> Result<()> {
             );
             results.push(
                 scenarios::test_topic_delete(
+                    &user1,
+                    &user2,
+                    env,
+                    &api_client,
+                    &mut sse1,
+                    &mut sse2,
+                )
+                .await?,
+            );
+            results.push(
+                scenarios::test_agreement_create(
+                    &user1,
+                    &user2,
+                    env,
+                    &api_client,
+                    &mut sse1,
+                    &mut sse2,
+                )
+                .await?,
+            );
+            results.push(
+                scenarios::test_agreement_update(
+                    &user1,
+                    &user2,
+                    env,
+                    &api_client,
+                    &mut sse1,
+                    &mut sse2,
+                )
+                .await?,
+            );
+            results.push(
+                scenarios::test_agreement_delete(
                     &user1,
                     &user2,
                     env,

--- a/testing-tools/src/scenarios.rs
+++ b/testing-tools/src/scenarios.rs
@@ -645,7 +645,12 @@ pub async fn test_agreement_update(
 
     println!("{} User 1 updating agreement...", "→".blue());
     api_client
-        .update_agreement(&user1.session_cookie, &agreement_id, "Updated body")
+        .update_agreement(
+            &user1.session_cookie,
+            &test_env.session_id,
+            &agreement_id,
+            "Updated body",
+        )
         .await?;
 
     println!(

--- a/testing-tools/src/scenarios.rs
+++ b/testing-tools/src/scenarios.rs
@@ -555,3 +555,182 @@ pub async fn test_topic_delete(
 
     Ok(expect_topics_changed(sse2, &test_env.session_id, "topic_delete", start).await)
 }
+
+// --- Agreements (session-scoped, entity-in-payload) ---
+
+pub async fn test_agreement_create(
+    user1: &AuthenticatedUser,
+    _user2: &AuthenticatedUser,
+    test_env: &TestEnvironment,
+    api_client: &ApiClient,
+    _sse1: &mut Connection,
+    sse2: &mut Connection,
+) -> Result<TestResult> {
+    let start = Instant::now();
+    println!(
+        "\n{}",
+        "=== TEST: Agreement Create ===".bright_cyan().bold()
+    );
+
+    println!("{} User 1 creating agreement...", "→".blue());
+    let agreement = api_client
+        .create_agreement(
+            &user1.session_cookie,
+            &test_env.session_id,
+            "Test Agreement - Create",
+        )
+        .await?;
+    let agreement_id = agreement["id"].as_str().unwrap();
+    println!("{} Agreement created (ID: {})", "✓".green(), agreement_id);
+
+    println!(
+        "{} Waiting for User 2 to receive agreement_created event...",
+        "→".blue()
+    );
+    match sse2
+        .wait_for_event("agreement_created", Duration::from_secs(5))
+        .await
+    {
+        Ok(event) => {
+            print_event(&sse2.user_label, &event);
+            let received_id = event.data["data"]["agreement"]["id"].as_str().unwrap();
+            let received_session_id = event.data["data"]["coaching_session_id"].as_str().unwrap();
+            let passed = received_id == agreement_id && received_session_id == test_env.session_id;
+            Ok(TestResult {
+                scenario: "agreement_create".to_string(),
+                passed,
+                message: (!passed).then(|| {
+                    format!(
+                        "Expected agreement_id={}, session_id={}; got agreement_id={}, session_id={}",
+                        agreement_id, test_env.session_id, received_id, received_session_id
+                    )
+                }),
+                duration: start.elapsed(),
+            })
+        }
+        Err(e) => Ok(TestResult {
+            scenario: "agreement_create".to_string(),
+            passed: false,
+            message: Some(format!("Timeout: {}", e)),
+            duration: start.elapsed(),
+        }),
+    }
+}
+
+pub async fn test_agreement_update(
+    user1: &AuthenticatedUser,
+    _user2: &AuthenticatedUser,
+    test_env: &TestEnvironment,
+    api_client: &ApiClient,
+    _sse1: &mut Connection,
+    sse2: &mut Connection,
+) -> Result<TestResult> {
+    let start = Instant::now();
+    println!(
+        "\n{}",
+        "=== TEST: Agreement Update ===".bright_cyan().bold()
+    );
+
+    let agreement = api_client
+        .create_agreement(
+            &user1.session_cookie,
+            &test_env.session_id,
+            "Test Agreement - Update",
+        )
+        .await?;
+    let agreement_id = agreement["id"].as_str().unwrap().to_string();
+    let _ = sse2
+        .wait_for_event("agreement_created", Duration::from_secs(5))
+        .await?;
+
+    println!("{} User 1 updating agreement...", "→".blue());
+    api_client
+        .update_agreement(&user1.session_cookie, &agreement_id, "Updated body")
+        .await?;
+
+    println!(
+        "{} Waiting for User 2 to receive agreement_updated event...",
+        "→".blue()
+    );
+    match sse2
+        .wait_for_event("agreement_updated", Duration::from_secs(5))
+        .await
+    {
+        Ok(event) => {
+            print_event(&sse2.user_label, &event);
+            let received_id = event.data["data"]["agreement"]["id"].as_str().unwrap();
+            let passed = received_id == agreement_id;
+            Ok(TestResult {
+                scenario: "agreement_update".to_string(),
+                passed,
+                message: (!passed).then(|| format!("Agreement ID mismatch: {}", received_id)),
+                duration: start.elapsed(),
+            })
+        }
+        Err(e) => Ok(TestResult {
+            scenario: "agreement_update".to_string(),
+            passed: false,
+            message: Some(format!("Timeout: {}", e)),
+            duration: start.elapsed(),
+        }),
+    }
+}
+
+pub async fn test_agreement_delete(
+    user1: &AuthenticatedUser,
+    _user2: &AuthenticatedUser,
+    test_env: &TestEnvironment,
+    api_client: &ApiClient,
+    _sse1: &mut Connection,
+    sse2: &mut Connection,
+) -> Result<TestResult> {
+    let start = Instant::now();
+    println!(
+        "\n{}",
+        "=== TEST: Agreement Delete ===".bright_cyan().bold()
+    );
+
+    let agreement = api_client
+        .create_agreement(
+            &user1.session_cookie,
+            &test_env.session_id,
+            "Test Agreement - Delete",
+        )
+        .await?;
+    let agreement_id = agreement["id"].as_str().unwrap().to_string();
+    let _ = sse2
+        .wait_for_event("agreement_created", Duration::from_secs(5))
+        .await?;
+
+    println!("{} User 1 deleting agreement...", "→".blue());
+    api_client
+        .delete_agreement(&user1.session_cookie, &agreement_id)
+        .await?;
+
+    println!(
+        "{} Waiting for User 2 to receive agreement_deleted event...",
+        "→".blue()
+    );
+    match sse2
+        .wait_for_event("agreement_deleted", Duration::from_secs(5))
+        .await
+    {
+        Ok(event) => {
+            print_event(&sse2.user_label, &event);
+            let received_id = event.data["data"]["agreement_id"].as_str().unwrap();
+            let passed = received_id == agreement_id;
+            Ok(TestResult {
+                scenario: "agreement_delete".to_string(),
+                passed,
+                message: (!passed).then(|| format!("Agreement ID mismatch: {}", received_id)),
+                duration: start.elapsed(),
+            })
+        }
+        Err(e) => Ok(TestResult {
+            scenario: "agreement_delete".to_string(),
+            passed: false,
+            message: Some(format!("Timeout: {}", e)),
+            duration: start.elapsed(),
+        }),
+    }
+}

--- a/web/src/controller/agreement_controller.rs
+++ b/web/src/controller/agreement_controller.rs
@@ -44,7 +44,13 @@ pub async fn create(
 ) -> Result<impl IntoResponse, Error> {
     debug!("POST Create a New Agreement from: {agreement_model:?}");
 
-    let agreement = AgreementApi::create(app_state.db_conn_ref(), agreement_model, user.id).await?;
+    let agreement = AgreementApi::create(
+        app_state.db_conn_ref(),
+        app_state.event_publisher.as_ref(),
+        agreement_model,
+        user.id,
+    )
+    .await?;
 
     debug!("New Agreement: {agreement:?}");
 
@@ -114,7 +120,13 @@ pub async fn update(
 ) -> Result<impl IntoResponse, Error> {
     debug!("PUT Update Agreement with id: {id}");
 
-    let agreement = AgreementApi::update(app_state.db_conn_ref(), id, agreement_model).await?;
+    let agreement = AgreementApi::update(
+        app_state.db_conn_ref(),
+        app_state.event_publisher.as_ref(),
+        id,
+        agreement_model,
+    )
+    .await?;
 
     debug!("Updated Agreement: {agreement:?}");
 
@@ -188,6 +200,11 @@ pub async fn delete(
 ) -> Result<impl IntoResponse, Error> {
     debug!("DELETE Agreement by id: {id}");
 
-    AgreementApi::delete_by_id(app_state.db_conn_ref(), id).await?;
+    AgreementApi::delete_by_id(
+        app_state.db_conn_ref(),
+        app_state.event_publisher.as_ref(),
+        id,
+    )
+    .await?;
     Ok(Json(json!({"id": id})))
 }


### PR DESCRIPTION
## What
Completes the dead-scaffold `agreement_*` SSE events **and corrects their scope**. They were defined in the wire `Event` enum but never emitted, and were mis-keyed by `coaching_relationship_id`. Agreements are session-owned (`agreements::Model` has `coaching_session_id`, read via `GET /agreements?coaching_session_id=`), so the events are re-keyed to `coaching_session_id` to match the data model and how the FE reads/caches agreements.

## How
- `events`: `AgreementCreated`/`AgreementUpdated` (carry serialized agreement entity) + `AgreementDeleted` (`agreement_id`), session-scoped domain events.
- `sse`: re-key `Event::Agreement*` wire variants `coaching_relationship_id` -> `coaching_session_id`; three handler arms.
- `domain`: **new** `domain::agreement` `create`/`update`/`delete_by_id` wrappers that call `entity_api` then emit; notify set = the agreement's session participants (best-effort).
- `web`: `agreement_controller` routes create/update/delete through the wrappers with the event publisher.

Wire (session-scoped, entity-in-payload):
```
agreement_created  {"coaching_session_id","agreement":<entity>}
agreement_updated  {"coaching_session_id","agreement":<entity>}
agreement_deleted  {"coaching_session_id","agreement_id"}
```

## Tests
New domain emit tests (created / updated / deleted) + `agreement_*` wire serialization pins. New `testing-tools` agreement scenarios added in this PR for live verification. Full mock-gated suite, clippy, fmt green.

## Coordination
`agreement_sse` + `agreement_sse_payload_confirmed` on the board were **corrected** from relationship- to session-scoped; FE notified to re-key listeners off `coaching_session_id`. Additive, no coordinated deploy. Independent branch off `main`.

## Still to do
- [ ] Live-verify on real Postgres via sse-test-client
- [ ] Pin a contract with the literal serialized `agreement` payload example