### PR TITLE
Bump quinn-proto to 0.11.16 (GHSA-4w2j-m93h-cj5j)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1466,11 +1466,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1480,11 +1478,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasip2",
  "wasip3",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3178,14 +3178,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.10.1",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3313,6 +3314,15 @@ name = "rand_core"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
+dependencies = [
+ "rand_core 0.10.1",
+]
 
 [[package]]
 name = "raw-cpuid"


### PR DESCRIPTION
## Description
Resolves Dependabot alert [#57](https://github.com/refactor-group/refactor-platform-rs/security/dependabot/57) (high): [GHSA-4w2j-m93h-cj5j](https://github.com/advisories/GHSA-4w2j-m93h-cj5j), remote memory exhaustion in `quinn-proto`'s out-of-order stream reassembly. A peer that sends stream fragments while withholding earlier parts of the stream can drive unbounded buffer growth in the receiver's `Assembler`.

Lockfile-only bump. Nothing in the workspace names `quinn-proto` directly, so no `Cargo.toml` change was needed.

### Changes
* `cargo update -p quinn-proto`: 0.11.14 -> 0.11.16 (first patched version is 0.11.15)
* Transitive fallout from that bump: adds `rand_pcg` 0.10.2, and moves `js-sys` / `wasm-bindgen` from `getrandom` 0.3.4 to 0.4.2 as quinn-proto picked up the newer `rand` / `getrandom` generation

### Testing Strategy
* `cargo check --workspace` passes
* CI build/test should be green; there are no source changes to exercise

### Concerns
* Practical exposure was already near zero: `quinn-proto` reaches us only through `reqwest`'s optional `http3` feature, which is not enabled, so it is recorded in `Cargo.lock` but never compiled (`cargo tree -i quinn-proto` returns nothing). Worth taking anyway, since it costs nothing and prevents silently inheriting the vulnerable version if `reqwest/http3` is ever turned on.
* Even in a live configuration the attack requires a hostile QUIC peer on an established connection, i.e. a malicious or compromised server we connect to as a client, not arbitrary inbound traffic.