### PR TITLE
Serde-default duration + timezone so user-create tolerates omitted fields

### DIFF
--- a/entity/src/users.rs
+++ b/entity/src/users.rs
@@ -163,9 +163,9 @@ mod tests {
         assert_eq!(model.timezone, "UTC");
     }
 
-    /// Explicit duration is still honored.
+    /// Explicit duration and timezone are still honored (defaults don't clobber).
     #[test]
-    fn deserialize_honors_explicit_duration() {
+    fn deserialize_honors_explicit_duration_and_timezone() {
         let model: Model = serde_json::from_value(serde_json::json!({
             "email": "coach@example.com",
             "first_name": "Co",
@@ -175,5 +175,6 @@ mod tests {
         }))
         .expect("payload with duration must deserialize");
         assert_eq!(model.default_coaching_session_duration_minutes, 90);
+        assert_eq!(model.timezone, "America/New_York");
     }
 }

--- a/entity/src/users.rs
+++ b/entity/src/users.rs
@@ -28,8 +28,9 @@ pub struct Model {
     #[sea_orm(default = "UTC")]
     pub timezone: String,
     /// Per-coach default session duration in minutes. Validated `1..=480`
-    /// via `entity::duration::Duration` on every write. The migration's
-    /// `NOT NULL DEFAULT 60` provides the column default.
+    /// via `entity::duration::Duration`. Serde default mirrors the column's
+    /// `NOT NULL DEFAULT 60` so it's optional on the wire (not an invalid `0`).
+    #[serde(default = "crate::duration::Duration::default_minutes")]
     pub default_coaching_session_duration_minutes: i16,
     #[sea_orm(default = "user")]
     // This is a legacy field and will be removed in favor of roles
@@ -136,5 +137,36 @@ mod tests {
         let user_a = test_user(Uuid::new_v4(), None);
         let user_b = test_user(Uuid::new_v4(), None);
         assert_ne!(user_a.session_auth_hash(), user_b.session_auth_hash());
+    }
+
+    /// Magic-link invite path: payload omits duration. Must default to 60, not 422/0.
+    #[test]
+    fn deserialize_defaults_duration_when_omitted() {
+        let model: Model = serde_json::from_value(serde_json::json!({
+            "email": "invite@example.com",
+            "first_name": "Inv",
+            "last_name": "Ite",
+            "display_name": "Inv Ite",
+            "timezone": "America/New_York",
+        }))
+        .expect("invite payload without duration must deserialize");
+        assert_eq!(
+            model.default_coaching_session_duration_minutes,
+            crate::duration::Duration::default_minutes(),
+        );
+    }
+
+    /// Explicit duration is still honored.
+    #[test]
+    fn deserialize_honors_explicit_duration() {
+        let model: Model = serde_json::from_value(serde_json::json!({
+            "email": "coach@example.com",
+            "first_name": "Co",
+            "last_name": "Ach",
+            "timezone": "America/New_York",
+            "default_coaching_session_duration_minutes": 90,
+        }))
+        .expect("payload with duration must deserialize");
+        assert_eq!(model.default_coaching_session_duration_minutes, 90);
     }
 }

--- a/entity/src/users.rs
+++ b/entity/src/users.rs
@@ -8,6 +8,10 @@ use sea_orm::entity::prelude::*;
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
+fn default_timezone() -> String {
+    "UTC".to_string()
+}
+
 // TODO: We should find a way to centralize the users/coaches/coachees types
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel, Eq, ToSchema, Serialize, Deserialize)]
 #[schema(as = domain::users::Model)] // OpenAPI schema
@@ -25,7 +29,9 @@ pub struct Model {
     pub password: Option<String>,
     pub github_username: Option<String>,
     pub github_profile_url: Option<String>,
+    // Serde default mirrors the column's `DEFAULT 'UTC'` so it's optional on the wire.
     #[sea_orm(default = "UTC")]
+    #[serde(default = "default_timezone")]
     pub timezone: String,
     /// Per-coach default session duration in minutes. Validated `1..=480`
     /// via `entity::duration::Duration`. Serde default mirrors the column's
@@ -139,21 +145,22 @@ mod tests {
         assert_ne!(user_a.session_auth_hash(), user_b.session_auth_hash());
     }
 
-    /// Magic-link invite path: payload omits duration. Must default to 60, not 422/0.
+    /// Magic-link invite path: payload omits duration AND timezone.
+    /// Both must default (60 / "UTC"), not 422.
     #[test]
-    fn deserialize_defaults_duration_when_omitted() {
+    fn deserialize_defaults_duration_and_timezone_when_omitted() {
         let model: Model = serde_json::from_value(serde_json::json!({
             "email": "invite@example.com",
             "first_name": "Inv",
             "last_name": "Ite",
             "display_name": "Inv Ite",
-            "timezone": "America/New_York",
         }))
-        .expect("invite payload without duration must deserialize");
+        .expect("invite payload without duration/timezone must deserialize");
         assert_eq!(
             model.default_coaching_session_duration_minutes,
             crate::duration::Duration::default_minutes(),
         );
+        assert_eq!(model.timezone, "UTC");
     }
 
     /// Explicit duration is still honored.


### PR DESCRIPTION
## Description
Fixes a backend regression where `POST /organizations/{id}/users` returned **422** on the magic-link invite flow. `users::Model` is used as both the SeaORM table model and the request DTO, so fields relying on a `#[sea_orm(default = ...)]` are silently *required on the wire* — the ORM default only fills the value on DB INSERT, never during JSON deserialization. axum's `Json` extractor therefore rejected any invite payload that omitted `default_coaching_session_duration_minutes` before the handler ran. Regressed in `230f807a` (which dropped the field's sea_orm default without adding a serde default).

While fixing it, `timezone` was found to have the identical latent gap (`#[sea_orm(default = "UTC")]`, no serde default → required on the wire) and is hardened in the same change.

### Changes
* `default_coaching_session_duration_minutes`: add `#[serde(default = "crate::duration::Duration::default_minutes")]` (→ 60, reusing the canonical const so the wire default and the column `NOT NULL DEFAULT 60` share one source of truth; bare `#[serde(default)]` would yield `0`, which fails the `1..=480` validation).
* `timezone`: add `#[serde(default = "default_timezone")]` (→ `"UTC"`, mirroring the column `DEFAULT 'UTC'`).
* Add deserialization regression tests: the minimal invite payload (omitting both fields) deserializes with both defaulting, and an explicit duration is still honored.

### Testing Strategy
* `cargo test -p entity` — 5/5 in `users::tests` green, including the new `deserialize_defaults_duration_and_timezone_when_omitted` and `deserialize_honors_explicit_duration`.
* `cargo clippy -p entity --all-targets` clean; `cargo fmt` applied.
* Live-verify: as a super-admin, add a member via the org members page (payload omits password + duration) → expect 201, not 422.

### Concerns
* Additive and non-breaking — existing payloads (which send `timezone`) are unaffected. No migration, no coordinated deploy.
* Other `users::Model` fields that rely solely on a sea_orm default would have the same wire-required behavior; only the two reachable via the invite flow are addressed here.
