### PR TITLE
Drop proc-macro-error2 via sea-bae 0.2.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3062,28 +3062,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3727,12 +3705,11 @@ checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "sea-bae"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f694a6ab48f14bc063cfadff30ab551d3c7e46d8f81836c51989d548f44a2a25"
+checksum = "260bbc7148a8d6818ac5032a1b9970da1a68bdd723d45b12d59f7c1bf3565e24"
 dependencies = [
  "heck 0.4.1",
- "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn 2.0.117",


### PR DESCRIPTION
## Description
`proc-macro-error2 2.0.1` re-exports the private built-in `proc_macro` crate, which rustc is phasing out ([rust-lang/rust#127909](https://github.com/rust-lang/rust/issues/127909)). It surfaced a future-incompatibility warning on every `cargo build` / `cargo run`:

```
warning: the following packages contain code that will be rejected by a future
version of Rust: proc-macro-error2 v2.0.1
```

It reached us transitively: `sea-orm` -> `sea-orm-macros` -> `sea-bae 0.2.1` -> `proc-macro-error2`.

Upstream `proc-macro-error2` has no fix released (its repo HEAD is still the 2.0.1 release with the offending re-export). But `sea-bae 0.2.2` drops the dependency outright, and `sea-orm-macros 1.1.20` already requires `bae ^0.2`, so only the lockfile pin needed to move. No manifest change, no `[patch]`, no fork.

### Changes
* `cargo update -p sea-bae`: `0.2.1` -> `0.2.2`
* Removes `proc-macro-error2 v2.0.1` and `proc-macro-error-attr2 v2.0.0` from the dependency graph
* `Cargo.lock` is the only file touched

### Testing Strategy
* `cargo check --workspace --locked` completes with no future-incompatibility warning. The `--locked` flag matters here: it fails if the lockfile does not exactly satisfy the manifests, so it proves the pin is consistent rather than silently rewritten.
* `cargo tree -i proc-macro-error2` now reports no such package.
* `cargo clippy --workspace --all-targets` and `cargo fmt --all --check` are clean.

### Concerns
* `proc-macro-error v1.0.4` (a different, also-unmaintained crate) remains in the tree via `utoipa-gen 4.3.1`. It does **not** contain the offending re-export and does not trigger this lint, so it is out of scope here. It would clear on a future utoipa upgrade.
