### PR TITLE
Drop useless borrows in debug! formatting args

### DIFF
--- a/web/src/controller/organization/coaching_relationship_controller.rs
+++ b/web/src/controller/organization/coaching_relationship_controller.rs
@@ -55,7 +55,7 @@ pub async fn create(
 
     debug!(
         "Newly created Coaching Relationship: {:?}",
-        &coaching_relationship
+        coaching_relationship
     );
 
     Ok(Json(ApiResponse::new(

--- a/web/src/controller/organization_controller.rs
+++ b/web/src/controller/organization_controller.rs
@@ -114,7 +114,7 @@ pub async fn create(
     let organization: organizations::Model =
         OrganizationApi::create(app_state.db_conn_ref(), organization_model).await?;
 
-    debug!("Newly Created Organization: {:?}", &organization);
+    debug!("Newly Created Organization: {:?}", organization);
 
     Ok(Json(ApiResponse::new(
         StatusCode::CREATED.into(),


### PR DESCRIPTION
## Description
CI clippy job on `main` was failing with `clippy::useless_borrows_in_formatting` (promoted to an error by `-D warnings`). Two `debug!` calls passed values by reference (`&value`) into `{:?}`, but `format_args!` already borrows its arguments, so the `&` is redundant noise the lint rejects.

#### GitHub Issue: N/A (unblocks failing CI on `main`)

### Changes
* `web/src/controller/organization/coaching_relationship_controller.rs`: drop `&` on the `coaching_relationship` `debug!` arg
* `web/src/controller/organization_controller.rs`: drop `&` on the `organization` `debug!` arg

### Testing Strategy
* `cargo clippy --all-targets -- -D warnings` passes cleanly (the exact CI invocation)
* `cargo fmt --all --check` passes
* No behavior change: format macros never consume their arguments, so both values remain usable in the subsequent `ApiResponse::new(...)` calls

### Concerns
None. Purely a lint fix with no runtime impact.
