### PR TITLE
Still notify participants when a legacy series occurrence cannot be addressed

### DIFF
--- a/domain/src/emails.rs
+++ b/domain/src/emails.rs
@@ -658,7 +658,7 @@ async fn send_session_email_to_recipient(
     to: &Recipient<'_>,
     session: &coaching_sessions::Model,
     organization: &organizations::Model,
-    ics_body: &str,
+    ics_body: Option<&str>,
     reschedule: Option<&RescheduleVars>,
 ) -> Result<(), Error> {
     let recipient = to.user;
@@ -684,7 +684,7 @@ async fn send_session_email_to_recipient(
         .add_variable("session_duration", session_duration.as_str())
         .add_variable("session_url", session_url.as_str())
         .add_optional_variable("session_or_series", reschedule.map(|r| r.session_or_series))
-        .add_ics_attachment(ics_body, &ical::Method::Request);
+        .add_optional_ics_attachment(ics_body, &ical::Method::Request);
 
     // The reschedule template declares both keys, so they ship together or not at all.
     let email_request = match reschedule {
@@ -831,9 +831,14 @@ async fn send_single_session_invite_email<N: EmailNotification>(
     });
 
     let dtstamp = chrono::Utc::now().naive_utc();
-    // A session inside a series is addressed as an override of its occurrence.
-    let ics_body = match session.coaching_session_series_id {
-        Some(series_id) => build_occurrence_reschedule_ics(
+    // A session inside a series is addressed as an override of its occurrence. One that
+    // predates `ical_recurrence_id` has no such address, so it goes out without an
+    // attachment rather than not going out at all.
+    let ics_body = match (
+        session.coaching_session_series_id,
+        session.ical_recurrence_id,
+    ) {
+        (Some(series_id), Some(_)) => Some(build_occurrence_reschedule_ics(
             coach,
             coachee,
             session,
@@ -841,10 +846,19 @@ async fn send_single_session_invite_email<N: EmailNotification>(
             organization,
             description,
             dtstamp,
-        )?,
-        None => {
-            build_session_invite_ics(coach, coachee, session, organization, description, dtstamp)?
+        )?),
+        (Some(_), None) => {
+            warn_unaddressable(session);
+            None
         }
+        (None, _) => Some(build_session_invite_ics(
+            coach,
+            coachee,
+            session,
+            organization,
+            description,
+            dtstamp,
+        )?),
     };
 
     // Email to coachee: "Your coach, ... has a session with you"
@@ -857,7 +871,7 @@ async fn send_single_session_invite_email<N: EmailNotification>(
         },
         session,
         organization,
-        &ics_body,
+        ics_body.as_deref(),
         reschedule,
     )
     .await
@@ -879,7 +893,7 @@ async fn send_single_session_invite_email<N: EmailNotification>(
         },
         session,
         organization,
-        &ics_body,
+        ics_body.as_deref(),
         reschedule,
     )
     .await
@@ -1027,14 +1041,6 @@ pub async fn notify_session_scheduled(
     config: &Config,
     session: &coaching_sessions::Model,
 ) {
-    if lacks_occurrence_address(session) {
-        warn!(
-            "Skipping scheduled invite for session {}: series member has no ical_recurrence_id",
-            session.id
-        );
-        return;
-    }
-
     let result: Result<(), Error> = async {
         let relationship =
             coaching_relationship::find_by_id(db, session.coaching_relationship_id).await?;
@@ -1054,10 +1060,17 @@ pub async fn notify_session_scheduled(
     }
 }
 
-/// True when a session belongs to a series but predates `ical_recurrence_id`, so no
-/// valid `RECURRENCE-ID` exists. Sending anything would address the wrong occurrence.
-fn lacks_occurrence_address(session: &coaching_sessions::Model) -> bool {
-    session.coaching_session_series_id.is_some() && session.ical_recurrence_id.is_none()
+/// A series member that predates `ical_recurrence_id` has no valid `RECURRENCE-ID`, so no
+/// invite can address its occurrence. The email still goes out; only the attachment is
+/// withheld. These sessions were materialized before invites existed, so no calendar holds
+/// an event for them and a `CANCEL` or update naming the series `UID` would act on the
+/// wrong instance.
+fn warn_unaddressable(session: &coaching_sessions::Model) {
+    warn!(
+        "Sending email without an invite for session {}: series member predates \
+         ical_recurrence_id, so its occurrence cannot be addressed",
+        session.id
+    );
 }
 
 /// Orchestrate sending session-rescheduled emails (best-effort).
@@ -1073,14 +1086,6 @@ pub async fn notify_session_rescheduled(
     session: &coaching_sessions::Model,
     previous_start: NaiveDateTime,
 ) {
-    if lacks_occurrence_address(session) {
-        warn!(
-            "Skipping reschedule invite for session {}: series member has no ical_recurrence_id",
-            session.id
-        );
-        return;
-    }
-
     let result: Result<(), Error> = async {
         let relationship =
             coaching_relationship::find_by_id(db, session.coaching_relationship_id).await?;
@@ -1179,7 +1184,7 @@ async fn send_session_cancelled_email_to_recipient(
     other_user_role: &str,
     session: &coaching_sessions::Model,
     organization: &organizations::Model,
-    ics_body: &str,
+    ics_body: Option<&str>,
 ) -> Result<(), Error> {
     let (session_date, session_time) = format_session_date_time(session.date, &recipient.timezone);
 
@@ -1197,7 +1202,7 @@ async fn send_session_cancelled_email_to_recipient(
         .add_variable("organization_name", organization.name.as_str())
         .add_variable("session_date", session_date.as_str())
         .add_variable("session_time", session_time.as_str())
-        .add_ics_attachment(ics_body, &ical::Method::Cancel)
+        .add_optional_ics_attachment(ics_body, &ical::Method::Cancel)
         .build()
         .await?;
 
@@ -1222,8 +1227,11 @@ async fn send_session_cancelled_email(
 
     let dtstamp = chrono::Utc::now().naive_utc();
     // A session inside a series is addressed as an override of its occurrence.
-    let ics_body = match session.coaching_session_series_id {
-        Some(series_id) => build_occurrence_cancel_ics(
+    let ics_body = match (
+        session.coaching_session_series_id,
+        session.ical_recurrence_id,
+    ) {
+        (Some(series_id), Some(_)) => Some(build_occurrence_cancel_ics(
             coach,
             coachee,
             session,
@@ -1231,15 +1239,19 @@ async fn send_session_cancelled_email(
             organization,
             SESSION_CANCELLED_DESCRIPTION.to_string(),
             dtstamp,
-        )?,
-        None => build_session_cancel_ics(
+        )?),
+        (Some(_), None) => {
+            warn_unaddressable(session);
+            None
+        }
+        (None, _) => Some(build_session_cancel_ics(
             coach,
             coachee,
             session,
             organization,
             SESSION_CANCELLED_DESCRIPTION.to_string(),
             dtstamp,
-        )?,
+        )?),
     };
 
     if let Err(e) = send_session_cancelled_email_to_recipient(
@@ -1249,7 +1261,7 @@ async fn send_session_cancelled_email(
         "coach",
         session,
         organization,
-        &ics_body,
+        ics_body.as_deref(),
     )
     .await
     {
@@ -1266,7 +1278,7 @@ async fn send_session_cancelled_email(
         "coachee",
         session,
         organization,
-        &ics_body,
+        ics_body.as_deref(),
     )
     .await
     {
@@ -1292,14 +1304,6 @@ pub async fn notify_session_cancelled(
     if session.date < chrono::Utc::now().naive_utc() {
         return;
     }
-    if lacks_occurrence_address(session) {
-        warn!(
-            "Skipping cancellation for session {}: series member has no ical_recurrence_id",
-            session.id
-        );
-        return;
-    }
-
     let result: Result<(), Error> = async {
         let relationship =
             coaching_relationship::find_by_id(db, session.coaching_relationship_id).await?;

--- a/domain/src/emails.rs
+++ b/domain/src/emails.rs
@@ -834,32 +834,24 @@ async fn send_single_session_invite_email<N: EmailNotification>(
     // A session inside a series is addressed as an override of its occurrence. One that
     // predates `ical_recurrence_id` has no such address, so it goes out without an
     // attachment rather than not going out at all.
-    let ics_body = match (
-        session.coaching_session_series_id,
-        session.ical_recurrence_id,
-    ) {
-        (Some(series_id), Some(_)) => Some(build_occurrence_reschedule_ics(
-            coach,
-            coachee,
-            session,
-            series_id,
-            organization,
-            description,
-            dtstamp,
-        )?),
-        (Some(_), None) => {
-            warn_unaddressable(session);
-            None
-        }
-        (None, _) => Some(build_session_invite_ics(
-            coach,
-            coachee,
-            session,
-            organization,
-            description,
-            dtstamp,
-        )?),
-    };
+    let ics_body = build_session_ics(
+        session,
+        description,
+        |series_id, description| {
+            build_occurrence_reschedule_ics(
+                coach,
+                coachee,
+                session,
+                series_id,
+                organization,
+                description,
+                dtstamp,
+            )
+        },
+        |description| {
+            build_session_invite_ics(coach, coachee, session, organization, description, dtstamp)
+        },
+    )?;
 
     // Email to coachee: "Your coach, ... has a session with you"
     if let Err(e) = send_session_email_to_recipient(
@@ -1060,6 +1052,32 @@ pub async fn notify_session_scheduled(
     }
 }
 
+/// The invite for one session, or `None` when its occurrence cannot be addressed.
+///
+/// A session inside a series is addressed as an override of its occurrence; a standalone
+/// one by its own `UID`. A series member materialized before `ical_recurrence_id` existed
+/// has neither, so it goes out with no attachment rather than not going out at all.
+///
+/// `description` is passed through to whichever builder runs, so it moves exactly once.
+fn build_session_ics(
+    session: &coaching_sessions::Model,
+    description: String,
+    build_occurrence: impl FnOnce(Id, String) -> Result<String, Error>,
+    build_standalone: impl FnOnce(String) -> Result<String, Error>,
+) -> Result<Option<String>, Error> {
+    match (
+        session.coaching_session_series_id,
+        session.ical_recurrence_id,
+    ) {
+        (Some(series_id), Some(_)) => build_occurrence(series_id, description).map(Some),
+        (Some(_), None) => {
+            warn_unaddressable(session);
+            Ok(None)
+        }
+        (None, _) => build_standalone(description).map(Some),
+    }
+}
+
 /// A series member that predates `ical_recurrence_id` has no valid `RECURRENCE-ID`, so no
 /// invite can address its occurrence. The email still goes out; only the attachment is
 /// withheld. These sessions were materialized before invites existed, so no calendar holds
@@ -1179,13 +1197,12 @@ fn build_occurrence_cancel_ics(
 /// variables than the invite sends: no `session_url` (the row is gone) and no duration.
 async fn send_session_cancelled_email_to_recipient(
     email_config: &ResolvedEmailConfig,
-    recipient: &users::Model,
-    other_user: &users::Model,
-    other_user_role: &str,
+    to: &Recipient<'_>,
     session: &coaching_sessions::Model,
     organization: &organizations::Model,
     ics_body: Option<&str>,
 ) -> Result<(), Error> {
+    let recipient = to.user;
     let (session_date, session_time) = format_session_date_time(session.date, &recipient.timezone);
 
     let email_request = SendEmailRequestBuilder::new()
@@ -1196,9 +1213,9 @@ async fn send_session_cancelled_email_to_recipient(
         )
         .template_id(&email_config.template_id)
         .add_variable("first_name", recipient.first_name.as_str())
-        .add_variable("other_user_first_name", other_user.first_name.as_str())
-        .add_variable("other_user_last_name", other_user.last_name.as_str())
-        .add_variable("other_user_role", other_user_role)
+        .add_variable("other_user_first_name", to.other_user.first_name.as_str())
+        .add_variable("other_user_last_name", to.other_user.last_name.as_str())
+        .add_variable("other_user_role", to.other_user_role)
         .add_variable("organization_name", organization.name.as_str())
         .add_variable("session_date", session_date.as_str())
         .add_variable("session_time", session_time.as_str())
@@ -1227,38 +1244,32 @@ async fn send_session_cancelled_email(
 
     let dtstamp = chrono::Utc::now().naive_utc();
     // A session inside a series is addressed as an override of its occurrence.
-    let ics_body = match (
-        session.coaching_session_series_id,
-        session.ical_recurrence_id,
-    ) {
-        (Some(series_id), Some(_)) => Some(build_occurrence_cancel_ics(
-            coach,
-            coachee,
-            session,
-            series_id,
-            organization,
-            SESSION_CANCELLED_DESCRIPTION.to_string(),
-            dtstamp,
-        )?),
-        (Some(_), None) => {
-            warn_unaddressable(session);
-            None
-        }
-        (None, _) => Some(build_session_cancel_ics(
-            coach,
-            coachee,
-            session,
-            organization,
-            SESSION_CANCELLED_DESCRIPTION.to_string(),
-            dtstamp,
-        )?),
-    };
+    let ics_body = build_session_ics(
+        session,
+        SESSION_CANCELLED_DESCRIPTION.to_string(),
+        |series_id, description| {
+            build_occurrence_cancel_ics(
+                coach,
+                coachee,
+                session,
+                series_id,
+                organization,
+                description,
+                dtstamp,
+            )
+        },
+        |description| {
+            build_session_cancel_ics(coach, coachee, session, organization, description, dtstamp)
+        },
+    )?;
 
     if let Err(e) = send_session_cancelled_email_to_recipient(
         &email_config,
-        coachee,
-        coach,
-        "coach",
+        &Recipient {
+            user: coachee,
+            other_user: coach,
+            other_user_role: "coach",
+        },
         session,
         organization,
         ics_body.as_deref(),
@@ -1273,9 +1284,11 @@ async fn send_session_cancelled_email(
 
     if let Err(e) = send_session_cancelled_email_to_recipient(
         &email_config,
-        coach,
-        coachee,
-        "coachee",
+        &Recipient {
+            user: coach,
+            other_user: coachee,
+            other_user_role: "coachee",
+        },
         session,
         organization,
         ics_body.as_deref(),

--- a/domain/src/emails_tests.rs
+++ b/domain/src/emails_tests.rs
@@ -77,6 +77,12 @@ impl IcsCapture {
         }
     }
 
+    /// The captured `.ics`, or `None` when the send carried no attachment.
+    #[cfg(feature = "mock")]
+    fn captured(&self) -> Option<String> {
+        self.0.lock().unwrap().clone()
+    }
+
     fn ics(&self) -> String {
         self.0
             .lock()
@@ -793,6 +799,20 @@ fn reject_template_variables(keys: &'static [&'static str]) -> impl Fn(&mockito:
                 keys.iter()
                     .all(|key| payload["template"]["variables"].get(key).is_none())
             })
+            .unwrap_or(false)
+    }
+}
+
+/// Asserts the payload carries no attachment. mockito has no negative body matcher, so
+/// absence rides on `match_request`; an unreadable or unparsable body fails the match.
+#[cfg(feature = "mock")]
+fn reject_attachments() -> impl Fn(&mockito::Request) -> bool {
+    move |request| {
+        request
+            .utf8_lossy_body()
+            .ok()
+            .and_then(|body| serde_json::from_str::<serde_json::Value>(&body).ok())
+            .map(|payload| payload.get("attachments").is_none())
             .unwrap_or(false)
     }
 }
@@ -1528,29 +1548,110 @@ fn test_standalone_session_ics_carries_no_recurrence_id() {
     assert!(!cancel.contains("RECURRENCE-ID"));
 }
 
-/// A series member with no `ical_recurrence_id` has no valid slot to address, so the
-/// guard must fire before any lookup and nothing may be sent.
+/// A series member that predates `ical_recurrence_id` cannot have its occurrence
+/// addressed, but the humans still need telling. The email goes out; only the `.ics` is
+/// withheld. This is the production case: series materialized before invites existed.
 #[cfg(feature = "mock")]
 #[tokio::test]
-async fn test_notify_session_cancelled_skips_series_member_without_recurrence_id() {
+async fn test_cancelling_a_legacy_series_member_emails_without_an_invite() {
+    let mut server = setup_test_server().await;
+    let config = create_full_config_with_mock(&server.url());
+    let capture = IcsCapture::default();
+
+    let coach = create_test_user_with("Alex", "Smith", "alex@example.com", "UTC");
+    let coachee = create_test_user_with("Jane", "Doe", "jane@example.com", "UTC");
+    let org = create_test_organization();
+
+    let mut session = create_test_session();
+    session.coaching_session_series_id = Some(Id::new_v4());
+    session.ical_recurrence_id = None;
+
+    // Both recipients still get mailed, and neither payload carries an attachment.
+    let mock = server
+        .mock("POST", "/emails")
+        .match_request(reject_attachments())
+        .match_request(capture.recorder())
+        .with_status(200)
+        .with_body(r#"{"id":"email_test"}"#)
+        .expect(2)
+        .create_async()
+        .await;
+
+    let result = send_session_cancelled_email(&config, &coach, &coachee, &session, &org).await;
+    assert!(result.is_ok());
+    mock.assert_async().await;
+
+    assert!(
+        capture.captured().is_none(),
+        "a session whose occurrence cannot be addressed must carry no invite"
+    );
+}
+
+/// The production regression, pinned at the layer where it occurred.
+///
+/// `notify_session_cancelled` used to return before any lookup when a series member had no
+/// `ical_recurrence_id`, so the coach and coachee were told nothing at all. With no mock
+/// results appended, the old code produced an empty transaction log; the new code must at
+/// least attempt the participant lookup. This is the exact inverse of the assertion the
+/// previous test made.
+///
+/// Driving the notify entry point matters: an earlier version of this test called
+/// `send_session_cancelled_email` directly and stayed green when the early return was put
+/// back. The full path cannot be mocked end to end because `user::find_by_id` uses
+/// `find_with_related`, which MockDatabase cannot express, so the send itself is covered
+/// separately by `test_cancelling_a_legacy_series_member_emails_without_an_invite`.
+#[cfg(feature = "mock")]
+#[tokio::test]
+async fn test_notify_session_cancelled_no_longer_short_circuits_a_legacy_series_member() {
     use sea_orm::{DatabaseBackend, MockDatabase};
 
     let server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
+
     let mut session = create_test_session();
     session.coaching_session_series_id = Some(Id::new_v4());
     session.ical_recurrence_id = None;
-    // Future-dated so the past-session guard cannot be what stops the send.
+    // Future-dated, so the past-session guard cannot be what decides the outcome.
     session.date = chrono::Utc::now().naive_utc() + chrono::Duration::days(7);
 
-    // Zero appended results: any query would panic or error rather than pass.
     let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
 
     notify_session_cancelled(&db, &config, &session).await;
 
     assert!(
-        db.into_transaction_log().is_empty(),
-        "a series member without a RECURRENCE-ID must return before any statement runs"
+        !db.into_transaction_log().is_empty(),
+        "a series member without a RECURRENCE-ID must still be looked up and emailed, \
+         not skipped before any statement runs"
+    );
+}
+
+/// The same regression on the other two entry points. All three shared the early return,
+/// so all three need the guard against it coming back.
+#[cfg(feature = "mock")]
+#[tokio::test]
+async fn test_scheduled_and_rescheduled_no_longer_short_circuit_a_legacy_series_member() {
+    use sea_orm::{DatabaseBackend, MockDatabase};
+
+    let server = setup_test_server().await;
+    let config = create_full_config_with_mock(&server.url());
+
+    let mut session = create_test_session();
+    session.coaching_session_series_id = Some(Id::new_v4());
+    session.ical_recurrence_id = None;
+    session.date = chrono::Utc::now().naive_utc() + chrono::Duration::days(7);
+
+    let scheduled_db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+    notify_session_scheduled(&scheduled_db, &config, &session).await;
+    assert!(
+        !scheduled_db.into_transaction_log().is_empty(),
+        "scheduled must not skip a legacy series member"
+    );
+
+    let rescheduled_db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
+    notify_session_rescheduled(&rescheduled_db, &config, &session, session.date).await;
+    assert!(
+        !rescheduled_db.into_transaction_log().is_empty(),
+        "rescheduled must not skip a legacy series member"
     );
 }
 

--- a/domain/src/emails_tests.rs
+++ b/domain/src/emails_tests.rs
@@ -4,6 +4,8 @@ use base64::engine::general_purpose::STANDARD;
 use base64::Engine;
 use chrono::NaiveDate;
 use mockito::{Server, ServerGuard};
+#[cfg(feature = "mock")]
+use sea_orm::{DatabaseBackend, MockDatabase};
 use service::config::Config;
 #[cfg(feature = "mock")]
 use std::collections::BTreeSet;
@@ -590,8 +592,6 @@ fn test_build_session_invite_ics_bumped_sequence() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_session_scheduled_email_variables() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let mut server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
 
@@ -687,8 +687,6 @@ async fn test_send_session_scheduled_email_variables() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_session_rescheduled_email() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let mut server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
 
@@ -778,8 +776,6 @@ async fn test_send_session_rescheduled_email() {
 /// Loaders for the single-session `.ics` description: topics, goals, actions.
 #[cfg(feature = "mock")]
 fn mock_description_loaders() -> DatabaseConnection {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     MockDatabase::new(DatabaseBackend::Postgres)
         .append_query_results::<entity::coaching_session_topics::Model, _, _>(vec![vec![]])
         .append_query_results::<entity::goals::Model, _, _>(vec![vec![]])
@@ -1587,6 +1583,60 @@ async fn test_cancelling_a_legacy_series_member_emails_without_an_invite() {
     );
 }
 
+/// The scheduled and rescheduled sends, for a series member whose occurrence cannot be
+/// addressed. Both must mail each participant and neither may attach an invite. These
+/// exist because the transaction-log tests below only prove the notify entry points stopped
+/// short-circuiting; they do not prove an email actually leaves with no attachment.
+#[cfg(feature = "mock")]
+#[tokio::test]
+async fn test_scheduling_and_rescheduling_a_legacy_series_member_omit_the_invite() {
+    let mut server = setup_test_server().await;
+    let config = create_full_config_with_mock(&server.url());
+
+    let coach = create_test_user_with("Alex", "Smith", "alex@example.com", "UTC");
+    let coachee = create_test_user_with("Jane", "Doe", "jane@example.com", "UTC");
+    let org = create_test_organization();
+
+    let mut session = create_test_session();
+    session.coaching_session_series_id = Some(Id::new_v4());
+    session.ical_recurrence_id = None;
+
+    // Two sends per flow, four in total, none carrying an attachment.
+    let mock = server
+        .mock("POST", "/emails")
+        .match_request(reject_attachments())
+        .with_status(200)
+        .with_body(r#"{"id":"email_test"}"#)
+        .expect(4)
+        .create_async()
+        .await;
+
+    let scheduled = send_session_scheduled_email(
+        &mock_description_loaders(),
+        &config,
+        &coach,
+        &coachee,
+        &session,
+        &org,
+    )
+    .await;
+    assert!(scheduled.is_ok());
+
+    let rescheduled = send_session_rescheduled_email(
+        &mock_description_loaders(),
+        &config,
+        &coach,
+        &coachee,
+        &session,
+        &org,
+        session.date - chrono::Duration::days(1),
+    )
+    .await;
+    assert!(rescheduled.is_ok());
+
+    mock.assert_async().await;
+}
+
 /// The production regression, pinned at the layer where it occurred.
 ///
 /// `notify_session_cancelled` used to return before any lookup when a series member had no
@@ -1603,8 +1653,6 @@ async fn test_cancelling_a_legacy_series_member_emails_without_an_invite() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_notify_session_cancelled_no_longer_short_circuits_a_legacy_series_member() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
 
@@ -1630,8 +1678,6 @@ async fn test_notify_session_cancelled_no_longer_short_circuits_a_legacy_series_
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_scheduled_and_rescheduled_no_longer_short_circuit_a_legacy_series_member() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
 
@@ -1751,8 +1797,6 @@ async fn test_send_occurrence_cancelled_email_uses_session_template() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_notify_session_cancelled_skips_past_session() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
     let mut session = create_test_session();
@@ -1775,8 +1819,6 @@ async fn test_notify_session_cancelled_skips_past_session() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_session_scheduled_email_missing_template_id() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     // Config has an API key and frontend base URL but no session-scheduled
     // template id — mirrors the welcome/action missing-template-id tests.
     // Fails at config resolution, before any loader query runs.
@@ -2245,8 +2287,6 @@ fn test_build_series_invite_ics_carries_bumped_sequence() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_recurring_sessions_scheduled_email_personalization() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let mut server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
 
@@ -2334,8 +2374,6 @@ async fn test_send_recurring_sessions_scheduled_email_personalization() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_recurring_sessions_rescheduled_email() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let mut server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
 
@@ -2429,8 +2467,6 @@ async fn test_send_recurring_sessions_rescheduled_email() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_recurring_sessions_rescheduled_email_previous_when_comes_from_old_rule() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let mut server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
 
@@ -2529,8 +2565,6 @@ fn create_test_series_with_rule(rule: serde_json::Value) -> coaching_session_ser
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_recurring_sessions_scheduled_email_carries_recurrence_summary() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let mut server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
     let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -2582,8 +2616,6 @@ async fn test_send_recurring_sessions_scheduled_email_carries_recurrence_summary
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_recurring_sessions_rescheduled_email_previous_recurrence_from_old_rule() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let mut server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
     let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -2655,8 +2687,6 @@ async fn test_send_recurring_sessions_rescheduled_email_previous_recurrence_from
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_recurring_sessions_rescheduled_email_unchanged_recurrence() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let mut server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
     let db = MockDatabase::new(DatabaseBackend::Postgres)
@@ -2724,8 +2754,6 @@ async fn test_send_recurring_sessions_rescheduled_email_unchanged_recurrence() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_notify_recurring_sessions_rescheduled_with_no_sessions_does_nothing() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
     let series = create_test_series();
@@ -2921,8 +2949,6 @@ async fn test_send_recurring_sessions_cancelled_email_omits_recurrence_variables
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_notify_recurring_sessions_cancelled_with_no_sessions_does_nothing() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
     let series = create_test_series();
@@ -2941,8 +2967,6 @@ async fn test_notify_recurring_sessions_cancelled_with_no_sessions_does_nothing(
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_recurring_sessions_scheduled_email_single_session() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let mut server = setup_test_server().await;
     let config = create_full_config_with_mock(&server.url());
 
@@ -2995,8 +3019,6 @@ async fn test_send_recurring_sessions_scheduled_email_single_session() {
 #[cfg(feature = "mock")]
 #[tokio::test]
 async fn test_send_recurring_sessions_scheduled_email_missing_template_id() {
-    use sea_orm::{DatabaseBackend, MockDatabase};
-
     let db = MockDatabase::new(DatabaseBackend::Postgres).into_connection();
     let server = setup_test_server().await;
     let config = Config::from_args([

--- a/domain/src/gateway/resend.rs
+++ b/domain/src/gateway/resend.rs
@@ -243,6 +243,18 @@ impl SendEmailRequestBuilder {
         self
     }
 
+    /// Attach an `.ics` only when one could be built.
+    ///
+    /// `None` sends the email with no attachment. That is the right shape for a session
+    /// whose calendar event we cannot address: the recipient still needs to be told what
+    /// happened, even though no calendar client can act on it.
+    pub fn add_optional_ics_attachment(self, ics_body: Option<&str>, method: &Method) -> Self {
+        match ics_body {
+            Some(body) => self.add_ics_attachment(body, method),
+            None => self,
+        }
+    }
+
     /// Attach an .ics calendar invite (base64-inline). filename is always
     /// invite.ics; the content_type carries the iCal METHOD so clients treat
     /// it as an invite/cancellation.


### PR DESCRIPTION
## Description

A coaching session that belongs to a series created **before** `.ics` support shipped has no `ical_recurrence_id`, so no invite can name its occurrence. All three notification paths treated that as a reason to send **nothing at all** — the coach and coachee were told nothing when such a session was scheduled, rescheduled, or cancelled.

Surfaced in production on a real cancellation:

```
[WARN] Skipping cancellation for session 2d4a5c79-db26-40b2-8e16-b27a34445db5:
       series member has no ical_recurrence_id
```

#### Follow-up to #384

### The confusion

Two different questions had been collapsed into one:

- *Can I address this occurrence on a calendar?* Genuinely **no**, for these sessions.
- *Should I tell these humans their session changed?* **Yes**, always.

They got merged because the `.ics` was built into the send rather than carried as an optional enclosure. So "no valid attachment" silently became "no email."

### Changes

* **The email always goes out; only the attachment is withheld.** New `SendEmailRequestBuilder::add_optional_ics_attachment`, mirroring the existing `add_optional_variable` idiom.
* **The three early returns in `notify_session_scheduled` / `_rescheduled` / `_cancelled` are gone.** The decision moved into the two single-session orchestrators, which now build `Option<String>` and log at the point the attachment is dropped rather than at the point the whole notification is abandoned.
* **Withholding the attachment is still correct.** These series were never published to any calendar, so nothing exists for a client to act on, and a `CANCEL` naming the series `UID` would address the wrong instance. Series-level paths are untouched — they address the series `UID` directly and never needed a `RECURRENCE-ID`.

### Measured scope (production, read-only query)

| | |
|---|---|
| Future sessions affected | **47** |
| Across | **6 series, 6 coachees, 2 coaches** |
| Drains without any change on | **2026-12-28** |
| Already-past (never reached the guard) | 27 |

No new session can enter this state; `bulk_create_recurring` has populated `ical_recurrence_id` since #384.

### Database Migration

None. No schema change, no backfill. Backfilling was considered and rejected: it would invent a `RECURRENCE-ID` for occurrences of a recurring event that was never published to a calendar, so the address would point at nothing.

### Testing Strategy

**Automated.** Mock suite green (domain 308 / entity_api 287 / web 162), both clippy invocations clean, `cargo fmt --check` clean.

Covered at two levels, deliberately, because the full notify path **cannot** be mocked end to end — `user::find_by_id` uses `find_with_related`, which `MockDatabase` cannot express:

- One test drives `send_session_cancelled_email` and asserts the Resend payload carries **no** `attachments` key at all.
- Three tests drive the `notify_*` entry points and assert the transaction log is **non-empty** — the exact inverse of what the old behavior required.

The first version of this covered only the send. Restoring the early return left it **green**, because it bypassed the guard entirely. The notify-level tests exist because that mutation check exposed the gap, and each was confirmed to fail with the early return put back.

### Concerns

1. **Behavior change for affected users, in the intended direction.** Six coachees begin receiving scheduling emails they were silently not getting. Nothing starts arriving that shouldn't.
2. **These sessions still get no calendar update, and cannot.** The email is the only channel available for them. Unchanged by this PR and not fixable — the invites were never issued.
3. **The warning changes meaning, not volume.** It still fires once per operation, since it sits in the orchestrator that builds the `.ics` once before fanning out to both recipients. It now reads `Sending email without an invite for session ... predates ical_recurrence_id` rather than `Skipping cancellation ...`, which is the material difference for an operator: previously nobody was told anything and manual follow-up was warranted; now only the calendar is out of date. Kept at `WARN` because the session remains permanently unable to carry a calendar update.
