### PR TITLE
Enable docs-collab image in previews; TIPTAP_URL as variable

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -108,10 +108,10 @@ Nginx runs as a Docker container (`docker-compose.nginx-preview.yaml`) using Doc
 The entrypoint waits for PostgreSQL readiness, then idempotently creates the `refactor_platform` schema and sets `search_path`. This supports the PR preview migrator container which needs the schema to exist before running migrations.
 
 ### Manual Dispatch (Primary Deployment Method)
-PR preview environments are deployed **manually via workflow dispatch only** — there are no automatic deploy triggers on PR events. `dispatch-pr-preview.yml` takes three text inputs:
-- `backend_pr_number` — required (e.g. `289` or `PR#289`).
-- `backend_sha_override` — optional, override the PR branch HEAD with a specific SHA.
-- `frontend_ref` — optional, default `main`; accepts `main`, a branch name, a 7+ char SHA, or `PR#<num>`.
+PR preview environments are deployed **manually via workflow dispatch only** — there are no automatic deploy triggers on PR events. `dispatch-pr-preview.yml` takes these dispatch inputs:
+- `backend_ref` (required): accepts `PR#<num>`, `<num>`, a branch, a tag, a full SHA, or a short SHA (>=6 hex).
+- `frontend_ref` (required): same vocabulary as `backend_ref`.
+- `reset_db` (optional, default `false`): drops the per-PR Postgres volume and re-seeds.
 
 At dispatch time, the `validate` job resolves each input to a full SHA via the GitHub API (`gh pr view`, `gh api repos/.../commits/<ref>`), validates that the backend PR is OPEN, and passes `backend_sha` / `frontend_sha` / `pr_number` / `branch_name` to the reusable `ci-deploy-pr-preview.yml`. Nothing is written to `main` — the workflow is stateless with respect to the default branch. Cleanup still runs automatically when the PR is closed or merged.
 

--- a/.github/workflows/ci-deploy-pr-preview.yml
+++ b/.github/workflows/ci-deploy-pr-preview.yml
@@ -520,9 +520,7 @@ jobs:
             backend_image_sha: ${{ steps.resolve.outputs.backend_image_sha }}
             frontend_image: ${{ steps.resolve.outputs.frontend_image }}
             frontend_image_sha: ${{ steps.resolve.outputs.frontend_image_sha }}
-            # Non-empty ONLY when a collab image was actually built + pushed this run
-            # (backend PR whose branch contains the crate). Empty otherwise, which keeps
-            # the deploy's collab compose profile inactive.
+            # Non-empty only when the collab image was actually built this run; empty keeps the collab profile off.
             docs_collab_image: ${{ steps.build_docs_collab.outcome == 'success' && steps.resolve.outputs.docs_collab_image || '' }}
             backend_branch: ${{ steps.resolve.outputs.backend_branch }}
             frontend_branch: ${{ steps.resolve.outputs.frontend_branch }}
@@ -664,10 +662,7 @@ jobs:
                       fi
                       DOCS_COLLAB_TAGS="${DOCS_COLLAB_IMAGE},${DOCS_COLLAB_SHA}"
                   else
-                      # Frontend-only previews do not build or run collab: no
-                      # docs-collab:main-arm64 image is published yet, so referencing one
-                      # would point at a missing image + WS endpoint. Leave empty; the
-                      # deploy keeps the compose `collab` profile inactive when unset.
+                      # Frontend-only previews don't run collab (no main-arm64 image); leave empty.
                       DOCS_COLLAB_IMAGE=""
                       DOCS_COLLAB_TAGS=""
                   fi
@@ -840,8 +835,7 @@ jobs:
                   provenance: true
                   sbom: false
 
-            # Skip the collab image build for PR branches that predate the crate
-            # (no Dockerfile in the checkout), so unrelated previews are unaffected.
+            # Skip the collab build when the checked-out branch lacks the crate's Dockerfile.
             - name: Check for docs-collab Dockerfile
               id: collab_dockerfile
               if: steps.resolve.outputs.backend_build_mode != 'skip' && (steps.resolve.outputs.backend_needs_build == 'true' || steps.backend_registry.outputs.exists == 'false')
@@ -853,9 +847,7 @@ jobs:
                       echo "::notice::docs-collab Dockerfile absent in this branch; skipping collab image build."
                   fi
 
-            # Build and push ARM64 docs-collab image from the same backend checkout.
-            # Its own GHCR package + cache scope; built whenever the backend builds
-            # (and only when the crate's Dockerfile is present in the checkout).
+            # Build+push the docs-collab image from the backend checkout (own GHCR package + cache scope).
             - name: Build and push docs-collab image
               id: build_docs_collab
               if: steps.collab_dockerfile.outputs.exists == 'true'
@@ -1339,10 +1331,7 @@ jobs:
                   # place (with its volume) on update deploys; the previous
                   # teardown step already removed the app-tier services, so
                   # they will be (re)created here against the new image.
-                  # Activate the collab compose profile only when a collab image was built
-                  # for this preview (backend PRs with the crate). Frontend-only previews
-                  # (and older backend PRs without the crate) leave it empty, so the
-                  # profiled docs-collab service is skipped instead of failing to pull.
+                  # Enable the collab profile only when its image was built (else skip the service).
                   COLLAB_PROFILE=""
                   if [[ -n "\${DOCS_COLLAB_IMAGE}" && "\${DOCS_COLLAB_IMAGE}" != "null" ]]; then
                       COLLAB_PROFILE="--profile collab"

--- a/.github/workflows/ci-deploy-pr-preview.yml
+++ b/.github/workflows/ci-deploy-pr-preview.yml
@@ -125,9 +125,7 @@ on:
                 required: false
 
             # Third-party service credentials for backend
-            TIPTAP_URL:
-                description: "TipTap service URL"
-                required: false
+            # NOTE: TIPTAP_URL is a non-secret VARIABLE (vars.TIPTAP_URL), not a secret.
             TIPTAP_AUTH_KEY:
                 description: "TipTap authentication key"
                 required: false
@@ -522,6 +520,7 @@ jobs:
             backend_image_sha: ${{ steps.resolve.outputs.backend_image_sha }}
             frontend_image: ${{ steps.resolve.outputs.frontend_image }}
             frontend_image_sha: ${{ steps.resolve.outputs.frontend_image_sha }}
+            docs_collab_image: ${{ steps.resolve.outputs.docs_collab_image }}
             backend_branch: ${{ steps.resolve.outputs.backend_branch }}
             frontend_branch: ${{ steps.resolve.outputs.frontend_branch }}
             backend_service_port: ${{ steps.resolve.outputs.backend_service_port }}
@@ -648,6 +647,24 @@ jobs:
                       fi
                   fi
 
+                  # Configure docs-collab image (built from the same backend
+                  # checkout/workspace; its own GHCR package under the backend repo).
+                  # For backend PRs it is a per-PR tag; frontend-only deploys reference
+                  # the main-arm64 collab tag (mirrors the backend main-arm64 strategy).
+                  DOCS_COLLAB_IMAGE_REPO="${BACKEND_IMAGE_REPO}/docs-collab"
+                  if [[ "$REPO_TYPE" == "backend" ]]; then
+                      DOCS_COLLAB_IMAGE="${DOCS_COLLAB_IMAGE_REPO}:pr-${PR}"
+                      if [[ -n "$BACKEND_SHA_OVERRIDE" ]]; then
+                          DOCS_COLLAB_SHA="${DOCS_COLLAB_IMAGE_REPO}:pr-${PR}-${BACKEND_SHA_OVERRIDE:0:7}"
+                      else
+                          DOCS_COLLAB_SHA="${DOCS_COLLAB_IMAGE_REPO}:pr-${PR}-${{ github.sha }}"
+                      fi
+                  else
+                      DOCS_COLLAB_IMAGE="${DOCS_COLLAB_IMAGE_REPO}:main-arm64"
+                      DOCS_COLLAB_SHA="${DOCS_COLLAB_IMAGE_REPO}:main-arm64-latest"
+                  fi
+                  DOCS_COLLAB_TAGS="${DOCS_COLLAB_IMAGE},${DOCS_COLLAB_SHA}"
+
                   # Configure frontend image strategy
                   # Always build PR-specific frontend image regardless of repo_type.
                   # Next.js basePath is baked in at build time — main-arm64 has basePath=""
@@ -688,6 +705,8 @@ jobs:
                   echo "backend_build_mode=${BACKEND_BUILD_MODE}" >> $GITHUB_OUTPUT
                   echo "backend_needs_build=${BACKEND_NEEDS_BUILD}" >> $GITHUB_OUTPUT
                   echo "backend_tags=${BACKEND_TAGS}" >> $GITHUB_OUTPUT
+                  echo "docs_collab_image=${DOCS_COLLAB_IMAGE}" >> $GITHUB_OUTPUT
+                  echo "docs_collab_tags=${DOCS_COLLAB_TAGS}" >> $GITHUB_OUTPUT
                   echo "frontend_image=${FRONTEND_IMAGE}" >> $GITHUB_OUTPUT
                   echo "frontend_image_sha=${FRONTEND_SHA}" >> $GITHUB_OUTPUT
                   echo "frontend_build_mode=${FRONTEND_BUILD_MODE}" >> $GITHUB_OUTPUT
@@ -814,6 +833,47 @@ jobs:
                   provenance: true
                   sbom: false
 
+            # Skip the collab image build for PR branches that predate the crate
+            # (no Dockerfile in the checkout), so unrelated previews are unaffected.
+            - name: Check for docs-collab Dockerfile
+              id: collab_dockerfile
+              if: steps.resolve.outputs.backend_build_mode != 'skip' && (steps.resolve.outputs.backend_needs_build == 'true' || steps.backend_registry.outputs.exists == 'false')
+              run: |
+                  if [[ -f ./backend-src/docs-collab-server/Dockerfile ]]; then
+                      echo "exists=true" >> $GITHUB_OUTPUT
+                  else
+                      echo "exists=false" >> $GITHUB_OUTPUT
+                      echo "::notice::docs-collab Dockerfile absent in this branch; skipping collab image build."
+                  fi
+
+            # Build and push ARM64 docs-collab image from the same backend checkout.
+            # Its own GHCR package + cache scope; built whenever the backend builds
+            # (and only when the crate's Dockerfile is present in the checkout).
+            - name: Build and push docs-collab image
+              id: build_docs_collab
+              if: steps.collab_dockerfile.outputs.exists == 'true'
+              uses: docker/build-push-action@v5
+              with:
+                  context: ./backend-src
+                  file: ./backend-src/docs-collab-server/Dockerfile
+                  platforms: linux/arm64
+                  push: true
+                  tags: ${{ steps.resolve.outputs.docs_collab_tags }}
+                  cache-from: |
+                      type=registry,ref=${{ steps.resolve.outputs.docs_collab_image }}
+                      type=registry,ref=${{ env.BACKEND_IMAGE_REPO }}/docs-collab:main-arm64
+                      type=gha,scope=docs-collab-arm64-${{ steps.resolve.outputs.backend_branch }}
+                      type=gha,scope=docs-collab-arm64-main
+                      type=gha,scope=docs-collab-arm64
+                  cache-to: type=gha,mode=max,scope=docs-collab-arm64-${{ steps.resolve.outputs.backend_branch }}
+                  labels: |
+                      pr.branch=${{ steps.resolve.outputs.backend_branch }}
+                      pr.number=${{ steps.resolve.outputs.pr_number }}
+                  build-args: |
+                      BUILDKIT_INLINE_CACHE=1
+                  provenance: true
+                  sbom: false
+
             # Get frontend source code if we need to build it.
             # Uses continue-on-error + fallback to main so that if a PR branch
             # has been deleted (e.g. after merge), the checkout still succeeds.
@@ -867,6 +927,7 @@ jobs:
                       NEXT_PUBLIC_BACKEND_API_VERSION=${{ vars.BACKEND_API_VERSION || '1.0.0-beta1' }}
                       NEXT_PUBLIC_TIPTAP_APP_ID=${{ vars.TIPTAP_APP_ID }}
                       NEXT_PUBLIC_BASE_PATH=/pr-${{ steps.resolve.outputs.pr_number }}
+                      NEXT_PUBLIC_DOCS_COLLAB_URL=ws://${{ secrets.RPI5_TAILSCALE_NAME || 'neo.rove-barbel.ts.net' }}/pr-${{ steps.resolve.outputs.pr_number }}/collab
                       FRONTEND_SERVICE_PORT=${{ vars.FRONTEND_SERVICE_PORT || '3000' }}
                       FRONTEND_SERVICE_INTERFACE=${{ vars.FRONTEND_SERVICE_INTERFACE || '0.0.0.0' }}
                       BUILDKIT_INLINE_CACHE=1
@@ -1141,6 +1202,7 @@ jobs:
                   PR_NUMBER=${{ needs.build-arm64-image.outputs.pr_number }}
                   BACKEND_IMAGE=${{ needs.build-arm64-image.outputs.backend_image }}
                   FRONTEND_IMAGE=${{ needs.build-arm64-image.outputs.frontend_image }}
+                  DOCS_COLLAB_IMAGE=${{ needs.build-arm64-image.outputs.docs_collab_image }}
                   PROJECT_NAME=${{ steps.ports.outputs.project_name }}
                   INITIAL_CREATE=${{ steps.db_lifecycle.outputs.initial_create }}
                   RESET_DB=${{ steps.db_lifecycle.outputs.reset_requested }}
@@ -1168,7 +1230,7 @@ jobs:
                   TIPTAP_AUTH_KEY='${{ secrets.TIPTAP_AUTH_KEY || 'UNUSED' }}'
                   TIPTAP_JWT_SIGNING_KEY='${{ secrets.TIPTAP_JWT_SIGNING_KEY || 'UNUSED' }}'
                   TIPTAP_APP_ID='${{ vars.TIPTAP_APP_ID || 'UNUSED' }}'
-                  TIPTAP_URL='${{ secrets.TIPTAP_URL || 'UNUSED' }}'
+                  TIPTAP_URL='${{ vars.TIPTAP_URL || 'UNUSED' }}'
                   RESEND_API_KEY='${{ secrets.RESEND_API_KEY || 'UNUSED' }}'
                   WELCOME_EMAIL_TEMPLATE_ID='${{ vars.WELCOME_EMAIL_TEMPLATE_ID || 'UNUSED' }}'
                   SESSION_SCHEDULED_EMAIL_TEMPLATE_ID='${{ vars.SESSION_SCHEDULED_EMAIL_TEMPLATE_ID || 'UNUSED' }}'
@@ -1192,6 +1254,7 @@ jobs:
                   NEXT_PUBLIC_BACKEND_SERVICE_PORT=80
                   NEXT_PUBLIC_BACKEND_SERVICE_API_PATH=pr-${{ needs.build-arm64-image.outputs.pr_number }}/api
                   NEXT_PUBLIC_BACKEND_API_VERSION=${{ vars.BACKEND_API_VERSION || '1.0.0-beta1' }}
+                  NEXT_PUBLIC_DOCS_COLLAB_URL=ws://${{ secrets.RPI5_TAILSCALE_NAME }}/pr-${{ needs.build-arm64-image.outputs.pr_number }}/collab
                   ENVEOF
 
                   # Transfer deployment configuration to target server

--- a/.github/workflows/ci-deploy-pr-preview.yml
+++ b/.github/workflows/ci-deploy-pr-preview.yml
@@ -835,7 +835,8 @@ jobs:
                   provenance: true
                   sbom: false
 
-            # Skip the collab build when the checked-out branch lacks the crate's Dockerfile.
+            # Skip the collab build when the branch lacks the crate's Dockerfile, or when a
+            # backend image override forces build_mode=skip (collab profile then stays off).
             - name: Check for docs-collab Dockerfile
               id: collab_dockerfile
               if: steps.resolve.outputs.backend_build_mode != 'skip' && (steps.resolve.outputs.backend_needs_build == 'true' || steps.backend_registry.outputs.exists == 'false')
@@ -926,7 +927,7 @@ jobs:
                       NEXT_PUBLIC_BACKEND_API_VERSION=${{ vars.BACKEND_API_VERSION || '1.0.0-beta1' }}
                       NEXT_PUBLIC_TIPTAP_APP_ID=${{ vars.TIPTAP_APP_ID }}
                       NEXT_PUBLIC_BASE_PATH=/pr-${{ steps.resolve.outputs.pr_number }}
-                      NEXT_PUBLIC_DOCS_COLLAB_URL=ws://${{ secrets.RPI5_TAILSCALE_NAME || 'neo.rove-barbel.ts.net' }}/pr-${{ steps.resolve.outputs.pr_number }}/collab
+                      NEXT_PUBLIC_DOCS_COLLAB_URL=ws://${{ secrets.RPI5_TAILSCALE_NAME }}/pr-${{ steps.resolve.outputs.pr_number }}/collab
                       FRONTEND_SERVICE_PORT=${{ vars.FRONTEND_SERVICE_PORT || '3000' }}
                       FRONTEND_SERVICE_INTERFACE=${{ vars.FRONTEND_SERVICE_INTERFACE || '0.0.0.0' }}
                       BUILDKIT_INLINE_CACHE=1
@@ -1152,7 +1153,7 @@ jobs:
                       # (avoids `volume rm` racing into the wrong state).
                       ssh -o StrictHostKeyChecking=yes -i ~/.ssh/id_ed25519 \
                           ${{ secrets.RPI5_USERNAME }}@${{ secrets.RPI5_TAILSCALE_NAME }} \
-                          "docker compose -p ${PROJECT_NAME} -f pr-${PR_NUMBER}-compose.yaml rm -fsv backend frontend migrator seed 2>/dev/null || true"
+                          "docker compose -p ${PROJECT_NAME} -f pr-${PR_NUMBER}-compose.yaml --profile collab rm -fsv backend frontend migrator seed docs-collab 2>/dev/null || true"
                       echo "::notice::✅ App-tier teardown complete (postgres + volume preserved)"
                   fi
 
@@ -1333,7 +1334,7 @@ jobs:
                   # they will be (re)created here against the new image.
                   # Enable the collab profile only when its image was built (else skip the service).
                   COLLAB_PROFILE=""
-                  if [[ -n "\${DOCS_COLLAB_IMAGE}" && "\${DOCS_COLLAB_IMAGE}" != "null" ]]; then
+                  if [[ -n "\${DOCS_COLLAB_IMAGE}" ]]; then
                       COLLAB_PROFILE="--profile collab"
                   fi
 

--- a/.github/workflows/ci-deploy-pr-preview.yml
+++ b/.github/workflows/ci-deploy-pr-preview.yml
@@ -520,7 +520,10 @@ jobs:
             backend_image_sha: ${{ steps.resolve.outputs.backend_image_sha }}
             frontend_image: ${{ steps.resolve.outputs.frontend_image }}
             frontend_image_sha: ${{ steps.resolve.outputs.frontend_image_sha }}
-            docs_collab_image: ${{ steps.resolve.outputs.docs_collab_image }}
+            # Non-empty ONLY when a collab image was actually built + pushed this run
+            # (backend PR whose branch contains the crate). Empty otherwise, which keeps
+            # the deploy's collab compose profile inactive.
+            docs_collab_image: ${{ steps.build_docs_collab.outcome == 'success' && steps.resolve.outputs.docs_collab_image || '' }}
             backend_branch: ${{ steps.resolve.outputs.backend_branch }}
             frontend_branch: ${{ steps.resolve.outputs.frontend_branch }}
             backend_service_port: ${{ steps.resolve.outputs.backend_service_port }}
@@ -659,11 +662,15 @@ jobs:
                       else
                           DOCS_COLLAB_SHA="${DOCS_COLLAB_IMAGE_REPO}:pr-${PR}-${{ github.sha }}"
                       fi
+                      DOCS_COLLAB_TAGS="${DOCS_COLLAB_IMAGE},${DOCS_COLLAB_SHA}"
                   else
-                      DOCS_COLLAB_IMAGE="${DOCS_COLLAB_IMAGE_REPO}:main-arm64"
-                      DOCS_COLLAB_SHA="${DOCS_COLLAB_IMAGE_REPO}:main-arm64-latest"
+                      # Frontend-only previews do not build or run collab: no
+                      # docs-collab:main-arm64 image is published yet, so referencing one
+                      # would point at a missing image + WS endpoint. Leave empty; the
+                      # deploy keeps the compose `collab` profile inactive when unset.
+                      DOCS_COLLAB_IMAGE=""
+                      DOCS_COLLAB_TAGS=""
                   fi
-                  DOCS_COLLAB_TAGS="${DOCS_COLLAB_IMAGE},${DOCS_COLLAB_SHA}"
 
                   # Configure frontend image strategy
                   # Always build PR-specific frontend image regardless of repo_type.
@@ -1332,8 +1339,17 @@ jobs:
                   # place (with its volume) on update deploys; the previous
                   # teardown step already removed the app-tier services, so
                   # they will be (re)created here against the new image.
+                  # Activate the collab compose profile only when a collab image was built
+                  # for this preview (backend PRs with the crate). Frontend-only previews
+                  # (and older backend PRs without the crate) leave it empty, so the
+                  # profiled docs-collab service is skipped instead of failing to pull.
+                  COLLAB_PROFILE=""
+                  if [[ -n "\${DOCS_COLLAB_IMAGE}" && "\${DOCS_COLLAB_IMAGE}" != "null" ]]; then
+                      COLLAB_PROFILE="--profile collab"
+                  fi
+
                   echo "🚀 Starting PR preview environment..."
-                  docker compose -p \${PROJECT_NAME} -f pr-${PR_NUMBER}-compose.yaml --env-file "\$ENV_FILE" up -d --no-recreate
+                  docker compose -p \${PROJECT_NAME} -f pr-${PR_NUMBER}-compose.yaml --env-file "\$ENV_FILE" \${COLLAB_PROFILE} up -d --no-recreate
 
                   # Allow services time to start up
                   echo "⏳ Waiting \${SERVICE_STARTUP_WAIT_SECONDS} seconds for services..."

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -139,8 +139,8 @@ jobs:
           # -------- TipTap Config
           # TipTap account unique ID
           TIPTAP_APP_ID=${{ vars.TIPTAP_APP_ID }}
-          # TipTap collaborative editor URL
-          TIPTAP_URL=${{ secrets.TIPTAP_URL }}
+          # TipTap collaborative editor URL (non-secret variable)
+          TIPTAP_URL=${{ vars.TIPTAP_URL }}
           # TipTap authentication key
           TIPTAP_AUTH_KEY=${{ secrets.TIPTAP_AUTH_KEY }}
           # JWT signing key for TipTap

--- a/.github/workflows/deploy_to_do.yml
+++ b/.github/workflows/deploy_to_do.yml
@@ -139,7 +139,7 @@ jobs:
           # -------- TipTap Config
           # TipTap account unique ID
           TIPTAP_APP_ID=${{ vars.TIPTAP_APP_ID }}
-          # TipTap collaborative editor URL (non-secret variable)
+          # TipTap collaborative editor URL
           TIPTAP_URL=${{ vars.TIPTAP_URL }}
           # TipTap authentication key
           TIPTAP_AUTH_KEY=${{ secrets.TIPTAP_AUTH_KEY }}


### PR DESCRIPTION
## Description
Enable the docs-collab-server in PR preview deployments, and reclassify `TIPTAP_URL` as a non-secret variable. This is the workflow-orchestration half of the docs-collab work ([#371](https://github.com/refactor-group/refactor-platform-rs/pull/371)), split out to `main` because `dispatch-pr-preview.yml` runs the reusable workflow **from `main`** (only the built source + compose/nginx come from the PR branch). So the collab build steps must be on `main` to take effect in any preview.

### Changes
* `ci-deploy-pr-preview.yml`: build + push a per-PR `docs-collab` image (own GHCR package + cache scope), expose it as the `docs_collab_image` job output, and set `DOCS_COLLAB_IMAGE` + `NEXT_PUBLIC_DOCS_COLLAB_URL` (frontend build-arg + runtime) in the deploy env.
* Guard: the collab build is skipped when the checked-out PR branch has no `docs-collab-server/Dockerfile`, so previews of PRs that predate the crate are unaffected.
* `TIPTAP_URL` reclassified secret -> variable in both `deploy_to_do.yml` (prod) and `ci-deploy-pr-preview.yml` (preview); its `secrets:` declaration is removed. The auth pair (`TIPTAP_AUTH_KEY`, `TIPTAP_JWT_SIGNING_KEY`) stay secrets.
* `CLAUDE.md`: correct the stale `dispatch-pr-preview.yml` input names (`backend_ref` / `frontend_ref` / `reset_db`).

### Testing Strategy
* Both workflow YAMLs validated locally. The real test is a preview dispatch of backend PR #371 once this is merged to `main`.

### Concerns — required GitHub config BEFORE this takes effect
* Create `vars.TIPTAP_URL = http://docs-collab:1234` in the backend **production** and **pr-preview** environments, then delete the old `TIPTAP_URL` secret. Production fails loud on the next deploy if the var is unset.
* Cross-repo: the frontend repo also calls this reusable workflow, so it needs `vars.TIPTAP_URL` in ITS pr-preview environment too. Confirm the frontend caller uses `secrets: inherit` (not an explicit `TIPTAP_URL:` secret pass, which would now error since the declaration was removed).
* Frontend-only previews reference `docs-collab:main-arm64` (not yet published); backend-PR previews build the per-PR image and work.
