### PR TITLE
Revoke the token with the provider on disconnect

### DIFF
--- a/docs/test-plans/oauth_disconnect_revokes_token_manual_testing.md
+++ b/docs/test-plans/oauth_disconnect_revokes_token_manual_testing.md
@@ -40,19 +40,29 @@ account permissions page after disconnecting.
 Same shape as Scenario A, against Zoom's app management page
 (https://marketplace.zoom.us > Manage > Added Apps).
 
-This scenario carries the real risk. Zoom's revoke endpoint authenticates the
-client with HTTP Basic, and the request previously sent no client credentials at
-all, so it would have failed on every call. That code was unreachable until
-`revoke_token` gained a caller, so it had never run. The fix follows Zoom's
-documented requirement but has not been observed working.
+**Result: BLOCKED. Zoom OAuth is not configured in any environment.**
 
-Because failures are `warn!` only, a still-broken Zoom revoke looks identical to
-success in the UI. Check the backend log as well as the Zoom page.
+`GET /oauth/zoom/authorize` returns 500 because `create_zoom_provider` needs
+`ZOOM_CLIENT_ID`, `ZOOM_CLIENT_SECRET` and `ZOOM_REDIRECT_URI`, and none of the
+three appear anywhere in the repository: not in `.env`, `docker-compose.yaml`,
+`docker-compose.pr-preview.yaml`, `deploy_to_do.yml`,
+`ci-deploy-pr-preview.yml` or `docs/setup.md`. Their Google counterparts are in
+all six. There is no Zoom connection to disconnect, so revocation cannot be
+exercised.
+
+Enabling Zoom means creating a Zoom Marketplace app and wiring those three
+variables through every layer. Until then Zoom revocation ships **unverified**.
+
+When Zoom is enabled, run this scenario before trusting it. Zoom's revoke
+endpoint authenticates the client with HTTP Basic, and the request previously
+sent no client credentials at all, so it would have failed on every call. That
+code was unreachable until `revoke_token` gained a caller. The fix follows
+Zoom's documented requirement but has never been observed working, and because
+failures are `warn!` only, a still-broken revoke looks identical to success in
+the UI.
 
 **Pass:** the app is gone from Added Apps, and the log shows
 `Revoked zoom grant for user <id>` rather than `Failed to revoke`.
-
-**Result: NOT YET RUN.**
 
 ## 4. Scenario C: A failed revoke still disconnects the user
 

--- a/docs/test-plans/oauth_disconnect_revokes_token_manual_testing.md
+++ b/docs/test-plans/oauth_disconnect_revokes_token_manual_testing.md
@@ -1,0 +1,77 @@
+# Test Plan: Manually Testing OAuth Disconnect Revocation
+
+Verify that disconnecting a meeting integration revokes the grant with the
+provider, not just the row in our database.
+
+The single most important property: **the provider must forget us.** Before this
+change, Disconnect deleted the `oauth_connections` row and returned, leaving the
+access and refresh tokens valid and the grant listed on the coach's provider
+account page. Our app showing "not connected" is **not** evidence of revocation.
+The provider's own permissions page is the only evidence that counts.
+
+> [!IMPORTANT]
+> No automated test reaches the wire. Providers are built from config rather than
+> injected, so the suite covers token selection and the delete but never an actual
+> `revoke_token` call. These scenarios are the only proof revocation works.
+
+## 1. Prerequisites
+
+- Backend on branch `fix/oauth-disconnect-revokes-token`, migrations applied.
+- `ENCRYPTION_KEY` set, plus `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` /
+  `GOOGLE_REDIRECT_URI` for Scenario A and the `ZOOM_*` equivalents for Scenario B.
+- A real Google account, and a real Zoom account for Scenario B.
+- Backend logs visible, since a failed revoke is only ever a `warn!`.
+
+## 2. Scenario A: Google disconnect revokes the grant
+
+1. Connect Google in Settings > Integrations.
+2. Open https://myaccount.google.com/permissions and confirm the app is listed.
+3. Hit Disconnect in the app.
+4. Reload the Google permissions page.
+
+**Pass:** the app is gone from the permissions page, and the connection no longer
+appears in Settings > Integrations.
+
+**Result: PASS, verified 2026-08-11.** The grant was removed from the Google
+account permissions page after disconnecting.
+
+## 3. Scenario B: Zoom disconnect revokes the grant
+
+Same shape as Scenario A, against Zoom's app management page
+(https://marketplace.zoom.us > Manage > Added Apps).
+
+This scenario carries the real risk. Zoom's revoke endpoint authenticates the
+client with HTTP Basic, and the request previously sent no client credentials at
+all, so it would have failed on every call. That code was unreachable until
+`revoke_token` gained a caller, so it had never run. The fix follows Zoom's
+documented requirement but has not been observed working.
+
+Because failures are `warn!` only, a still-broken Zoom revoke looks identical to
+success in the UI. Check the backend log as well as the Zoom page.
+
+**Pass:** the app is gone from Added Apps, and the log shows
+`Revoked zoom grant for user <id>` rather than `Failed to revoke`.
+
+**Result: NOT YET RUN.**
+
+## 4. Scenario C: A failed revoke still disconnects the user
+
+Revocation is best effort. A provider we cannot reach must not strand the user in
+a connected-but-broken state.
+
+1. Connect a provider.
+2. Make revocation fail: disconnect the host from the network, or point the
+   provider's config at an unroutable revoke URL and restart the backend.
+3. Hit Disconnect.
+
+**Pass:** the app reports success, the connection is gone from
+Settings > Integrations, the row is gone from `oauth_connections`, and the log
+carries a `Failed to revoke` or `Cannot revoke` warning.
+
+**Result: NOT YET RUN.**
+
+## 5. Known limitation
+
+Anyone who disconnected before this shipped still has a live grant at the provider
+and no row left for us to revoke from. They have to revoke manually from the
+provider's account permissions page.

--- a/domain/src/oauth_connection.rs
+++ b/domain/src/oauth_connection.rs
@@ -13,8 +13,7 @@ use secrecy::{ExposeSecret, SecretString};
 use service::config::Config;
 
 pub use entity_api::oauth_connection::{
-    delete_by_user_and_provider, find_all_by_user, find_by_user, find_by_user_and_provider,
-    get_by_user_and_provider,
+    find_all_by_user, find_by_user, find_by_user_and_provider, get_by_user_and_provider,
 };
 
 /// Build the Provider's OAuth authorization URL with the given CSRF state token.
@@ -23,12 +22,7 @@ pub fn authorize_url(
     state: &str,
     provider: MeetingProvider,
 ) -> Result<String, Error> {
-    let oauth_provider: Box<dyn Provider> = match provider {
-        MeetingProvider::Google => Box::new(create_google_provider(config)?),
-        MeetingProvider::Zoom => Box::new(create_zoom_provider(config)?),
-    };
-
-    let auth_request = oauth_provider.authorization_url(state, None);
+    let auth_request = create_provider(config, provider)?.authorization_url(state, None);
 
     Ok(auth_request.url)
 }
@@ -53,10 +47,7 @@ pub async fn exchange_and_store_tokens(
         error_kind: DomainErrorKind::Internal(InternalErrorKind::Config),
     })?);
 
-    let oauth_provider: Box<dyn Provider> = match provider {
-        MeetingProvider::Google => Box::new(create_google_provider(config)?),
-        MeetingProvider::Zoom => Box::new(create_zoom_provider(config)?),
-    };
+    let oauth_provider = create_provider(config, provider)?;
 
     let tokens_raw = oauth_provider
         .exchange_code(authorization_code, None)
@@ -200,7 +191,10 @@ pub async fn get_valid_access_token(
                 "Refresh token revoked for user {}, removing connection",
                 user_id
             );
-            if let Err(del_err) = delete_by_user_and_provider(db, user_id, provider).await {
+            // The provider already revoked this grant, so drop the row without a revoke round trip.
+            if let Err(del_err) =
+                oauth_connection::delete_by_user_and_provider(db, user_id, provider).await
+            {
                 warn!(
                     "Failed to delete revoked OAuth connection for user {}: {:?}",
                     user_id, del_err
@@ -214,6 +208,84 @@ pub async fn get_valid_access_token(
             })
         }
         Err(e) => Err(e.into()),
+    }
+}
+
+/// Disconnect a user from a provider: revoke the stored grant, then delete the connection.
+///
+/// Revocation is best effort. It is attempted first so that a token is never orphaned at the
+/// provider, but a failure is logged rather than propagated: leaving the row behind would strand
+/// the user in a connected-but-broken state with no way to retry.
+///
+/// # Errors
+///
+/// Returns `RecordNotFound` when the user has no connection for `provider`.
+pub async fn delete_by_user_and_provider(
+    db: &DatabaseConnection,
+    config: &Config,
+    user_id: Id,
+    provider: MeetingProvider,
+) -> Result<(), Error> {
+    if let Some(connection) =
+        oauth_connection::find_by_user_and_provider(db, user_id, provider).await?
+    {
+        revoke_stored_token(config, &connection, provider).await;
+    }
+
+    oauth_connection::delete_by_user_and_provider(db, user_id, provider).await?;
+
+    info!("Disconnected {} for user {}", provider, user_id);
+
+    Ok(())
+}
+
+/// Revoke a connection's stored token with the provider, logging and returning on any failure.
+async fn revoke_stored_token(
+    config: &Config,
+    connection: &OauthConnectionModel,
+    provider: MeetingProvider,
+) {
+    let user_id = connection.user_id;
+
+    let Some(encryption_key) = config.encryption_key() else {
+        warn!("Cannot revoke {provider} token for user {user_id}: no encryption key configured");
+        return;
+    };
+
+    // Google and Zoom both revoke the whole grant given either token, so prefer the longer-lived
+    // refresh token and fall back to the access token when the connection has none.
+    let stored_token = connection
+        .refresh_token
+        .as_deref()
+        .unwrap_or(&connection.access_token);
+
+    let token = match encryption::decrypt(stored_token, &encryption_key) {
+        Ok(token) => token,
+        Err(e) => {
+            warn!("Failed to decrypt {provider} token for user {user_id}: {e:?}");
+            return;
+        }
+    };
+
+    let result = match create_provider(config, provider) {
+        Ok(oauth_provider) => oauth_provider.revoke_token(&token).await,
+        Err(e) => {
+            warn!("Cannot revoke {provider} token for user {user_id}: {e:?}");
+            return;
+        }
+    };
+
+    match result {
+        Ok(()) => info!("Revoked {provider} token for user {user_id}"),
+        Err(e) => warn!("Failed to revoke {provider} token for user {user_id}: {e:?}"),
+    }
+}
+
+/// Create the OAuth provider implementation backing a meeting provider.
+fn create_provider(config: &Config, provider: MeetingProvider) -> Result<Box<dyn Provider>, Error> {
+    match provider {
+        MeetingProvider::Google => Ok(Box::new(create_google_provider(config)?)),
+        MeetingProvider::Zoom => Ok(Box::new(create_zoom_provider(config)?)),
     }
 }
 
@@ -307,4 +379,73 @@ fn apply_google_fields(model: &mut OauthConnectionModel, user_info: UserInfo) {
 fn apply_zoom_fields(model: &mut OauthConnectionModel, user_info: UserInfo) {
     model.external_account_id = Some(user_info.id);
     model.external_email = Some(user_info.email);
+}
+
+#[cfg(test)]
+#[cfg(feature = "mock")]
+mod tests {
+    use super::*;
+    use sea_orm::{DatabaseBackend, MockDatabase, MockExecResult};
+
+    fn test_model() -> OauthConnectionModel {
+        let now = chrono::Utc::now();
+        OauthConnectionModel {
+            id: Id::new_v4(),
+            user_id: Id::new_v4(),
+            provider: MeetingProvider::Google,
+            external_account_id: None,
+            external_email: Some("coach@example.com".to_string()),
+            access_token: "encrypted-access".to_string(),
+            refresh_token: Some("encrypted-refresh".to_string()),
+            token_expires_at: Some(now.into()),
+            token_type: "Bearer".to_string(),
+            scopes: "openid email".to_string(),
+            created_at: now.into(),
+            updated_at: now.into(),
+        }
+    }
+
+    /// An unusable revoke path must never strand the user in a connected-but-broken state.
+    #[tokio::test]
+    async fn delete_removes_the_connection_even_when_revocation_cannot_run() -> Result<(), Error> {
+        let model = test_model();
+
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            // Our own lookup, then the one entity_api's delete performs.
+            .append_query_results(vec![vec![model.clone()], vec![model.clone()]])
+            .append_exec_results(vec![MockExecResult {
+                last_insert_id: 0,
+                rows_affected: 1,
+            }])
+            .into_connection();
+
+        // A default Config has no encryption key or provider credentials, so revocation bails out.
+        delete_by_user_and_provider(
+            &db,
+            &Config::default(),
+            model.user_id,
+            MeetingProvider::Google,
+        )
+        .await
+    }
+
+    #[tokio::test]
+    async fn delete_errors_when_the_user_has_no_connection_for_the_provider() {
+        let db = MockDatabase::new(DatabaseBackend::Postgres)
+            .append_query_results::<OauthConnectionModel, Vec<OauthConnectionModel>, _>(vec![
+                vec![],
+                vec![],
+            ])
+            .into_connection();
+
+        let result = delete_by_user_and_provider(
+            &db,
+            &Config::default(),
+            Id::new_v4(),
+            MeetingProvider::Google,
+        )
+        .await;
+
+        assert!(result.is_err());
+    }
 }

--- a/domain/src/oauth_connection.rs
+++ b/domain/src/oauth_connection.rs
@@ -4,7 +4,7 @@ use crate::meeting_provider::Provider as MeetingProvider;
 use crate::oauth_connections::Model as OauthConnectionModel;
 use crate::oauth_token_storage::DbOAuthTokenStorage;
 use crate::Id;
-use entity_api::oauth_connection;
+use entity_api::oauth_connection as ConnectionApi;
 use log::*;
 use meeting_auth::oauth::token::{encryption, Manager, Plain};
 use meeting_auth::oauth::UserInfo;
@@ -92,11 +92,11 @@ pub async fn exchange_and_store_tokens(
             )),
         })?;
 
-    let existing = oauth_connection::find_by_user_and_provider(db, user_id, provider).await?;
+    let existing = ConnectionApi::find_by_user_and_provider(db, user_id, provider).await?;
 
     match existing {
         Some(conn) => {
-            oauth_connection::update_tokens(
+            ConnectionApi::update_tokens(
                 db,
                 conn.id,
                 encrypted_access,
@@ -115,7 +115,7 @@ pub async fn exchange_and_store_tokens(
                 encrypted_access,
                 encrypted_refresh,
             );
-            oauth_connection::create(db, model).await?;
+            ConnectionApi::create(db, model).await?;
         }
     }
 
@@ -193,7 +193,7 @@ pub async fn get_valid_access_token(
             );
             // The provider already revoked this grant, so drop the row without a revoke round trip.
             if let Err(del_err) =
-                oauth_connection::delete_by_user_and_provider(db, user_id, provider).await
+                ConnectionApi::delete_by_user_and_provider(db, user_id, provider).await
             {
                 warn!(
                     "Failed to delete revoked OAuth connection for user {}: {:?}",
@@ -215,7 +215,9 @@ pub async fn get_valid_access_token(
 ///
 /// Revocation is best effort. It is attempted first so that a token is never orphaned at the
 /// provider, but a failure is logged rather than propagated: leaving the row behind would strand
-/// the user in a connected-but-broken state with no way to retry.
+/// the user in a connected-but-broken state with no way to retry. In the reverse case, where the
+/// grant is revoked but the delete fails, the next token use fails as `TokenRevoked` and
+/// `get_valid_access_token` drops the row then.
 ///
 /// # Errors
 ///
@@ -226,21 +228,25 @@ pub async fn delete_by_user_and_provider(
     user_id: Id,
     provider: MeetingProvider,
 ) -> Result<(), Error> {
-    if let Some(connection) =
-        oauth_connection::find_by_user_and_provider(db, user_id, provider).await?
-    {
-        revoke_stored_token(config, &connection, provider).await;
-    }
+    let connection = ConnectionApi::get_by_user_and_provider(db, user_id, provider).await?;
 
-    oauth_connection::delete_by_user_and_provider(db, user_id, provider).await?;
+    revoke_stored_tokens(config, &connection, provider).await;
+
+    // Delete by id rather than re-resolving the pair, so a concurrent disconnect that already
+    // removed the row still succeeds instead of surfacing a 404 after a completed revoke.
+    ConnectionApi::delete_by_id(db, connection.id).await?;
 
     info!("Disconnected {} for user {}", provider, user_id);
 
     Ok(())
 }
 
-/// Revoke a connection's stored token with the provider, logging and returning on any failure.
-async fn revoke_stored_token(
+/// Revoke a connection's stored grant with the provider, logging and returning on any failure.
+///
+/// Tries the refresh token first, since it outlives the access token, and falls back to the access
+/// token. Google revokes the whole grant given either, while Zoom documents only the access token,
+/// so trying both is what makes one code path correct for both providers.
+async fn revoke_stored_tokens(
     config: &Config,
     connection: &OauthConnectionModel,
     provider: MeetingProvider,
@@ -252,33 +258,41 @@ async fn revoke_stored_token(
         return;
     };
 
-    // Google and Zoom both revoke the whole grant given either token, so prefer the longer-lived
-    // refresh token and fall back to the access token when the connection has none.
-    let stored_token = connection
-        .refresh_token
-        .as_deref()
-        .unwrap_or(&connection.access_token);
+    let tokens = revocable_tokens(connection, &encryption_key);
+    if tokens.is_empty() {
+        warn!("Cannot revoke {provider} token for user {user_id}: no token could be decrypted");
+        return;
+    }
 
-    let token = match encryption::decrypt(stored_token, &encryption_key) {
-        Ok(token) => token,
-        Err(e) => {
-            warn!("Failed to decrypt {provider} token for user {user_id}: {e:?}");
-            return;
-        }
-    };
-
-    let result = match create_provider(config, provider) {
-        Ok(oauth_provider) => oauth_provider.revoke_token(&token).await,
+    let oauth_provider = match create_provider(config, provider) {
+        Ok(oauth_provider) => oauth_provider,
         Err(e) => {
             warn!("Cannot revoke {provider} token for user {user_id}: {e:?}");
             return;
         }
     };
 
-    match result {
-        Ok(()) => info!("Revoked {provider} token for user {user_id}"),
-        Err(e) => warn!("Failed to revoke {provider} token for user {user_id}: {e:?}"),
+    for token in &tokens {
+        match oauth_provider.revoke_token(token).await {
+            Ok(()) => {
+                info!("Revoked {provider} grant for user {user_id}");
+                return;
+            }
+            Err(e) => warn!("Failed to revoke {provider} token for user {user_id}: {e:?}"),
+        }
     }
+}
+
+/// The connection's decryptable tokens, refresh first, skipping any that fail to decrypt.
+fn revocable_tokens(connection: &OauthConnectionModel, encryption_key: &str) -> Vec<String> {
+    [
+        connection.refresh_token.as_deref(),
+        Some(connection.access_token.as_str()),
+    ]
+    .into_iter()
+    .flatten()
+    .filter_map(|stored| encryption::decrypt(stored, encryption_key).ok())
+    .collect()
 }
 
 /// Create the OAuth provider implementation backing a meeting provider.
@@ -405,21 +419,24 @@ mod tests {
         }
     }
 
+    /// 32 bytes hex, matching what `encryption::encrypt` expects.
+    const TEST_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+
     /// An unusable revoke path must never strand the user in a connected-but-broken state.
     #[tokio::test]
     async fn delete_removes_the_connection_even_when_revocation_cannot_run() -> Result<(), Error> {
         let model = test_model();
 
         let db = MockDatabase::new(DatabaseBackend::Postgres)
-            // Our own lookup, then the one entity_api's delete performs.
-            .append_query_results(vec![vec![model.clone()], vec![model.clone()]])
+            .append_query_results(vec![vec![model.clone()]])
             .append_exec_results(vec![MockExecResult {
                 last_insert_id: 0,
                 rows_affected: 1,
             }])
             .into_connection();
 
-        // A default Config has no encryption key or provider credentials, so revocation bails out.
+        // Neither stored token is valid ciphertext, so revocation bails before any network call
+        // regardless of what the ambient environment configures.
         delete_by_user_and_provider(
             &db,
             &Config::default(),
@@ -429,11 +446,51 @@ mod tests {
         .await
     }
 
+    #[test]
+    fn revocable_tokens_prefers_the_refresh_token() {
+        let model = OauthConnectionModel {
+            access_token: encryption::encrypt("access", TEST_KEY).unwrap(),
+            refresh_token: Some(encryption::encrypt("refresh", TEST_KEY).unwrap()),
+            ..test_model()
+        };
+
+        assert_eq!(
+            revocable_tokens(&model, TEST_KEY),
+            vec!["refresh", "access"]
+        );
+    }
+
+    #[test]
+    fn revocable_tokens_falls_back_to_the_access_token() {
+        let model = OauthConnectionModel {
+            access_token: encryption::encrypt("access", TEST_KEY).unwrap(),
+            refresh_token: None,
+            ..test_model()
+        };
+
+        assert_eq!(revocable_tokens(&model, TEST_KEY), vec!["access"]);
+    }
+
+    #[test]
+    fn revocable_tokens_skips_what_it_cannot_decrypt() {
+        let model = OauthConnectionModel {
+            access_token: encryption::encrypt("access", TEST_KEY).unwrap(),
+            refresh_token: Some("not-ciphertext".to_string()),
+            ..test_model()
+        };
+
+        assert_eq!(revocable_tokens(&model, TEST_KEY), vec!["access"]);
+    }
+
+    #[test]
+    fn revocable_tokens_is_empty_when_nothing_decrypts() {
+        assert!(revocable_tokens(&test_model(), TEST_KEY).is_empty());
+    }
+
     #[tokio::test]
     async fn delete_errors_when_the_user_has_no_connection_for_the_provider() {
         let db = MockDatabase::new(DatabaseBackend::Postgres)
             .append_query_results::<OauthConnectionModel, Vec<OauthConnectionModel>, _>(vec![
-                vec![],
                 vec![],
             ])
             .into_connection();

--- a/domain/src/oauth_connection.rs
+++ b/domain/src/oauth_connection.rs
@@ -422,6 +422,20 @@ mod tests {
     /// 32 bytes hex, matching what `encryption::encrypt` expects.
     const TEST_KEY: &str = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
 
+    /// Every statement the mock saw, flattened across transactions.
+    fn statements(db: DatabaseConnection) -> Vec<String> {
+        db.into_transaction_log()
+            .iter()
+            .flat_map(|transaction| {
+                transaction
+                    .statements()
+                    .iter()
+                    .map(|statement| statement.sql.clone())
+                    .collect::<Vec<_>>()
+            })
+            .collect()
+    }
+
     /// An unusable revoke path must never strand the user in a connected-but-broken state.
     #[tokio::test]
     async fn delete_removes_the_connection_even_when_revocation_cannot_run() -> Result<(), Error> {
@@ -435,15 +449,23 @@ mod tests {
             }])
             .into_connection();
 
-        // Neither stored token is valid ciphertext, so revocation bails before any network call
-        // regardless of what the ambient environment configures.
+        // Revocation cannot reach the network here whichever way the ambient environment is
+        // configured: without an encryption key it bails before decrypting, and with one it bails
+        // because neither stored token is valid ciphertext.
         delete_by_user_and_provider(
             &db,
             &Config::default(),
             model.user_id,
             MeetingProvider::Google,
         )
-        .await
+        .await?;
+
+        assert!(
+            statements(db).iter().any(|sql| sql.starts_with("DELETE")),
+            "the connection row must be deleted even when revocation cannot run"
+        );
+
+        Ok(())
     }
 
     #[test]

--- a/domain/src/oauth_connection.rs
+++ b/domain/src/oauth_connection.rs
@@ -219,6 +219,9 @@ pub async fn get_valid_access_token(
 /// grant is revoked but the delete fails, the next token use fails as `TokenRevoked` and
 /// `get_valid_access_token` drops the row then.
 ///
+/// A refresh or reconnect that writes to the row while revocation is in flight is deleted along
+/// with it: the grant it belongs to has already been revoked, so the disconnect wins.
+///
 /// # Errors
 ///
 /// Returns `RecordNotFound` when the user has no connection for `provider`.

--- a/entity_api/src/oauth_connection.rs
+++ b/entity_api/src/oauth_connection.rs
@@ -114,6 +114,15 @@ pub async fn update_tokens(
     Ok(active_model.update(db).await?.try_into_model()?)
 }
 
+/// Deletes an OAuth connection by ID, succeeding when the row is already gone
+pub async fn delete_by_id(db: &DatabaseConnection, id: Id) -> Result<(), Error> {
+    debug!("Deleting OAuth connection: {id}");
+
+    Entity::delete_by_id(id).exec(db).await?;
+
+    Ok(())
+}
+
 /// Deletes an OAuth connection by user ID and provider (disconnect)
 pub async fn delete_by_user_and_provider(
     db: &DatabaseConnection,

--- a/meeting-auth/src/oauth/providers/zoom.rs
+++ b/meeting-auth/src/oauth/providers/zoom.rs
@@ -277,9 +277,11 @@ impl crate::oauth::Provider for Provider {
     async fn revoke_token(&self, token: &str) -> Result<(), Error> {
         debug!("Revoking Zoom token");
 
+        // Unlike Google's, Zoom's revoke endpoint authenticates the client with HTTP Basic.
         let response = self
             .http_client
             .post(REVOKE_URL)
+            .basic_auth(&self.client_id, Some(self.client_secret.expose_secret()))
             .form(&[("token", token)])
             .send()
             .await

--- a/web/src/controller/oauth_controller.rs
+++ b/web/src/controller/oauth_controller.rs
@@ -151,6 +151,9 @@ pub async fn read(
 /// DELETE /oauth/connections/:provider
 ///
 /// Disconnects (deletes) the OAuth connection for the authenticated user and given provider.
+///
+/// Revokes the stored grant with the provider before deleting the connection. Revocation is best
+/// effort: the connection is removed, and this endpoint reports success, even when it fails.
 #[utoipa::path(
     delete,
     path = "/oauth/connections/{provider}",
@@ -172,8 +175,13 @@ pub async fn delete(
     State(app_state): State<AppState>,
     Path(provider): Path<Provider>,
 ) -> Result<impl IntoResponse, Error> {
-    oauth_connection::delete_by_user_and_provider(app_state.db_conn_ref(), user.id, provider)
-        .await?;
+    oauth_connection::delete_by_user_and_provider(
+        app_state.db_conn_ref(),
+        &app_state.config,
+        user.id,
+        provider,
+    )
+    .await?;
 
     Ok(Json(ApiResponse::<()>::no_content(
         StatusCode::NO_CONTENT.into(),


### PR DESCRIPTION
## Description

Disconnecting an OAuth integration deleted the `oauth_connections` row without telling the provider. Tokens stayed valid at the provider and the grant remained listed on the coach's account permissions page, so the disconnect was a lie from the user's point of view. `revoke_token()` was already implemented and had zero callers.

Blocks Google production verification for `meetings.space.created`, whose submitted scope justification states that tokens are revoked on disconnect. **That claim is now verified true** (see Testing Strategy).

Scope note: this fixes the Google path, which is verified end to end. It also corrects a Zoom bug found along the way, but Zoom revocation ships **unverified** because Zoom OAuth is not configured in any environment. Details below.

### Changes
* `domain::oauth_connection::delete_by_user_and_provider` is now a real domain function instead of a passthrough re-export. It revokes the stored grant, then deletes the row.
* Revocation is best effort. Missing encryption key, decrypt failure, unbuildable credentials, and a rejecting or unreachable endpoint are all logged and the row is deleted anyway. Leaving it behind would strand the user in a connected-but-broken state with no way to retry.
* Tries the refresh token, then the access token. Google accepts either; Zoom documents only the access token. Trying both keeps one code path correct for both providers.
* Resolves the connection once and deletes by id, closing a window where a concurrent disconnect returned 404 to the caller after the grant was already revoked.
* The already-revoked cleanup path in `get_valid_access_token` calls `entity_api` directly, so it makes no pointless revoke round trip.
* **Zoom revoke sent no client credentials at all**, where Zoom authenticates that endpoint with HTTP Basic. Unreachable until `revoke_token` gained a caller, so it had never been exercised. Fixed, but see the Zoom note under Testing Strategy before relying on it.
* No wire-format change. Revoke failures are deliberately not surfaced, so the client still sees success.

### Testing Strategy

Six domain tests. The load-bearing one asserts a `DELETE` actually runs when revocation cannot, verified by mutation; four cover token preference, fallback, and undecryptable input. Mock suite green (entity_api 283, domain 246, web 162); clippy and fmt clean.

No automated test reaches the wire, since providers are built from config rather than injected, so manual verification is the only proof revocation works. Plan at `docs/test-plans/oauth_disconnect_revokes_token_manual_testing.md`.

* **Google: PASS, verified 2026-08-11.** Connected Google, confirmed the app was listed at https://myaccount.google.com/permissions, disconnected, and the grant was gone from that page. This is the acceptance criterion behind the Google submission.
* **Zoom: BLOCKED, ships unverified.** `GET /oauth/zoom/authorize` returns 500 because `ZOOM_CLIENT_ID`, `ZOOM_CLIENT_SECRET` and `ZOOM_REDIRECT_URI` appear in **no** file in this repository, while their Google counterparts are in six. There is no Zoom connection to disconnect, so revocation cannot be exercised. Pre-existing and unrelated to this PR: Zoom OAuth has never been usable in any environment. Enabling it needs a Zoom Marketplace app and those three variables wired through every layer, tracked separately.

### Concerns
* A failed revoke is visible only as a `warn!`. Correct against blocking disconnect, but a broken revoke path fails silently and looks identical to success from the client, which is how the Zoom bug survived. Worth a log alert on `Failed to revoke`.
* The Zoom Basic auth fix follows Zoom's documented requirement but has never been observed working. It is strictly better than sending no credentials, and it should be re-tested when Zoom OAuth is configured.
* Anyone who disconnected before this ships still has a live grant and no row left to revoke from. They would have to revoke manually from their provider's account permissions page.